### PR TITLE
issue-339 Refactoring and order by desc implemented for caseList

### DIFF
--- a/apps/react/case-portal/src/services/CaseService.js
+++ b/apps/react/case-portal/src/services/CaseService.js
@@ -91,7 +91,7 @@ async function filterCase(keycloak, caseDefId, status, cursor) {
   url = url + (caseDefId ? `&caseDefinitionId=${caseDefId}` : '')
   url = url + `&before=${cursor.before || ''}`
   url = url + `&after=${cursor.after || ''}`
-  url = url + `&sort=${cursor.sort || 'asc'}`
+  url = url + `&sort=${cursor.sort || 'desc'}`
   url = url + `&limit=${cursor.limit || 10}`
 
   const headers = {
@@ -259,12 +259,17 @@ function mapperToCase(resp) {
     return mapper[status] || '-'
   }
 
-  const toCase = data.map((element) => {
+  const toCase = data.map((element, index) => {
     const createdAt = element?.attributes?.find(
       (attribute) => attribute.name === 'createdAt',
     )
     element.createdAt = createdAt ? createdAt.value : ''
     element.statusDescription = toStatus(element.status)
+
+    if (!element.id) {
+      element.tempId = `${element.businessKey}-${index}`
+    }
+
     return element
   })
 

--- a/apps/react/case-portal/src/views/caseList/caseList.js
+++ b/apps/react/case-portal/src/views/caseList/caseList.js
@@ -53,7 +53,7 @@ export const CaseList = ({ status, caseDefId }) => {
   const [caseDefs, setCaseDefs] = useState([])
   const [fetching, setFetching] = useState(false)
   const [filter, setFilter] = useState({
-    sort: '',
+    sort: 'desc',
     limit: 10,
     after: '',
     before: '',
@@ -223,7 +223,7 @@ export const CaseList = ({ status, caseDefId }) => {
   )
 
   const handlerNextPage = () => {
-    setFetching(true)
+    setFetching(true) / setCases([])
 
     const next = {
       sort: filter.sort,
@@ -250,6 +250,8 @@ export const CaseList = ({ status, caseDefId }) => {
 
   const handlerPriorPage = () => {
     setFetching(true)
+
+    setCases([])
 
     const prior = {
       sort: filter.sort,
@@ -285,7 +287,12 @@ export const CaseList = ({ status, caseDefId }) => {
   const handlePageSizeSelect = (pageSize) => {
     setFetching(true)
 
-    CaseService.filterCase(keycloak, caseDefId, status, { limit: pageSize })
+    setCases([])
+
+    CaseService.filterCase(keycloak, caseDefId, status, {
+      sort: filter.sort,
+      limit: pageSize,
+    })
       .then((resp) => {
         const { data, paging } = resp
 
@@ -304,6 +311,11 @@ export const CaseList = ({ status, caseDefId }) => {
 
     handlePageSizeClose()
   }
+
+  const processedCases = cases.map((caseItem, index) => ({
+    ...caseItem,
+    tempId: `${caseItem.businessKey}-${index}`,
+  }))
 
   return (
     <div style={{ height: 650, width: '100%' }}>
@@ -372,9 +384,9 @@ export const CaseList = ({ status, caseDefId }) => {
                         display: 'none',
                       },
                     }}
-                    rows={cases}
+                    rows={processedCases}
                     columns={makeColumns()}
-                    getRowId={(row) => row.businessKey}
+                    getRowId={(row) => row.id || row.tempId || row.businessKey}
                     loading={fetching}
                     hideFooter={true}
                     disableSelectionOnClick
@@ -458,7 +470,7 @@ export const CaseList = ({ status, caseDefId }) => {
             <Suspense fallback={<div>Loading...</div>}>
               <Kanban
                 stages={stages}
-                cases={cases}
+                cases={processedCases}
                 caseDefId={caseDefId}
                 kanbanConfig={fetchKanbanConfig()}
                 setACase={setACase}
@@ -513,6 +525,8 @@ function fetchCases(
   setFilter,
 ) {
   setFetching(true)
+
+  setCases([])
 
   CaseService.getCaseDefinitionsById(keycloak, caseDefId)
     .then((resp) => {


### PR DESCRIPTION
fix: Prevent duplicate records when navigating between case pages

- Changed default sort order from 'asc' to 'desc' in both UI and API
- Added unique identifiers to rows to ensure proper React rendering
- Clear data between page navigation to prevent visual duplication
- Fixed page size handler to maintain sort order when changing page size

This resolves the issue where the same business key appears multiple times 
when navigating through pages in the case list view.