### PR TITLE
Story 1.3 — code-review follow-up fixes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Mirrors .github/workflows/ci.yml verbatim so local green == CI green.
+# Enable once per clone: git config core.hooksPath .githooks
+# Emergency skip: WKS_SKIP_CI_LOCAL=1 git push   (use only if you know why)
+set -euo pipefail
+
+if [[ "${WKS_SKIP_CI_LOCAL:-0}" == "1" ]]; then
+  echo "pre-push: WKS_SKIP_CI_LOCAL=1 — skipping local CI mirror" >&2
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+echo "pre-push: backend — mvnw verify (incl. spotless, unit, ArchUnit)"
+( cd backend && ./mvnw -B -ntp verify )
+
+echo "pre-push: frontend — npm ci + lint + format:check + test + build"
+(
+  cd frontend
+  npm ci --no-audit --no-fund
+  npm run lint
+  npm run format:check
+  npm test
+  npm run build
+
+  count=$(find dist/assets -name '*.woff2' | wc -l | tr -d ' ')
+  echo "pre-push: found $count woff2 files in dist/assets"
+  if [ "$count" -lt 4 ]; then
+    echo "pre-push: expected >= 4 woff2 files, found $count" >&2
+    exit 1
+  fi
+)
+
+echo "pre-push: local CI mirror passed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,16 @@ docker buildx build -f docker/Dockerfile -t wks:ci .
 
 "Lint + test + build" is **not** the full set. `format:check` is a separate step and Prettier regressions only surface there. When in doubt, grep `ci.yml` for `run:` and copy every command verbatim.
 
+### Pre-push hook (one-time setup)
+
+A committed `pre-push` hook at `.githooks/pre-push` runs the full CI mirror automatically. Enable it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Emergency bypass (use only if you know why): `WKS_SKIP_CI_LOCAL=1 git push`. Do **not** use `--no-verify` — the hook exists because the memory-backed "match CI locally" rule kept getting violated.
+
 ---
 
 ## Story 1.1 artifacts

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/WebMvcConfig.java
@@ -14,12 +14,22 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * <p>React Router 7 runs in history mode — route transitions never hit the server, but a page
  * reload on a client-side route (e.g. {@code /tasks}) becomes a direct GET. Spring MVC has no
  * static file at that path and falls through to a JSON 404 {@code ProblemDetail}. This config
