### PR TITLE
319 implementing menu updates for case definitions and record types

### DIFF
--- a/apps/react/case-portal/src/App.js
+++ b/apps/react/case-portal/src/App.js
@@ -2,7 +2,7 @@ import { useEffect, useState, lazy, Suspense } from 'react'
 import { ThemeRoutes } from './routes'
 import ThemeCustomization from './themes'
 import { SessionStoreProvider } from './SessionStoreContext'
-import { CaseService, RecordService , MenuEventService} from 'services'
+import { CaseService, RecordService, MenuEventService } from 'services'
 import menuItemsDefs from './menu'
 import { RegisterInjectUserSession, RegisteOptions } from './plugins'
 import { accountStore, sessionStore } from './store'
@@ -32,13 +32,13 @@ const App = () => {
       registerExtensionModulesFormio()
 
       const unsubscribe = MenuEventService.subscribeToMenuUpdates(() => {
-        buildMenuItems(keycloak);
-      });
+        buildMenuItems(keycloak)
+      })
 
       return () => {
-        if (unsubscribe) unsubscribe();
-      };
-    })    
+        if (unsubscribe) unsubscribe()
+      }
+    })
 
     keycloak.onAuthRefreshError = () => {
       window.location.reload()
@@ -97,15 +97,17 @@ const App = () => {
     }
 
     if (menu.items[0].children) {
-      const recordListMenu = menu.items[0].children.find(menu => menu.id === 'record-list');
+      const recordListMenu = menu.items[0].children.find(
+        (menu) => menu.id === 'record-list',
+      )
       if (recordListMenu) {
-        recordListMenu.children = []; 
+        recordListMenu.children = []
       }
     }
 
     await RecordService.getAllRecordTypes(keycloak).then((data) => {
       setRecordsTypes(data)
-  
+
       data.forEach((element) => {
         menu.items[0].children
           .filter((menu) => menu.id === 'record-list')[0]
@@ -120,9 +122,11 @@ const App = () => {
     })
 
     if (menu.items[0].children) {
-      const caseListMenu = menu.items[0].children.find(menu => menu.id === 'case-list');
+      const caseListMenu = menu.items[0].children.find(
+        (menu) => menu.id === 'case-list',
+      )
       if (caseListMenu) {
-        caseListMenu.children = []; 
+        caseListMenu.children = []
       }
     }
 

--- a/apps/react/case-portal/src/App.js
+++ b/apps/react/case-portal/src/App.js
@@ -2,7 +2,7 @@ import { useEffect, useState, lazy, Suspense } from 'react'
 import { ThemeRoutes } from './routes'
 import ThemeCustomization from './themes'
 import { SessionStoreProvider } from './SessionStoreContext'
-import { CaseService, RecordService } from 'services'
+import { CaseService, RecordService , MenuEventService} from 'services'
 import menuItemsDefs from './menu'
 import { RegisterInjectUserSession, RegisteOptions } from './plugins'
 import { accountStore, sessionStore } from './store'
@@ -30,7 +30,15 @@ const App = () => {
       RegisteOptions(keycloak)
       forceLogoutIfUserNoMinimalRoleForSystem(keycloak)
       registerExtensionModulesFormio()
-    })
+
+      const unsubscribe = MenuEventService.subscribeToMenuUpdates(() => {
+        buildMenuItems(keycloak);
+      });
+
+      return () => {
+        if (unsubscribe) unsubscribe();
+      };
+    })    
 
     keycloak.onAuthRefreshError = () => {
       window.location.reload()
@@ -88,9 +96,16 @@ const App = () => {
       items: [...menuItemsDefs.items],
     }
 
+    if (menu.items[0].children) {
+      const recordListMenu = menu.items[0].children.find(menu => menu.id === 'record-list');
+      if (recordListMenu) {
+        recordListMenu.children = []; 
+      }
+    }
+
     await RecordService.getAllRecordTypes(keycloak).then((data) => {
       setRecordsTypes(data)
-
+  
       data.forEach((element) => {
         menu.items[0].children
           .filter((menu) => menu.id === 'record-list')[0]
@@ -103,6 +118,13 @@ const App = () => {
           })
       })
     })
+
+    if (menu.items[0].children) {
+      const caseListMenu = menu.items[0].children.find(menu => menu.id === 'case-list');
+      if (caseListMenu) {
+        caseListMenu.children = []; 
+      }
+    }
 
     await CaseService.getCaseDefinitions(keycloak).then((data) => {
       setCasesDefinitions(data)

--- a/apps/react/case-portal/src/services/MenuEventService.js
+++ b/apps/react/case-portal/src/services/MenuEventService.js
@@ -1,0 +1,13 @@
+const MENU_UPDATE_EVENT = 'menu-update-event';
+
+export const MenuEventService = {
+  triggerMenuUpdate: () => {
+    const event = new CustomEvent(MENU_UPDATE_EVENT);
+    window.dispatchEvent(event);
+  },
+  
+  subscribeToMenuUpdates: (callback) => {
+    window.addEventListener(MENU_UPDATE_EVENT, callback);
+    return () => window.removeEventListener(MENU_UPDATE_EVENT, callback);
+  }
+};

--- a/apps/react/case-portal/src/services/MenuEventService.js
+++ b/apps/react/case-portal/src/services/MenuEventService.js
@@ -1,13 +1,13 @@
-const MENU_UPDATE_EVENT = 'menu-update-event';
+const MENU_UPDATE_EVENT = 'menu-update-event'
 
 export const MenuEventService = {
   triggerMenuUpdate: () => {
-    const event = new CustomEvent(MENU_UPDATE_EVENT);
-    window.dispatchEvent(event);
+    const event = new CustomEvent(MENU_UPDATE_EVENT)
+    window.dispatchEvent(event)
   },
-  
+
   subscribeToMenuUpdates: (callback) => {
-    window.addEventListener(MENU_UPDATE_EVENT, callback);
-    return () => window.removeEventListener(MENU_UPDATE_EVENT, callback);
-  }
-};
+    window.addEventListener(MENU_UPDATE_EVENT, callback)
+    return () => window.removeEventListener(MENU_UPDATE_EVENT, callback)
+  },
+}

--- a/apps/react/case-portal/src/services/index.js
+++ b/apps/react/case-portal/src/services/index.js
@@ -10,7 +10,7 @@ import { RecordTypeService } from './RecordTypeService'
 import { FileService } from './FileService'
 import { DeploymentService } from './DeploymentService'
 import { VariableService } from './VariableService'
-import { MenuEventService } from './MenuEventService';
+import { MenuEventService } from './MenuEventService'
 
 export {
   NotificationService,
@@ -25,5 +25,5 @@ export {
   FileService,
   DeploymentService,
   VariableService,
-  MenuEventService
+  MenuEventService,
 }

--- a/apps/react/case-portal/src/services/index.js
+++ b/apps/react/case-portal/src/services/index.js
@@ -10,6 +10,7 @@ import { RecordTypeService } from './RecordTypeService'
 import { FileService } from './FileService'
 import { DeploymentService } from './DeploymentService'
 import { VariableService } from './VariableService'
+import { MenuEventService } from './MenuEventService';
 
 export {
   NotificationService,
@@ -24,4 +25,5 @@ export {
   FileService,
   DeploymentService,
   VariableService,
+  MenuEventService
 }

--- a/apps/react/case-portal/src/views/management/caseDef/caseDefForm/caseDefForm.js
+++ b/apps/react/case-portal/src/views/management/caseDef/caseDefForm/caseDefForm.js
@@ -74,8 +74,8 @@ export const CaseDefForm = ({ open, handleClose, caseDefParam }) => {
     if (caseDef.status && caseDef.status === 'new') {
       CaseDefService.create(keycloak, caseDef)
         .then(() => {
-          MenuEventService.triggerMenuUpdate();
-          handleClose();
+          MenuEventService.triggerMenuUpdate()
+          handleClose()
         })
         .catch((err) => {
           console.log(err.message)
@@ -83,8 +83,8 @@ export const CaseDefForm = ({ open, handleClose, caseDefParam }) => {
     } else {
       CaseDefService.update(keycloak, caseDef.id, caseDef)
         .then(() => {
-          MenuEventService.triggerMenuUpdate();
-          handleClose();
+          MenuEventService.triggerMenuUpdate()
+          handleClose()
         })
         .catch((err) => {
           console.log(err.message)
@@ -95,14 +95,14 @@ export const CaseDefForm = ({ open, handleClose, caseDefParam }) => {
   const handleDelete = () => {
     CaseDefService.remove(keycloak, caseDef.id)
       .then(() => {
-        MenuEventService.triggerMenuUpdate();
-        handleClose();
+        MenuEventService.triggerMenuUpdate()
+        handleClose()
       })
       .catch((err) => {
         console.log(err.message)
       })
   }
-  
+
   return (
     <div>
       <Dialog

--- a/apps/react/case-portal/src/views/management/caseDef/caseDefForm/caseDefForm.js
+++ b/apps/react/case-portal/src/views/management/caseDef/caseDefForm/caseDefForm.js
@@ -17,7 +17,7 @@ import { CaseDefFormStages } from './caseDefFormStages'
 import { CaseDefGeneralForm } from './caseDefGeneralForm'
 import { CaseDefFormForm } from './caseDefFormForm'
 import { CaseKanbanForm } from './caseDefKanban'
-import { CaseDefService } from 'services'
+import { CaseDefService, MenuEventService } from 'services'
 import { useSession } from 'SessionStoreContext'
 
 const Transition = React.forwardRef(function Transition(props, ref) {
@@ -73,13 +73,19 @@ export const CaseDefForm = ({ open, handleClose, caseDefParam }) => {
   const handleSave = () => {
     if (caseDef.status && caseDef.status === 'new') {
       CaseDefService.create(keycloak, caseDef)
-        .then(() => handleClose())
+        .then(() => {
+          MenuEventService.triggerMenuUpdate();
+          handleClose();
+        })
         .catch((err) => {
           console.log(err.message)
         })
     } else {
       CaseDefService.update(keycloak, caseDef.id, caseDef)
-        .then(() => handleClose())
+        .then(() => {
+          MenuEventService.triggerMenuUpdate();
+          handleClose();
+        })
         .catch((err) => {
           console.log(err.message)
         })
@@ -88,12 +94,15 @@ export const CaseDefForm = ({ open, handleClose, caseDefParam }) => {
 
   const handleDelete = () => {
     CaseDefService.remove(keycloak, caseDef.id)
-      .then(() => handleClose())
+      .then(() => {
+        MenuEventService.triggerMenuUpdate();
+        handleClose();
+      })
       .catch((err) => {
         console.log(err.message)
       })
   }
-
+  
   return (
     <div>
       <Dialog

--- a/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
+++ b/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
@@ -12,7 +12,7 @@ import Typography from '@mui/material/Typography'
 import { FormBuilder } from '@formio/react'
 import { TextField } from '@mui/material'
 import MainCard from 'components/MainCard'
-import { RecordTypeService, MenuEventService } from 'services'
+import { RecordTypeService, MenuEventService} from 'services'
 import { useSession } from 'SessionStoreContext'
 import { StorageService } from 'plugins/storage'
 

--- a/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
+++ b/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
@@ -12,7 +12,7 @@ import Typography from '@mui/material/Typography'
 import { FormBuilder } from '@formio/react'
 import { TextField } from '@mui/material'
 import MainCard from 'components/MainCard'
-import { RecordTypeService } from 'services'
+import { RecordTypeService, MenuEventService } from 'services'
 import { useSession } from 'SessionStoreContext'
 import { StorageService } from 'plugins/storage'
 
@@ -31,13 +31,19 @@ export const RecordTypeForm = ({
   const save = () => {
     if (recordType.mode && recordType.mode === 'new') {
       RecordTypeService.create(keycloak, recordType)
-        .then(() => handleClose())
+        .then(() => {
+          MenuEventService.triggerMenuUpdate();
+          handleClose();
+        })
         .catch((err) => {
           console.log(err.message)
         })
     } else {
       RecordTypeService.update(keycloak, recordType.id, recordType)
-        .then(() => handleClose())
+        .then(() => {
+          MenuEventService.triggerMenuUpdate();
+          handleClose();
+        })
         .catch((err) => {
           console.log(err.message)
         })
@@ -46,7 +52,10 @@ export const RecordTypeForm = ({
 
   const deleteRecordType = () => {
     RecordTypeService.remove(keycloak, recordType.id)
-      .then(() => handleClose())
+      .then(() => {
+        MenuEventService.triggerMenuUpdate();
+        handleClose();
+      })
       .catch((err) => {
         console.log(err.message)
       })

--- a/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
+++ b/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
@@ -12,7 +12,7 @@ import Typography from '@mui/material/Typography'
 import { FormBuilder } from '@formio/react'
 import { TextField } from '@mui/material'
 import MainCard from 'components/MainCard'
-import { RecordTypeService, MenuEventService} from 'services'
+import { RecordTypeService, MenuEventService } from 'services'
 import { useSession } from 'SessionStoreContext'
 import { StorageService } from 'plugins/storage'
 
@@ -32,8 +32,8 @@ export const RecordTypeForm = ({
     if (recordType.mode && recordType.mode === 'new') {
       RecordTypeService.create(keycloak, recordType)
         .then(() => {
-          MenuEventService.triggerMenuUpdate();
-          handleClose();
+          MenuEventService.triggerMenuUpdate()
+          handleClose()
         })
         .catch((err) => {
           console.log(err.message)
@@ -41,8 +41,8 @@ export const RecordTypeForm = ({
     } else {
       RecordTypeService.update(keycloak, recordType.id, recordType)
         .then(() => {
-          MenuEventService.triggerMenuUpdate();
-          handleClose();
+          MenuEventService.triggerMenuUpdate()
+          handleClose()
         })
         .catch((err) => {
           console.log(err.message)
@@ -53,8 +53,8 @@ export const RecordTypeForm = ({
   const deleteRecordType = () => {
     RecordTypeService.remove(keycloak, recordType.id)
       .then(() => {
-        MenuEventService.triggerMenuUpdate();
-        handleClose();
+        MenuEventService.triggerMenuUpdate()
+        handleClose()
       })
       .catch((err) => {
         console.log(err.message)


### PR DESCRIPTION
This PR implements automatic menu updates when record types and case definitions are modified. Key changes:

Created MenuEventService for custom event handling
Updated recordTypeForm and caseDefForm to trigger menu update events after CRUD operations
Modified App.js to listen for these events and rebuild the menu dynamically
Fixed menu duplication issue by resetting children arrays before repopulating

Users can now create, update, or delete record types and case definitions, and the menu will automatically reflect these changes without requiring a page refresh or F5.