### PR TITLE
Story 1.5 — Repository transition & Gate 1 signals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on:
   pull_request:
   push:
-    # v2-develop is the active trunk for v2 work; develop stays frozen at
-    # v1-final until Victor decides to merge v2 in.
+    # v2-develop is the active trunk for v2 work; develop stays frozen
+    # at v1-final until v2 is merged in.
     branches: [v2-develop, develop]
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to WKS Platform
+
+WKS Platform is open-source case management for system integrators —
+YAML case types, BPMN lifecycles, 30-minute evaluation. Thanks for
+considering a contribution.
+
+## Is the project accepting contributions?
+
+Yes, with a named scope:
+
+- **Bug reports** — open a GitHub issue with a reproduction.
+- **Typo and documentation fixes** — PR directly.
+- **Focused code contributions** against the published roadmap items.
+
+v2 is pre-1.0 and spec-driven. The public
+[`ROADMAP.md`](./ROADMAP.md) lists what is in flight and what comes
+next. If you want to contribute a feature, open an issue first so it
+can be sized and slotted against the roadmap. PRs adding features
+outside the roadmap are not accepted pre-1.0.
+
+## How do I set up?
+
+Follow the [README Quick start](./README.md#quick-start) — `docker
+compose up --build` from `docker/`, then
+`http://localhost:8080/`. Before opening a PR, run the local CI-parity
+sequence, which mirrors [`.github/workflows/ci.yml`](./.github/workflows/ci.yml):
+
+```bash
+# Backend (Temurin 21)
+cd backend && ./mvnw -B -ntp verify
+
+# Frontend (Node 22)
+cd frontend && npm ci --no-audit --no-fund
+npm run lint && npm run format:check && npm test && npm run build
+
+# Docker image build (same args as CI)
+docker buildx build -f docker/Dockerfile -t wks-platform:local .
+```
+
+Copy these commands verbatim — paraphrasing causes local-vs-CI drift.
+
+## What's the branching model?
+
+- `v2-develop` is the **v2 trunk**. All v2 PRs target `v2-develop`.
+- `develop` is frozen at `v1-final` and does not accept v2 work.
+- Feature branches follow a `topic/short-slug` shape, e.g.
+  `fix/login-redirect-loop` or `feat/case-list-empty-state`.
+- **Never** target `develop` or `main` with a v2 PR.
+
+## What's the commit style?
+
+[Conventional Commits](https://www.conventionalcommits.org/): `feat(scope):`,
+`fix(scope):`, `chore:`, `docs(scope):`, `test(scope):`. One concern per
+commit. Squash-on-merge is used, so the pre-squash history is still
+reviewed and should read cleanly.
+
+PR description should include:
+
+- **Summary** — what changed and why, in plain language.
+- **Test plan** — what you ran locally (`mvnw verify`, `npm test`,
+  `docker compose up` smoke), and what a reviewer should re-run to be
+  confident.
+- **Screenshots / output** — for UI changes or observable behaviour
+  changes.
+
+## Code of conduct and security policy
+
+See [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) — all contributors are
+expected to follow it. See [`SECURITY.md`](./SECURITY.md) for supported
+versions, response times, and scope.
+
+## Where do I report a security issue?
+
+**Do NOT open a public GitHub issue.** Follow [`SECURITY.md`](./SECURITY.md) —
+email `security@wkspower.com` with the details. Public issues leak the
+vulnerability before a fix is available.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ Strings live in `frontend/src/i18n/en.json` and are looked up via a
 small `t('key')` helper. `react-i18next` arrives in Phase 1; until
 then the bundle is English-only and a Vitest guardrail asserts every
 `t('...')` reference has an entry. Self-hosted Poppins + Rubik fonts
-are bundled (no Google Fonts CDN). The full design vocabulary lives
-in the
-[UX spec](_bmad-output/planning-artifacts/ux/ux-design-spec.md).
+are bundled (no Google Fonts CDN).
 
 ## Quick start
 
@@ -72,11 +70,33 @@ sessions stable across restarts.
 
 v1 code lives on the [`v1` branch](https://github.com/wkspower/wks-platform/tree/v1)
 and the [`v1-final` tag](https://github.com/wkspower/wks-platform/releases/tag/v1-final).
-It is frozen — no new features, no security updates. v2 is a full rewrite
+It is frozen — no new features, no security updates (see
+[`SECURITY.md`](./SECURITY.md#supported-versions)). v2 is a full rewrite
 because v1's monorepo-of-microservices (seven services, shared Docker
 network, Keycloak + OPA for auth) made evaluation painful and deployment
 brittle. v2 is a single-container monolith with strict hexagonal
 boundaries so the evaluation takes 30 minutes instead of 30 hours.
+
+For a fuller archival summary see [`docs/v1-archival.md`](./docs/v1-archival.md).
+
+## Project status
+
+**What works today?** The platform foundation is complete: project
+skeleton + `docker compose up` boot, authentication + session
+management, React application shell + design system, and the REST API
+foundation with H2/PostgreSQL persistence. Login works, `/api/health`
+is live, and Swagger UI serves the real endpoints.
+
+**What's next?** Case lifecycle and workspace — YAML case-type
+configuration, embedded CIB seven BPMN deployment, case CRUD, and the
+split-pane workspace. That milestone is the first evaluable build.
+
+**When can I try the 30-minute demo?** After the case-lifecycle
+milestone ships. The
+[public roadmap](./ROADMAP.md) tracks shipped vs. next vs. later —
+watch this README or follow
+[Victor on LinkedIn](https://www.linkedin.com/in/victorhugof/) for the
+announcement.
 
 ## Architecture
 
@@ -87,21 +107,19 @@ deployment. Case types are YAML files; lifecycle rules are BPMN processes;
 the UI is rendered from a server-generated JSON schema so no case-specific
 frontend code is needed.
 
-See [docs/architecture.md](./docs/architecture.md) for the full decision log (document in progress).
+See [docs/architecture.md](./docs/architecture.md) for the full decision
+log (growing per epic).
 
 ## Links
 
-- **API** — `http://localhost:8080/swagger-ui/index.html` (real endpoints arrive in Story 1.4)
-- **Architecture** — [docs/architecture.md](./docs/architecture.md) _(in progress)_
-- **Security policy** — [SECURITY.md](./SECURITY.md)
-- **Code of conduct** — [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
-
-## Project status
-
-v2 is under active development on `v2-develop`. The roadmap is published as
-per-epic story specs under `_bmad-output/implementation-artifacts/` in
-the planning repo. Pre-1.0 releases will be cut from `main` once the
-Phase-0 epics (1–9) are complete.
+- **API reference** — `http://localhost:8080/swagger-ui/index.html`
+- **Architecture** — [`docs/architecture.md`](./docs/architecture.md)
+- **API conventions** — [`docs/api-conventions.md`](./docs/api-conventions.md)
+- **Roadmap** — [`ROADMAP.md`](./ROADMAP.md)
+- **Contributing** — [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+- **Security policy** — [`SECURITY.md`](./SECURITY.md)
+- **Code of conduct** — [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md)
+- **v1 archival** — [`docs/v1-archival.md`](./docs/v1-archival.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ split-pane workspace. That milestone is the first evaluable build.
 **When can I try the 30-minute demo?** After the case-lifecycle
 milestone ships. The
 [public roadmap](./ROADMAP.md) tracks shipped vs. next vs. later —
-watch this README or follow
-[Victor on LinkedIn](https://www.linkedin.com/in/victorhugof/) for the
+watch this README or the repository's Releases page for the
 announcement.
 
 ## Architecture

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,8 +69,7 @@ Grouped roughly in the order of shipping, not a commitment:
   follow releases.
 - **Watch this file** — it moves entries from _Next_ to _Shipped_ as
   each milestone closes.
-- **Follow [Victor on LinkedIn](https://www.linkedin.com/in/victorhugof/)**
-  for milestone announcements.
+- **Watch the repository's Releases page** for milestone announcements.
 
 ## Pre-1.0 caveat
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,80 @@
+# WKS Platform Roadmap
+
+A plain-English view of what has shipped, what is in flight, and what
+comes next. Updated per milestone. For the architectural "why", see
+[`docs/architecture.md`](./docs/architecture.md).
+
+## Shipped
+
+### Platform foundation
+
+- **Project skeleton + zero-config boot** — `docker compose up --build`
+  from `docker/` brings the full stack up on a fresh machine with no
+  Java or Node installed.
+- **Authentication + session management** — Argon2id password hashing,
+  short-lived JWT in an `HttpOnly` cookie, first-boot admin seed in
+  dev, mandatory admin credentials in production.
+- **React application shell + design system** — single design-token
+  file, Tailwind 4 `@theme inline`, self-hosted Poppins + Rubik fonts,
+  placeholder routes for Cases, Tasks, Admin, Dev.
+- **REST API foundation + database abstraction** — envelope / error
+  conventions, H2 in dev, PostgreSQL in production via JPA + Flyway,
+  Swagger UI at `/swagger-ui/index.html`, `/api/health` live.
+
+## Next — case lifecycle and workspace
+
+The first evaluable build. It makes WKS a real product a system
+integrator can stand up and try end-to-end.
+
+- YAML case-type configuration with validation.
+- Embedded CIB seven BPMN engine behind the `WorkflowEngine` port;
+  BPMN process deployment alongside YAML case types.
+- Case CRUD and domain model.
+- Case status transitions driven by BPMN.
+- Config-driven case list view.
+- Split-pane workspace and case detail screen.
+- Case creation flow.
+- Task completion with honest lifecycle semantics.
+
+At the end of this milestone the README's 30-minute evaluation claim
+is demonstrable: clone, `docker compose up`, deploy a sample case
+type, create a case, move it through its lifecycle.
+
+## Later
+
+Grouped roughly in the order of shipping, not a commitment:
+
+- **Documents** — document storage API, list and download inside case
+  detail.
+- **Activity feed, audit trail, and real-time events** — domain-event
+  infrastructure, business-language activity feed, server-sent events
+  for live updates, sidebar notification badges.
+- **Users and roles** — user admin panel, role-based access per case
+  type.
+- **Developer console** — configuration workflow screen, case
+  workspace bridge for previewing case types before rollout.
+- **Templates and first-run experience** — template package format,
+  BFSI example pack, guided launcher.
+- **Tasks screen and orchestrative actions** — dedicated tasks view,
+  escalate / reassign / add-note flows.
+- **Production readiness** — production Docker profile, theming and
+  branding, webhooks and SMTP notifications, document preview, live
+  demo auto-deploy.
+- **Platform evolution** — v1 → v2 transition path, upgrade and data
+  export tooling.
+
+## How to follow along
+
+- **Star [`wkspower/wks-platform`](https://github.com/wkspower/wks-platform)** to
+  follow releases.
+- **Watch this file** — it moves entries from _Next_ to _Shipped_ as
+  each milestone closes.
+- **Follow [Victor on LinkedIn](https://www.linkedin.com/in/victorhugof/)**
+  for milestone announcements.
+
+## Pre-1.0 caveat
+
+WKS Platform v2 is pre-1.0. Scope below _Later_ may shift as the
+case-lifecycle milestone reveals what evaluators actually need first.
+When that happens, this file is updated; breaking changes go in the
+release notes of the next tagged release.

--- a/docs/v1-archival.md
+++ b/docs/v1-archival.md
@@ -1,0 +1,46 @@
+# v1 Archival
+
+WKS Platform v1 is archived. v2 is a full rewrite on this repository's
+default branch. If you are landing here from the v1 README or a v1
+link, this page summarises what that means.
+
+## Four things to know
+
+1. **Frozen — no new features, no security updates.** The last v1
+   release is tagged [`v1-final`](https://github.com/wkspower/wks-platform/releases/tag/v1-final).
+   No further commits will land on the v1 codebase. See
+   [`SECURITY.md`](../SECURITY.md#supported-versions) for the supported-
+   versions table.
+
+2. **Why a rewrite.** v1 was a monorepo of seven microservices with a
+   shared Docker network and Keycloak + OPA for authentication.
+   Elegant on a whiteboard; brutal in the first 30 minutes of
+   evaluation. An open-source case-management platform lives or dies
+   on that first 30 minutes. v2 is a single-container monolith with
+   strict hexagonal boundaries so the evaluation path is
+   `docker compose up` → open localhost → evaluate.
+
+3. **v1 is still readable.** The v1 code is preserved on the
+   [`v1` branch](https://github.com/wkspower/wks-platform/tree/v1) and
+   at the [`v1-final` tag](https://github.com/wkspower/wks-platform/releases/tag/v1-final).
+   Clone, browse, fork — nothing is deleted or moved. The v1 branch's
+   own `README.md` is retained untouched: editing a frozen branch
+   would contradict the "no further changes" promise this archival
+   makes.
+
+4. **v2 is reachable from v1.** The `v1` branch lives inside this
+   repository (`wkspower/wks-platform`). Navigating one level up from
+   `/tree/v1` lands on the default branch, which serves v2. There is
+   no separate v1 repo and no separate v2 repo — both are branches of
+   the same canonical project.
+
+## What this means for existing v1 users
+
+- **Keep running v1 if you need to**, but plan a migration. No
+  security updates will land.
+- **Do not expect compatibility.** v2's data model, API surface, and
+  configuration format all differ from v1. An automated upgrade path
+  is tracked on the public [`ROADMAP.md`](../ROADMAP.md) under
+  _Later → Platform evolution_.
+- **Follow the default branch of this repo** for v2 progress, or see
+  [`ROADMAP.md`](../ROADMAP.md) for the shipped / next / later view.


### PR DESCRIPTION
## Summary

Story 1.5 delivers the external signals for the repository's first public milestone. With the platform foundation shipped across Stories 1.1–1.4, this PR lands the documentation that lets an external visitor (v1 user, Camunda follower, or drive-by GitHub visitor) parse *what is WKS v2, what works today, and when can I try it* in under 10 seconds.

**Four code-repo artefacts, all documentation:**

- **`ROADMAP.md`** — new public roadmap (80 lines, shipped / next / later). Epic-granularity, external-reader language. Stable surface that future milestone posts cite into.
- **`docs/v1-archival.md`** — new external-reader archival summary. Four points: frozen / no updates, why the rewrite, v1 still readable (branch + tag), v2 reachable from v1 (branch-inside-repo).
- **`README.md`** — removes post-1.1 stale wording (`(real endpoints arrive in Story 1.4)`, `(document in progress)`), rewrites *Project status* section into three plain-English questions, adds Links entries for API conventions / Roadmap / Contributing / v1 archival, wires `SECURITY.md#supported-versions` into the "no security updates" clause.
- **`CONTRIBUTING.md`** — new on-ramp for first-time contributors (76 lines). Six sections in expected order; CI-parity command block copied verbatim from `.github/workflows/ci.yml`; inlined PR-body expectations; no CLA / issue-template promises.

**Public / private boundary (design choice worth calling out):**

None of the four code-repo artefacts link into any private planning repo. None exposes internal `FR`, `AC`, `Story N`, `Epic N`, or `Gate N` vocabulary. The one-way rule is: private planning artefacts may cite into public code-repo docs; public code-repo docs never cite back. This keeps the public surface coherent for an external reader and preserves internal bookkeeping where it belongs.

## Test plan

- [x] `./mvnw -B -ntp verify` from `backend/` — BUILD SUCCESS, 11 IT tests, Spotless clean.
- [x] `npm ci && npm run lint && npm run format:check && npm test && npm run build` from `frontend/` — 61/61 tests, build clean, 4 woff2 files in `dist/assets/`.
- [x] `docker compose up --build -d` from `docker/`, then `curl http://localhost:8080/api/health` — returned 200 with `{"data":{"version":"2.0.0-SNAPSHOT","uptime":"PT5.6S"},"meta":{}}`.
- [x] `npx prettier --check` on `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `docs/v1-archival.md` — all clean.
- [x] Pre-flight verification of v1 archival: `origin` has `v1-final` tag, `v1` branch, and `v2-develop` branch.
- [ ] Reviewer spot-check: every link in `README.md` and `CONTRIBUTING.md` resolves to a file in this repo or a runtime URL available after `docker compose up`; no link goes to a private repo.

## Notes

Gate 1 is **conditionally passed** once this PR merges. Final sign-off requires LinkedIn post #1 to go live. The draft lives in the private planning repo and publishing belongs to Victor; when the post is published, a separate planning-repo commit records the URL and date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)