- * forwards the five known Phase-0 SPA routes (and their sub-paths) to {@code /index.html} so the
+ * forwards the known Phase-0 SPA routes (and their sub-paths) to {@code /index.html} so the
  * React Router tree resolves them client-side.
  *
  * <p>Routes mirror {@code frontend/src/routes.tsx}. When a new top-level route lands in a later
  * story, add it here in the same commit. Everything under {@code /api/**} is unaffected — explicit
  * controller mappings always win over view controllers.
+ *
+ * <p><b>Known limitation (deferred to a later backend hardening pass):</b> an allow-list
+ * approach was chosen over a generic {@code /{*path}} fallback because Spring's
+ * {@link org.springframework.web.util.pattern.PathPatternParser} rejects multi-segment patterns
+ * with a trailing capture (e.g. {@code /**\/{path}}) and a single-segment generic fallback like
+ * {@code /{path:[^\.]*}} would also match unmatched {@code /api/**} paths, forwarding them to
+ * the SPA instead of surfacing as JSON {@code ProblemDetail}. A correct generic fallback requires
+ * a dedicated {@code @Controller} with {@code /{*path}} capture and explicit {@code /api/}
+ * exclusion logic in the handler body — worth doing, but out of scope for Story 1.3 and tracked
+ * in {@code deferred-work.md}.
  */
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/WebMvcConfig.java
@@ -14,22 +14,22 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * <p>React Router 7 runs in history mode — route transitions never hit the server, but a page
  * reload on a client-side route (e.g. {@code /tasks}) becomes a direct GET. Spring MVC has no
  * static file at that path and falls through to a JSON 404 {@code ProblemDetail}. This config
- * forwards the known Phase-0 SPA routes (and their sub-paths) to {@code /index.html} so the
- * React Router tree resolves them client-side.
+ * forwards the known Phase-0 SPA routes (and their sub-paths) to {@code /index.html} so the React
+ * Router tree resolves them client-side.
  *
  * <p>Routes mirror {@code frontend/src/routes.tsx}. When a new top-level route lands in a later
  * story, add it here in the same commit. Everything under {@code /api/**} is unaffected — explicit
  * controller mappings always win over view controllers.
  *
- * <p><b>Known limitation (deferred to a later backend hardening pass):</b> an allow-list
- * approach was chosen over a generic {@code /{*path}} fallback because Spring's
- * {@link org.springframework.web.util.pattern.PathPatternParser} rejects multi-segment patterns
- * with a trailing capture (e.g. {@code /**\/{path}}) and a single-segment generic fallback like
- * {@code /{path:[^\.]*}} would also match unmatched {@code /api/**} paths, forwarding them to
- * the SPA instead of surfacing as JSON {@code ProblemDetail}. A correct generic fallback requires
- * a dedicated {@code @Controller} with {@code /{*path}} capture and explicit {@code /api/}
- * exclusion logic in the handler body — worth doing, but out of scope for Story 1.3 and tracked
- * in {@code deferred-work.md}.
+ * <p><b>Known limitation (deferred to a later backend hardening pass):</b> an allow-list approach
+ * was chosen over a generic {@code /{*path}} fallback because Spring's {@link
+ * org.springframework.web.util.pattern.PathPatternParser} rejects multi-segment patterns with a
+ * trailing capture (e.g. {@code /**\/{path}}) and a single-segment generic fallback like {@code
+ * /{path:[^\.]*}} would also match unmatched {@code /api/**} paths, forwarding them to the SPA
+ * instead of surfacing as JSON {@code ProblemDetail}. A correct generic fallback requires a
+ * dedicated {@code @Controller} with {@code /{*path}} capture and explicit {@code /api/} exclusion
+ * logic in the handler body — worth doing, but out of scope for Story 1.3 and tracked in {@code
+ * deferred-work.md}.
  */
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {

--- a/backend/src/test/java/com/wkspower/platform/integration/SpaRoutingIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/SpaRoutingIT.java
@@ -46,11 +46,12 @@ class SpaRoutingIT {
 
   @Test
   void unknownApiPathIsNotSwallowedBySpaForward() {
-    // Unknown /api/** paths hit SecurityConfig's authenticated() matcher before Spring MVC
-    // handler resolution, so they return 401 rather than 404 — but crucially, they do NOT
-    // forward to index.html. The SPA forward never intercepts /api/*.
+    // The SPA forward must never intercept /api/*. We tolerate either 401 (when auth config
+    // requires authentication ahead of handler resolution) or 404 (when the path is under a
+    // permitted segment) — the invariant we actually care about is "response is not the SPA
+    // index.html". Asserting a specific status couples this routing test to SecurityConfig.
     ResponseEntity<String> response = rest.getForEntity("/api/does-not-exist", String.class);
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getStatusCode()).isIn(HttpStatus.UNAUTHORIZED, HttpStatus.NOT_FOUND);
     assertThat(response.getBody()).doesNotContain("<div id=\"root\">");
   }
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -85,6 +85,8 @@ export default [
         HTMLSelectElement: 'readonly',
         HTMLTextAreaElement: 'readonly',
         React: 'readonly',
+        AbortController: 'readonly',
+        AbortSignal: 'readonly',
         // Node-ish (used by tests + ts files that read fs)
         __dirname: 'readonly',
         __filename: 'readonly',

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -16,8 +16,12 @@ const noLiteralJsxText = {
     'Literal JSX text is banned — wrap user-visible strings in t(\'...\') so they land in the i18n bundle.',
 };
 
+// Match only valid CSS hex lengths (3, 4, 6, 8) AND require at least one
+// a–f letter so numeric-only tokens like issue references ('#1234') or
+// error codes ('#0001') aren't misclassified as colors.
 const noRawHexInStyles = {
-  selector: "Literal[value=/^#[0-9a-fA-F]{3,8}$/]",
+  selector:
+    "Literal[value=/^#(?=[0-9a-fA-F]*[a-fA-F])[0-9a-fA-F]{3}([0-9a-fA-F])?([0-9a-fA-F]{2})?([0-9a-fA-F]{2})?$/]",
   message:
     'Raw hex color literals are banned — reference a design token via Tailwind utilities (bg-primary) or arbitrary value (bg-[var(--token)]).',
 };

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -14,7 +14,7 @@ export async function logout(): Promise<void> {
   await apiFetch<void>('/api/auth/logout', { method: 'POST' });
 }
 
-export async function getMe(): Promise<AuthUser> {
-  const result = await apiFetch<AuthUser>('/api/auth/me');
+export async function getMe(signal?: AbortSignal): Promise<AuthUser> {
+  const result = await apiFetch<AuthUser>('/api/auth/me', { signal });
   return result.data;
 }

--- a/frontend/src/components/layout/AppShell.test.tsx
+++ b/frontend/src/components/layout/AppShell.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event';
 import { Route, Routes } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { sessionBus } from '@/api/sessionBus';
 import { renderWithProviders } from '@/test/renderWithProviders';
@@ -51,5 +51,34 @@ describe('AppShell', () => {
     await user.click(getByLabelText(/dismiss/i));
     // After dismiss, banner is no longer in the DOM.
     expect(queryByRole('alert')).toBeNull();
+  });
+
+  it('RouteErrorBoundary resets when the user navigates to a different route', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    function Boom(): never {
+      throw new Error('kaboom');
+    }
+    const { getByRole, queryByRole, findByText } = renderWithProviders(
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/cases" element={<Boom />} />
+          <Route path="/tasks" element={<div>Tasks content</div>} />
+        </Route>
+      </Routes>,
+      {
+        initialPath: '/cases',
+        initialAuth: {
+          user: { id: 'u', email: 'u@x', roles: ['admin'] },
+          status: 'authenticated',
+        },
+      },
+    );
+    // Boundary catches the thrown error on /cases
+    expect(getByRole('heading', { level: 2 })).toHaveTextContent(/something unexpected/i);
+    // Navigating via sidebar should clear the boundary (pathname-keyed remount)
+    await userEvent.setup().click(getByRole('link', { name: /tasks/i }));
+    expect(await findByText('Tasks content')).toBeInTheDocument();
+    expect(queryByRole('heading', { level: 2 })).toBeNull();
+    errSpy.mockRestore();
   });
 });

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import { RouteErrorBoundary } from '@/components/errors/RouteErrorBoundary';
 
@@ -8,6 +8,7 @@ import { SkipLink } from './SkipLink';
 import { TopBar } from './TopBar';
 
 export function AppShell() {
+  const location = useLocation();
   return (
     <div className="grid min-h-screen grid-cols-[auto_1fr]">
       <SkipLink />
@@ -17,9 +18,14 @@ export function AppShell() {
         <TopBar />
         <main
           id="main"
-          className="flex-1 bg-[var(--background)] p-[var(--space-6)] text-[var(--foreground)]"
+          tabIndex={-1}
+          className="flex-1 bg-[var(--background)] p-[var(--space-6)] text-[var(--foreground)] focus:outline-none"
         >
-          <RouteErrorBoundary>
+          {/* Keying the boundary on pathname remounts it on route change, so a
+              thrown error on one route clears automatically when the user
+              navigates to another via the sidebar. Without this the boundary
+              traps the user on the fallback card until a full reload. */}
+          <RouteErrorBoundary key={location.pathname}>
             <Outlet />
           </RouteErrorBoundary>
         </main>

--- a/frontend/src/components/layout/LoginLayout.tsx
+++ b/frontend/src/components/layout/LoginLayout.tsx
@@ -4,7 +4,8 @@ export function LoginLayout() {
   return (
     <main
       id="main"
-      className="flex min-h-screen items-center justify-center bg-[var(--brand-navy)] p-[var(--space-6)]"
+      tabIndex={-1}
+      className="flex min-h-screen items-center justify-center bg-[var(--brand-navy)] p-[var(--space-6)] focus:outline-none"
     >
       <Outlet />
     </main>

--- a/frontend/src/components/routing/RequireAuth.tsx
+++ b/frontend/src/components/routing/RequireAuth.tsx
@@ -30,7 +30,7 @@ export function RequireAuth({ children, requiredRole }: RequireAuthProps) {
   }
 
   if (status === 'unauthenticated' || !user) {
-    const returnTo = encodeURIComponent(location.pathname + location.search);
+    const returnTo = encodeURIComponent(location.pathname + location.search + location.hash);
     return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
   }
 

--- a/frontend/src/components/ui/Button.test.tsx
+++ b/frontend/src/components/ui/Button.test.tsx
@@ -29,4 +29,14 @@ describe('Button', () => {
     );
     expect(getByRole('link')).toHaveAccessibleName('Go');
   });
+
+  it('defaults to type="button" so it does not accidentally submit forms', () => {
+    const { getByRole } = renderWithProviders(<Button>Save</Button>);
+    expect(getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('honors an explicit type="submit"', () => {
+    const { getByRole } = renderWithProviders(<Button type="submit">Submit</Button>);
+    expect(getByRole('button')).toHaveAttribute('type', 'submit');
+  });
 });

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -35,9 +35,20 @@ export interface ButtonProps
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { className, variant, size, asChild = false, ...props },
+  { className, variant, size, asChild = false, type, ...props },
   ref,
 ) {
   const Comp = asChild ? Slot : 'button';
-  return <Comp ref={ref} className={cn(buttonVariants({ variant, size, className }))} {...props} />;
+  // Default real <button> elements to type="button" so a Button placed inside
+  // a <form> without an explicit type doesn't accidentally submit the form.
+  // Slot/asChild callers own their child element's type (or its absence).
+  const resolvedType = asChild ? type : (type ?? 'button');
+  return (
+    <Comp
+      ref={ref}
+      type={resolvedType}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
 });

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,11 +1,19 @@
 import { QueryClient } from '@tanstack/react-query';
 
+import { ApiError } from '@/api/client';
+
 export function createQueryClient(): QueryClient {
   return new QueryClient({
     defaultOptions: {
       queries: {
         staleTime: 30_000,
-        retry: 1,
+        // Skip retry for auth failures — the session-expired bus has
+        // already fired on the first attempt; a retry would double-emit
+        // and the user is being redirected to /login anyway.
+        retry: (failureCount, error) => {
+          if (error instanceof ApiError && error.status === 401) return false;
+          return failureCount < 1;
+        },
         refetchOnWindowFocus: false,
       },
     },

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -28,25 +28,41 @@ class AppErrorBoundary extends Component<{ children: ReactNode }, BoundaryState>
   }
 }
 
-const queryClient = createQueryClient();
+const STARTUP_FALLBACK_HTML =
+  '<main style="min-height:100vh;display:grid;place-items:center;font-family:system-ui,sans-serif;color:#0B1437"><div style="text-align:center"><h1>WKS Platform failed to start</h1><p>Please reload the page or contact support.</p></div></main>';
+
+function renderStartupFallback(): void {
+  if (typeof document !== 'undefined' && document.body) {
+    document.body.innerHTML = STARTUP_FALLBACK_HTML;
+  }
+}
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
-  // Story 1.1 deferred fix: surface a visible fallback rather than a
-  // blank screen if index.html is misconfigured.
-  document.body.innerHTML =
-    '<main style="min-height:100vh;display:grid;place-items:center;font-family:system-ui,sans-serif;color:#0B1437"><div style="text-align:center"><h1>WKS Platform failed to start</h1><p>Missing #root element in index.html. Please contact support.</p></div></main>';
+  renderStartupFallback();
   throw new Error('Missing #root element in index.html');
 }
 
-createRoot(rootElement).render(
-  <StrictMode>
-    <AppErrorBoundary>
-      <AuthProvider>
-        <QueryClientProvider client={queryClient}>
-          <RouterProvider router={router} />
-        </QueryClientProvider>
-      </AuthProvider>
-    </AppErrorBoundary>
-  </StrictMode>,
-);
+try {
+  const queryClient = createQueryClient();
+  createRoot(rootElement).render(
+    <StrictMode>
+      <AppErrorBoundary>
+        <AuthProvider>
+          <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </AuthProvider>
+      </AppErrorBoundary>
+    </StrictMode>,
+  );
+} catch (err) {
+  // Synchronous failure during createRoot/render means AppErrorBoundary
+  // never mounted — surface the same inline HTML fallback so users see
+  // a visible message instead of a blank page. The error is re-thrown
+  // so bundled telemetry (when it lands) can still capture it.
+  renderStartupFallback();
+  // eslint-disable-next-line no-console
+  console.error('[main] startup failed', err);
+  throw err;
+}

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -56,12 +56,29 @@ describe('LoginPage', () => {
     expect(alert).toHaveTextContent(/something went wrong/i);
   });
 
-  it('double-submit protection: only one network request is fired', async () => {
+  it('native :invalid blocks submission when required fields are empty', async () => {
+    let callCount = 0;
+    server.use(
+      http.post('/api/auth/login', () => {
+        callCount += 1;
+        return HttpResponse.json({ data: null, meta: {} }, { status: 200 });
+      }),
+    );
+    const user = userEvent.setup();
+    const { getByLabelText, getByRole } = loginAt();
+    await user.click(getByRole('button', { name: /sign in/i }));
+    // No custom client-side error message, no network request.
+    expect(callCount).toBe(0);
+    const emailInput = getByLabelText(/email/i) as HTMLInputElement;
+    expect(emailInput.validity.valid).toBe(false);
+  });
+
+  it('double-submit protection: only one network request is fired and the button is disabled during the in-flight call', async () => {
     let callCount = 0;
     server.use(
       http.post('/api/auth/login', async () => {
         callCount += 1;
-        await delay(150);
+        await delay(200);
         return HttpResponse.json(
           {
             data: { id: 'u', email: 'a@b.c', roles: ['admin'] },
@@ -78,6 +95,8 @@ describe('LoginPage', () => {
     const button = getByRole('button', { name: /sign in/i });
     // Click twice in immediate succession; the second click should be a no-op.
     await user.click(button);
+    // The button must be disabled while the first request is in flight.
+    expect(button).toBeDisabled();
     await user.click(button);
     expect(await findByText('cases page')).toBeInTheDocument();
     expect(callCount).toBe(1);

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -9,10 +9,22 @@ import { Input } from '@/components/ui/Input';
 import { t } from '@/i18n';
 import { useAuthStore } from '@/stores/authStore';
 
-function safeReturnTo(value: string | null): string {
+export function safeReturnTo(value: string | null): string {
   if (!value) return '/cases';
-  if (!value.startsWith('/') || value.startsWith('//')) return '/cases';
-  return value;
+  // Parse against the current origin; this normalizes every encoding and
+  // backslash/whitespace edge case that ad-hoc `startsWith` checks miss.
+  // Reject anything that resolves to a different origin, and bounce the
+  // `/login` self-reference so we can't recursively redirect users back
+  // to the login screen.
+  let url: URL;
+  try {
+    url = new URL(value, window.location.origin);
+  } catch {
+    return '/cases';
+  }
+  if (url.origin !== window.location.origin) return '/cases';
+  if (url.pathname === '/login') return '/cases';
+  return url.pathname + url.search + url.hash;
 }
 
 export function LoginPage() {
@@ -53,7 +65,11 @@ export function LoginPage() {
           {t('login.title')}
         </h1>
       </CardHeader>
-      <form onSubmit={handleSubmit} aria-describedby={errorMessage ? 'login-error' : undefined}>
+      <form
+        onSubmit={handleSubmit}
+        autoComplete="on"
+        aria-describedby={errorMessage ? 'login-error' : undefined}
+      >
         <CardContent className="flex flex-col gap-[var(--space-4)]">
           <label className="flex flex-col gap-[var(--space-2)] text-sm">
             <span>{t('login.email')}</span>

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
+import { createBrowserRouter, Navigate, Outlet, useSearchParams } from 'react-router-dom';
 
 import { NotFoundPage } from '@/components/errors/NotFoundPage';
 import { AppShell } from '@/components/layout/AppShell';
@@ -8,13 +8,19 @@ import { RootRedirect } from '@/components/routing/RootRedirect';
 import { AdminPage } from '@/pages/AdminPage';
 import { CasesPage } from '@/pages/CasesPage';
 import { DevConsolePage } from '@/pages/DevConsolePage';
-import { LoginPage } from '@/pages/LoginPage';
+import { LoginPage, safeReturnTo } from '@/pages/LoginPage';
 import { TasksPage } from '@/pages/TasksPage';
 import { useAuthStore } from '@/stores/authStore';
 
 function LoginGate() {
   const status = useAuthStore((s) => s.status);
-  if (status === 'authenticated') return <Navigate to="/cases" replace />;
+  const [params] = useSearchParams();
+  if (status === 'authenticated') {
+    // Honor `?returnTo` when an already-authenticated user hits /login,
+    // so deep-link flows (e.g. copy/paste /login?returnTo=/admin) land
+    // on the intended page rather than defaulting to /cases.
+    return <Navigate to={safeReturnTo(params.get('returnTo'))} replace />;
+  }
   return <Outlet />;
 }
 
@@ -54,7 +60,12 @@ export const router = createBrowserRouter([
           </RequireAuth>
         ),
       },
+      // Catch-all is nested under AppShell so authenticated 404s keep
+      // the sidebar + topbar chrome (AC #20). Unauthenticated users
+      // flow through RequireAuth → /login?returnTo=<path> before ever
+      // reaching this route, so no separate unauthenticated 404 is
+      // needed (they land on the login screen instead).
+      { path: '*', element: <NotFoundPage /> },
     ],
   },
-  { path: '*', element: <NotFoundPage /> },
 ]);

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -55,7 +55,7 @@ describe('authStore', () => {
     expect(useAuthStore.getState().error).toBeNull();
   });
 
-  it('login on 401 records the error message and rethrows', async () => {
+  it('login on 401 clears error (UI reads ApiError directly) and rethrows', async () => {
     vi.spyOn(authApi, 'login').mockRejectedValue(
       new ApiError({
         status: 401,
@@ -65,6 +65,15 @@ describe('authStore', () => {
     );
     await expect(useAuthStore.getState().login('a@b.c', 'pw')).rejects.toBeInstanceOf(ApiError);
     expect(useAuthStore.getState().status).toBe('unauthenticated');
-    expect(useAuthStore.getState().error).toBe('Invalid email or password');
+    // 401 meaning is carried by status + the thrown ApiError; store.error
+    // never surfaces backend-controlled text.
+    expect(useAuthStore.getState().error).toBeNull();
+  });
+
+  it('login on non-ApiError sets generic sentinel and rethrows', async () => {
+    vi.spyOn(authApi, 'login').mockRejectedValue(new Error('boom'));
+    await expect(useAuthStore.getState().login('a@b.c', 'pw')).rejects.toBeInstanceOf(Error);
+    expect(useAuthStore.getState().status).toBe('unauthenticated');
+    expect(useAuthStore.getState().error).toBe('unexpected');
   });
 });

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -6,6 +6,19 @@ import type { AuthUser } from '@/types/auth';
 
 export type AuthStatus = 'pending' | 'authenticated' | 'unauthenticated';
 
+// 401 carries the "invalid credentials" meaning via status='unauthenticated'; the
+// localized message belongs to the UI layer (LoginPage reads the thrown ApiError
+// directly). Non-ApiError failures collapse to a single generic sentinel so
+// store.error never surfaces backend-controlled text to future consumers.
+export const LOGIN_ERROR_GENERIC = 'unexpected';
+
+// Hydrate in-flight latch — prevents StrictMode's double-invoke (and any other
+// concurrent caller) from firing a second /api/auth/me. The canonical pending→
+// authenticated/unauthenticated status alone can't distinguish "not started"
+// from "in flight" because both leave status='pending'.
+let hydrating = false;
+const HYDRATE_TIMEOUT_MS = 8_000;
+
 export interface AuthState {
   user: AuthUser | null;
   status: AuthStatus;
@@ -26,8 +39,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const user = await loginRequest(email, password);
       set({ user, status: 'authenticated', error: null });
     } catch (err) {
-      const message = err instanceof ApiError ? err.message : 'Unexpected error during login';
-      set({ user: null, status: 'unauthenticated', error: message });
+      const isAuthFailure = err instanceof ApiError && err.status === 401;
+      set({
+        user: null,
+        status: 'unauthenticated',
+        error: isAuthFailure ? null : LOGIN_ERROR_GENERIC,
+      });
       throw err;
     }
   },
@@ -42,13 +59,13 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   async hydrate() {
-    // React 19 StrictMode runs effects twice in dev. The store guards
-    // against a second hydrate while the first is still in flight by
-    // checking the canonical pending->authenticated/unauthenticated
-    // transition: re-entering hydrate() during 'pending' is a no-op.
-    if (get().status !== 'pending' && get().user !== null) return;
+    if (hydrating) return;
+    if (get().status === 'authenticated') return;
+    hydrating = true;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), HYDRATE_TIMEOUT_MS);
     try {
-      const user = await getMe();
+      const user = await getMe(controller.signal);
       set({ user, status: 'authenticated', error: null });
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
@@ -58,6 +75,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // eslint-disable-next-line no-console
       console.warn('[auth] hydrate failed', err);
       set({ user: null, status: 'unauthenticated', error: null });
+    } finally {
+      clearTimeout(timer);
+      hydrating = false;
     }
   },
 }));

--- a/frontend/src/styles/fonts.test.ts
+++ b/frontend/src/styles/fonts.test.ts
@@ -8,9 +8,12 @@ const INDEX_HTML = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
 const INDEX_CSS = fs.readFileSync(path.join(ROOT, 'src/index.css'), 'utf8');
 
 // Matches an off-origin fetch target: href / src / url() with an http(s)
-// URL. The SVG xmlns="http://www.w3.org/2000/svg" namespace attribute is
-// intentionally ignored — it's not a fetch, just an identifier.
-const OFF_ORIGIN_FETCH_RE = /(?:href|src)=["']https?:\/\/|url\(\s*["']?https?:\/\//i;
+// URL or a protocol-relative `//host` URL (which the browser resolves to
+// the page scheme and still constitutes an off-origin request). The SVG
+// xmlns="http://www.w3.org/2000/svg" namespace attribute is intentionally
+// ignored — it's not a fetch, just an identifier.
+const OFF_ORIGIN_FETCH_RE =
+  /(?:href|src)=["'](?:https?:)?\/\/[a-z]|url\(\s*["']?(?:https?:)?\/\/[a-z]/i;
 
 describe('fonts', () => {
   it('index.html does not reference any external font CDN', () => {


### PR DESCRIPTION
## Summary

Follow-up to merged Story 1.3 (#370). Four-chunk adversarial code review (Blind Hunter / Edge Case Hunter / Acceptance Auditor) produced 14 code patches across 4 commits. All decisions resolved, 31 items triaged to `deferred-work.md`.

### Highlights

- **Auth resilience** — StrictMode `hydrate()` double-fetch latch, 8s AbortController timeout, `store.error` stops leaking backend text, `queryClient` skips retry on 401 `ApiError`.
- **Routing** — `RouteErrorBoundary` keyed on pathname (stops trapping users on the fallback card across sidebar navigation), `LoginGate` honors `?returnTo`, catch-all `*` nested under `AppShell` (AC #20), `safeReturnTo` rewritten via `new URL(value, origin)` to correctly reject every open-redirect bypass.
- **A11y** — `<main tabIndex={-1}>` in AppShell + LoginLayout so the skip link actually moves keyboard focus, `Button` defaults to `type="button"` (no more silent form-submit footgun), `RequireAuth.returnTo` preserves `location.hash`.
- **AC compliance** — LoginPage `<form autoComplete="on">`, validation test added (5th case in AC #29), double-submit test bumped to 200ms + asserts button disabled mid-flight, `fonts.test.ts` regex catches protocol-relative URLs.
- **Startup robustness** — `main.tsx` wraps `createRoot().render()` in try/catch that surfaces the shared `STARTUP_FALLBACK_HTML` on any synchronous import/render failure. `SpaRoutingIT` decoupled from `SecurityConfig` — asserts body-is-not-SPA + status in {401, 404}.
- **ESLint** — `noRawHexInStyles` selector tightened to valid hex lengths (3/4/6/8) requiring at least one a–f letter, eliminating false positives on issue references like `'#1234'`.

Full review findings (decisions resolved, patches applied, deferred items, dismissed false alarms) written to `_bmad-output/implementation-artifacts/1-3-frontend-application-shell-and-design-system.md` in the `wks-platform2` planning repo.

## Commits

- `857b922f` review(1-3): apply chunk-1 adversarial code-review patches
- `2f28e7e5` review(1-3): apply chunk-2 adversarial code-review patches
- `01195bf7` review(1-3): apply chunk-3 adversarial code-review patches
- `05b6ad70` review(1-3): apply chunk-4 adversarial code-review patches

## Test plan

- [ ] `cd frontend && npm run lint` — clean
- [ ] `cd frontend && npm test -- --run` — 61/61 pass (up from 56; 5 new tests added)
- [ ] `cd backend && ./mvnw -Dtest=SpaRoutingIT test` — 4/4 pass
- [ ] `./mvnw -pl backend verify` — green (no unrelated regressions)
- [ ] `cd frontend && npm run build` — zero TS errors, 4 woff2 files in `dist/assets/`
- [ ] CI green across backend / frontend / docker-build / font-count
- [ ] Manual: force a crash in `CasesPage`, click Tasks in the sidebar → `RouteErrorBoundary` clears automatically (previously required hard reload)
- [ ] Manual: deep-link to `/cases#section`, let session expire, log back in → hash preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
