### PR TITLE
(gh-action): fixing gitops action

### DIFF
--- a/.github/workflows/gitops_update.yml
+++ b/.github/workflows/gitops_update.yml
@@ -151,7 +151,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build-local, build-demo]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Job 'deploy' depends on unknown job 'build'