### PR TITLE
Feat: Adding architecture-overview to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Additionally, the MongoDB database used by these applications is running on port
 
 Remember to ensure that you have Docker installed on your system before running the `docker-compose up` command.
 
+Find an architecture overview of WKS Platform below: 
+<img width="1507" alt="architecture-overview" src="https://github.com/wkspower/wks-platform/assets/30292227/3e24d9a2-88b3-4e08-8184-3bb0a4c58acb">
+
 ## Screenshots
 
 Form Designer


### PR DESCRIPTION
Adding the WKS Platform Architecture as *.png to the readme. (Excalidraw file and *.svg included in the docs repository)