### PR TITLE
Story 2.3 — Case CRUD operations & domain model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ wks-platform/
   all deploy-time validation codes stay below 100. Architecture doc gets a follow-up patch.)
 - `WKS-CFG-200–299`: Template validation (reserved)
 - `WKS-API-001–099`: API input validation (`WKS-API-413` for multipart cap, Story 2.2)
-- `WKS-RTM-001–099`: Runtime errors
+- `WKS-RTM-001–099`: Runtime errors (`WKS-RTM-409` optimistic-lock conflict, Story 2.3)
 - Error structure: `{ code, message, field, line }`
 - Collection pattern: collect ALL errors, never fail-on-first
 
@@ -316,7 +316,36 @@ Case types are declared as YAML files in a directory mounted into the container.
   `enableDuplicateFiltering(true)` makes redeploy of identical bytes a no-op; whitespace-only
   edits trip a new engine version (by design — engine hashes resource bytes).
 
+### Case CRUD (Story 2.3)
+
+- **Endpoints**: `POST/GET/PUT /api/cases` and `GET /api/cases/{id}` (see `docs/api-conventions.md`).
+- **JSON column**: `cases.data` is `JSON` on H2 and `JSONB` on Postgres (Java migration
+  `V202604260002` upgrades the column on Postgres only). Hibernate 6.6+ native `@JdbcTypeCode(SqlTypes.JSON)`
+  maps it — no third-party hibernate-types adapter.
+- **Initial status**: comes from the case-type YAML's `statuses[0].id` (declaration order).
+  Story 2.4's BPMN execution listener will keep it in sync once transitions ship.
+- **Optimistic locking**: `cases.version` (from `BaseJpaEntity.@Version`) drives `PUT` semantics.
+  Mismatch → HTTP 409 `WKS-RTM-409`.
+- **`documentCount` is always 0** in the response until Epic 3 wires the document store.
+- **`case_type_version` snapshot**: the case row records the case-type version at create time.
+  Phase 0 forward-compat: validation runs against the **current** schema, not the snapshot.
+- **Permission gating**: `@PreAuthorize` SpEL bean refs into `CaseTypePermissionEvaluator` —
+  `create` on POST, `view` on GET / list / PUT (PUT-on-`view` is the Phase 0 simplification —
+  the YAML grammar already supports `edit` since Story 2.1; tightening is Story 5.2 territory).
+- **Engine ordering**: `CaseService.create` is engine-first / DB-second. Engine failure aborts
+  the transaction cleanly; DB failure after engine success leaves a dangling process instance
+  (accepted Phase 0 partial state — Phase 1 wraps in an outbox).
+
 ## Change Log
+
+- 2026-04-26 — Story 2.3: Case CRUD shipped — `POST/GET/PUT /api/cases`, JSON column for
+  dynamic case data (H2 native + Postgres JSONB upgrade via Java Flyway migration),
+  `WorkflowEngine.startProcessInstance` extension, `BaseJpaEntity.equals/hashCode`
+  (id-based, transient-aware), `WKS-RTM-409` optimistic-locking code, ArchUnit rules for the
+  case-domain boundary. Picks up Epic 1 retro action #5 (BaseJpaEntity equals/hashCode), Story
+  1.4 chunk-3 deferred (`AdminUserSeeder.run()` broaden catch for
+  `ObjectOptimisticLockingFailureException`). Networknt JSON-Schema-validator promoted from
+  test to compile scope to power case-data validation.
 
 - 2026-04-26 — Story 2.2: BPMN engine activated (embedded), `POST /api/admin/deploy` shipped,
   BPMN validator codes `WKS-CFG-010/012/020/021/022` added. The `WKS-CFG-010..099` band is now

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -165,13 +165,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- JSON Schema Draft 2020-12 validator — Story 2.1 schema round-trip tests only.
-             Do NOT move to main scope; the generator produces Schemas, it does not validate. -->
+        <!-- JSON Schema Draft 2020-12 validator — used by CaseDataValidatorAdapter (Story 2.3)
+             to validate dynamic case data against the schema generated from the case-type YAML. -->
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>1.5.3</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.tngtech.archunit</groupId>

--- a/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
@@ -6,8 +6,10 @@ import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.WksAuthenticationException;
 import com.wkspower.platform.domain.exception.WksAuthorizationException;
 import com.wkspower.platform.domain.exception.WksConfigException;
+import com.wkspower.platform.domain.exception.WksConflictException;
 import com.wkspower.platform.domain.exception.WksException;
 import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.exception.WksValidationAggregateException;
 import com.wkspower.platform.domain.exception.WksValidationException;
 import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
 import org.slf4j.Logger;
@@ -17,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -121,6 +124,56 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
               ApiResponse.error(
                   ErrorPayload.of(
                       code, "Multipart upload exceeds the configured size cap (1 MB per part)")));
+    } finally {
+      MDC.remove(MDC_KEY);
+    }
+  }
+
+  @ExceptionHandler(WksValidationAggregateException.class)
+  public ResponseEntity<ApiResponse<Void>> handleValidationAggregate(
+      WksValidationAggregateException ex) {
+    MDC.put(MDC_KEY, ex.getCode());
+    try {
+      log.warn("Validation aggregate: {} ({} error(s))", ex.getCode(), ex.getErrors().size());
+      return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+          .body(
+              ApiResponse.error(
+                  ErrorPayload.ofAggregate(ex.getCode(), ex.getMessage(), ex.getErrors())));
+    } finally {
+      MDC.remove(MDC_KEY);
+    }
+  }
+
+  @ExceptionHandler(WksConflictException.class)
+  public ResponseEntity<ApiResponse<Void>> handleConflict(WksConflictException ex) {
+    MDC.put(MDC_KEY, ex.getCode());
+    try {
+      log.warn("Optimistic-lock conflict: {}", ex.getCode());
+      return ResponseEntity.status(HttpStatus.CONFLICT)
+          .body(ApiResponse.error(ErrorPayload.of(ex.getCode(), ex.getMessage())));
+    } finally {
+      MDC.remove(MDC_KEY);
+    }
+  }
+
+  /**
+   * Pinned debt from Story 1.4 chunk-3 deferred — surface {@link
+   * ObjectOptimisticLockingFailureException} as {@code WKS-RTM-409} for any persistence adapter
+   * that hasn't pre-translated to {@link WksConflictException}. {@code AdminUserSeeder}'s catch
+   * broaden (Task 9.4) closes the seeder-side path; this handler covers anything else.
+   */
+  @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+  public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(
+      ObjectOptimisticLockingFailureException ex) {
+    String code = ErrorCode.WKS_RTM_409.wire();
+    MDC.put(MDC_KEY, code);
+    try {
+      log.warn("Optimistic-lock conflict (Spring): {}", code);
+      return ResponseEntity.status(HttpStatus.CONFLICT)
+          .body(
+              ApiResponse.error(
+                  ErrorPayload.of(
+                      code, "Resource was modified by another transaction; reload and retry")));
     } finally {
       MDC.remove(MDC_KEY);
     }

--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
@@ -1,0 +1,147 @@
+package com.wkspower.platform.api.controller;
+
+import com.wkspower.platform.api.dto.ApiResponse;
+import com.wkspower.platform.api.dto.request.CreateCaseRequest;
+import com.wkspower.platform.api.dto.request.UpdateCaseRequest;
+import com.wkspower.platform.api.dto.response.CaseDto;
+import com.wkspower.platform.api.dto.response.CaseSummaryDto;
+import com.wkspower.platform.api.mapper.CaseDtoMapper;
+import com.wkspower.platform.api.pagination.PageRequestParams;
+import com.wkspower.platform.api.pagination.SortSpec;
+import com.wkspower.platform.api.pagination.SortWhitelist;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.WksValidationException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseQuery;
+import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.page.Page;
+import com.wkspower.platform.domain.page.PageRequest;
+import com.wkspower.platform.domain.page.SortOrder;
+import com.wkspower.platform.domain.service.CaseService;
+import com.wkspower.platform.security.CaseTypePermissionEvaluator;
+import com.wkspower.platform.security.WksUserPrincipal;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST surface for case CRUD (Story 2.3 AC5–AC8). Permission gating happens in the handler bodies
+ * (D2 from code review): for {@code GET /{id}} and {@code PUT /{id}} the case is loaded first (404
+ * from {@link CaseService#findById} if missing), then the verb gate fires against the loaded
+ * case-type id. {@code POST} and list-{@code GET} gate before any work because the case-type id
+ * comes straight from the request.
+ *
+ * <p>{@code PUT} requires the {@code edit} verb (D1 from code review) — operators must grant {@code
+ * edit} to roles that should retain mutation rights in their case-type YAML.
+ */
+@RestController
+@RequestMapping("/api/cases")
+public class CaseController {
+
+  private static final SortWhitelist CASE_LIST_SORT =
+      () -> Set.of("updatedAt", "createdAt", "status");
+
+  private final CaseService caseService;
+  private final CaseTypePermissionEvaluator evaluator;
+
+  public CaseController(CaseService caseService, CaseTypePermissionEvaluator evaluator) {
+    this.caseService = caseService;
+    this.evaluator = evaluator;
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<CaseDto>> create(
+      @Valid @RequestBody CreateCaseRequest request,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    requireVerb(actor, request.caseTypeId(), "create");
+    Case created =
+        caseService.create(request.caseTypeId(), request.data(), request.assignee(), actor.id());
+    CaseTypeConfig caseType = caseService.requireCaseType(created.caseTypeId());
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.success(CaseDtoMapper.toDto(created, caseType)));
+  }
+
+  @GetMapping("/{id}")
+  public ApiResponse<CaseDto> get(
+      @PathVariable("id") UUID id, @AuthenticationPrincipal WksUserPrincipal actor) {
+    Case found = caseService.findById(id);
+    requireVerb(actor, found.caseTypeId(), "view");
+    CaseTypeConfig caseType = caseService.requireCaseType(found.caseTypeId());
+    return ApiResponse.success(CaseDtoMapper.toDto(found, caseType));
+  }
+
+  @GetMapping
+  public ApiResponse<List<CaseSummaryDto>> list(
+      @RequestParam("caseType") String caseType,
+      @RequestParam(value = "status", required = false) String status,
+      @RequestParam(value = "page", required = false) Integer page,
+      @RequestParam(value = "size", required = false) Integer size,
+      @RequestParam(value = "sort", required = false) List<String> sort,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    if (caseType == null || caseType.isBlank()) {
+      throw new WksValidationException(
+          ErrorCode.WKS_API_001, "caseType query parameter is required", "caseType");
+    }
+    requireVerb(actor, caseType, "view");
+    PageRequestParams params = PageRequestParams.of(page, size, sort);
+    // toPageable validates page/size bounds and the sort allow-list; we use the parsed sort
+    // (not the Spring Pageable) to translate into our domain SortOrder list.
+    params.toPageable(CASE_LIST_SORT);
+
+    List<SortOrder> domainSort =
+        params.parsedSort().stream()
+            .map(s -> new SortOrder(s.property(), s.direction() == SortSpec.Direction.ASC))
+            .toList();
+    if (domainSort.isEmpty()) {
+      domainSort = List.of(new SortOrder("updatedAt", false));
+    }
+    PageRequest pageRequest =
+        PageRequest.of(
+            params.page(), Math.min(params.size(), PageRequestParams.MAX_SIZE), domainSort);
+    CaseQuery query = CaseQuery.of(caseType, status);
+
+    Page<CaseSummary> results = caseService.list(query, pageRequest);
+    List<CaseSummaryDto> dtos =
+        results.content().stream().map(CaseDtoMapper::toSummaryDto).toList();
+    Map<String, Object> meta =
+        Map.of(
+            "page", results.page(),
+            "size", results.size(),
+            "total", results.total());
+    return ApiResponse.success(dtos, meta);
+  }
+
+  @PutMapping("/{id}")
+  public ApiResponse<CaseDto> update(
+      @PathVariable("id") UUID id,
+      @Valid @RequestBody UpdateCaseRequest request,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    Case found = caseService.findById(id);
+    requireVerb(actor, found.caseTypeId(), "edit");
+    Case updated = caseService.update(id, request.data(), request.version(), actor.id());
+    CaseTypeConfig caseType = caseService.requireCaseType(updated.caseTypeId());
+    return ApiResponse.success(CaseDtoMapper.toDto(updated, caseType));
+  }
+
+  private void requireVerb(WksUserPrincipal actor, String caseTypeId, String verb) {
+    if (actor == null || !evaluator.hasVerb(actor.authenticated(), caseTypeId, verb)) {
+      throw new AccessDeniedException(
+          "Forbidden: missing verb '" + verb + "' on case type " + caseTypeId);
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/request/CreateCaseRequest.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/request/CreateCaseRequest.java
@@ -1,0 +1,13 @@
+package com.wkspower.platform.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Request body for {@code POST /api/cases} (Story 2.3 AC5). {@code data} carries the dynamic
+ * case-type field map (null is treated as empty by {@code CaseService.create}); {@code assignee} is
+ * optional (queue placement when {@code null}).
+ */
+public record CreateCaseRequest(
+    @NotBlank String caseTypeId, Map<String, Object> data, UUID assignee) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/request/UpdateCaseRequest.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/request/UpdateCaseRequest.java
@@ -1,0 +1,10 @@
+package com.wkspower.platform.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+
+/**
+ * Request body for {@code PUT /api/cases/{id}} (Story 2.3 AC8). {@code version} is the optimistic
+ * lock — mismatch surfaces as {@code WKS-RTM-409}.
+ */
+public record UpdateCaseRequest(@NotNull Map<String, Object> data, long version) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseDto.java
@@ -1,0 +1,26 @@
+package com.wkspower.platform.api.dto.response;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Wire shape for {@code GET /api/cases/{id}} and the result of {@code POST /api/cases} / {@code PUT
+ * /api/cases/{id}} (Story 2.3 AC5–AC8). {@code documentCount} is always {@code 0} until Epic 3;
+ * {@code caseType} is the embedded type view (sub-object). The field shape is frozen here so Story
+ * 3.2 can fill {@code documentCount} without a DTO bump.
+ */
+public record CaseDto(
+    UUID id,
+    String caseTypeId,
+    int caseTypeVersion,
+    String status,
+    UUID assignee,
+    Map<String, Object> data,
+    String processInstanceId,
+    int documentCount,
+    Instant createdAt,
+    UUID createdBy,
+    Instant updatedAt,
+    long version,
+    CaseTypeViewDto caseType) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseSummaryDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseSummaryDto.java
@@ -1,0 +1,19 @@
+package com.wkspower.platform.api.dto.response;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Wire shape for one row of {@code GET /api/cases} (Story 2.3 AC7). System columns are top-level;
+ * YAML-declared list columns appear under {@code fields}. The full {@code data} JSON is never
+ * surfaced on the list path.
+ */
+public record CaseSummaryDto(
+    UUID id,
+    String caseTypeId,
+    String status,
+    UUID assignee,
+    Instant createdAt,
+    Instant updatedAt,
+    Map<String, Object> fields) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
@@ -1,0 +1,21 @@
+package com.wkspower.platform.api.dto.response;
+
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import java.util.List;
+
+/**
+ * Subset of {@code CaseTypeConfig} embedded into {@link CaseDto} so the case-detail UI renders in
+ * one round-trip (architecture.md §Decision 12 — config-driven rendering pipeline).
+ *
+ * <p>Roles and the workflow {@code bpmn} reference are intentionally NOT echoed — leaking the
+ * role/permission matrix to the client would expose authorization metadata; the BPMN file path is
+ * an internal concern.
+ */
+public record CaseTypeViewDto(
+    String id,
+    String displayName,
+    int version,
+    List<FieldDefinition> fields,
+    List<StatusDefinition> statuses,
+    List<String> listColumns) {}

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -1,0 +1,57 @@
+package com.wkspower.platform.api.mapper;
+
+import com.wkspower.platform.api.dto.response.CaseDto;
+import com.wkspower.platform.api.dto.response.CaseSummaryDto;
+import com.wkspower.platform.api.dto.response.CaseTypeViewDto;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseSummary;
+
+/**
+ * Domain-model → wire-DTO mapping for the case CRUD endpoints. Manual mapping (no MapStruct) per
+ * Story 1.4 precedent.
+ */
+public final class CaseDtoMapper {
+
+  private CaseDtoMapper() {
+    // utility
+  }
+
+  public static CaseDto toDto(Case domain, CaseTypeConfig caseType) {
+    return new CaseDto(
+        domain.id(),
+        domain.caseTypeId(),
+        domain.caseTypeVersion(),
+        domain.status(),
+        domain.assignee(),
+        domain.data(),
+        domain.processInstanceId(),
+        0, // documentCount — Epic 3 fills this; AC5 freezes the field at 0 in Phase 0.
+        domain.createdAt(),
+        domain.createdBy(),
+        domain.updatedAt(),
+        domain.version(),
+        toCaseTypeView(caseType));
+  }
+
+  public static CaseSummaryDto toSummaryDto(CaseSummary summary) {
+    return new CaseSummaryDto(
+        summary.id(),
+        summary.caseTypeId(),
+        summary.status(),
+        summary.assignee(),
+        summary.createdAt(),
+        summary.updatedAt(),
+        summary.fields());
+  }
+
+  public static CaseTypeViewDto toCaseTypeView(CaseTypeConfig caseType) {
+    return new CaseTypeViewDto(
+        caseType.id(),
+        caseType.displayName(),
+        caseType.version(),
+        caseType.fields(),
+        caseType.statuses(),
+        caseType.listColumns());
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/event/CaseCreated.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/CaseCreated.java
@@ -1,0 +1,14 @@
+package com.wkspower.platform.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Emitted after a {@code Case} is persisted by {@code CaseService.create}. Story 2.3 publishes via
+ * the {@code EventPublisher} port; activity-feed and audit listeners attach in Story 4.1; SSE
+ * transport in Story 4.3.
+ *
+ * <p>Schema follows {@code architecture.md §Decision 11} — entity ids, actor, timestamp.
+ */
+public record CaseCreated(
+    UUID caseId, String caseTypeId, int caseTypeVersion, UUID actorId, Instant timestamp) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/event/CaseUpdated.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/CaseUpdated.java
@@ -1,0 +1,24 @@
+package com.wkspower.platform.domain.event;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Emitted after a {@code Case} is updated by {@code CaseService.update}. Carries the set of field
+ * ids whose value changed between the old and new {@code data} maps so Story 4.1's listener can
+ * write activity-feed entries like "Meera updated Applicant Name and Loan Amount".
+ *
+ * <p>{@code changedFieldIds} is computed by {@code CaseService.update} as the union of field ids
+ * whose values are not {@link java.util.Objects#equals} between old and new {@code data}.
+ *
+ * <p>This event is additive vs the {@code architecture.md §Decision 11} table; the canonical
+ * status-change event ({@code CaseStatusChanged}) lands with Story 2.4.
+ */
+public record CaseUpdated(
+    UUID caseId, UUID actorId, Instant timestamp, Set<String> changedFieldIds) {
+
+  public CaseUpdated {
+    changedFieldIds = Set.copyOf(changedFieldIds);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/event/ConfigDeployed.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/ConfigDeployed.java
@@ -14,6 +14,7 @@ public record ConfigDeployed(
     String caseTypeId,
     int version,
     String deploymentId,
+    String processDefinitionKey,
     String processDefinitionId,
     String actorEmail,
     Instant timestamp) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -100,6 +100,14 @@ public enum ErrorCode {
   /** YAML parse error / I/O failure (catastrophic — validator never produces). */
   WKS_CFG_099("WKS-CFG-099"),
 
+  // 409 — runtime conflict.
+  /**
+   * Optimistic-locking conflict on update — the row was modified by another transaction between
+   * read and write. Story 2.3 introduces this code; produced by {@code
+   * GlobalExceptionHandler.handleOptimisticLock} and {@code WksConflictException}.
+   */
+  WKS_RTM_409("WKS-RTM-409"),
+
   // 500.
   /** Uncaught exception — last resort. */
   WKS_RTM_500("WKS-RTM-500");

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/WksConflictException.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/WksConflictException.java
@@ -1,0 +1,19 @@
+package com.wkspower.platform.domain.exception;
+
+/**
+ * Thrown on optimistic-locking conflict — the row was modified by another transaction between read
+ * and write. Maps to HTTP 409 + {@link ErrorCode#WKS_RTM_409} via {@code GlobalExceptionHandler}.
+ *
+ * <p>Story 2.3 introduces this exception together with {@code WKS_RTM_409}. Phase 0 surfaces only
+ * the wire code; Phase 1 will surface a "case was modified by another user" UX message.
+ */
+public class WksConflictException extends WksException {
+
+  public WksConflictException(String message) {
+    super(ErrorCode.WKS_RTM_409, message);
+  }
+
+  public WksConflictException(String message, Throwable cause) {
+    super(ErrorCode.WKS_RTM_409, message, cause);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/WksValidationAggregateException.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/WksValidationAggregateException.java
@@ -1,0 +1,32 @@
+package com.wkspower.platform.domain.exception;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Multi-error aggregate for case-data validation failures. Bound to {@link ErrorCode#WKS_API_002}
+ * (per code-review D3) so the wire code distinguishes 422-aggregate-validation from the
+ * 400-single-field path that uses {@link ErrorCode#WKS_API_001}.
+ *
+ * <p>Maps to HTTP 422 with the wire envelope shape {@code error.errors[]}. Story 2.3 introduces
+ * this exception when {@code CaseService.create} / {@code update} receives a {@code data} map that
+ * does not satisfy the case type's JSON Schema.
+ */
+public class WksValidationAggregateException extends WksException {
+
+  private final List<ErrorDetail> errors;
+
+  public WksValidationAggregateException(String message, List<ErrorDetail> errors) {
+    super(ErrorCode.WKS_API_002, message);
+    Objects.requireNonNull(errors, "errors");
+    if (errors.isEmpty()) {
+      throw new IllegalArgumentException(
+          "WksValidationAggregateException requires at least one ErrorDetail.");
+    }
+    this.errors = List.copyOf(errors);
+  }
+
+  public List<ErrorDetail> getErrors() {
+    return errors;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/model/Case.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/Case.java
@@ -1,0 +1,54 @@
+package com.wkspower.platform.domain.model;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Domain record for a single business case. Plain Java — no Spring, no JPA, no Jackson annotations.
+ * The ArchUnit rule {@code caseDomainHasNoSpringOrJpaImports} (Story 2.3 AC9) enforces this.
+ *
+ * <p>The {@code data} map carries dynamic fields whose ids come from the case-type YAML schema
+ * (Story 2.1). The map is owned by the case — callers are expected to treat it as immutable; the
+ * record's compact constructor makes a defensive copy.
+ *
+ * @param id case identifier (UUID)
+ * @param caseTypeId case type id from YAML
+ * @param caseTypeVersion snapshot of the case type version when the case was created
+ * @param status current status id (initial value comes from {@code statuses[0].id} of the case
+ *     type; later mutated by Story 2.4's BPMN execution listener)
+ * @param assignee user id assigned to the case, or {@code null} when unassigned (queue)
+ * @param data dynamic case data — keys are field ids declared in the case type's schema
+ * @param processInstanceId BPMN engine-assigned process instance id; populated after engine start
+ * @param createdAt creation timestamp
+ * @param createdBy user id of the actor who created the case
+ * @param updatedAt last-update timestamp
+ * @param version optimistic-locking version (from {@code @Version} on the JPA row)
+ */
+public record Case(
+    UUID id,
+    String caseTypeId,
+    int caseTypeVersion,
+    String status,
+    UUID assignee,
+    Map<String, Object> data,
+    String processInstanceId,
+    Instant createdAt,
+    UUID createdBy,
+    Instant updatedAt,
+    long version) {
+
+  public Case {
+    Objects.requireNonNull(id, "id");
+    Objects.requireNonNull(caseTypeId, "caseTypeId");
+    Objects.requireNonNull(status, "status");
+    Objects.requireNonNull(createdAt, "createdAt");
+    Objects.requireNonNull(createdBy, "createdBy");
+    Objects.requireNonNull(updatedAt, "updatedAt");
+    Map<String, Object> source = data == null ? Map.of() : data;
+    data = Collections.unmodifiableMap(new HashMap<>(source));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/model/CaseQuery.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/CaseQuery.java
@@ -1,0 +1,29 @@
+package com.wkspower.platform.domain.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Query criteria for {@code CaseRepository.findByCaseType}. The case-type id is required (case
+ * lists are always scoped to a single type per AC7); optional status narrows by exact match.
+ */
+public record CaseQuery(String caseTypeId, Optional<String> status) {
+
+  public CaseQuery {
+    Objects.requireNonNull(caseTypeId, "caseTypeId");
+    if (caseTypeId.isBlank()) {
+      throw new IllegalArgumentException("caseTypeId must not be blank");
+    }
+    Objects.requireNonNull(status, "status");
+  }
+
+  public static CaseQuery of(String caseTypeId) {
+    return new CaseQuery(caseTypeId, Optional.empty());
+  }
+
+  public static CaseQuery of(String caseTypeId, String status) {
+    Optional<String> normalized =
+        (status == null || status.isBlank()) ? Optional.empty() : Optional.of(status);
+    return new CaseQuery(caseTypeId, normalized);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/model/CaseSummary.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/CaseSummary.java
@@ -1,0 +1,38 @@
+package com.wkspower.platform.domain.model;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Lightweight projection of a case for list views. Carries only the fields the case-type's {@code
+ * listColumns} declares (in {@code fields}) plus the system columns. The full {@code data} JSON
+ * column is intentionally omitted — list-path SQL never fetches it (Story 2.3 AC7).
+ *
+ * @param id case id
+ * @param caseTypeId case type id
+ * @param status current status id
+ * @param assignee assignee user id, or {@code null}
+ * @param createdAt creation timestamp
+ * @param updatedAt last-update timestamp
+ * @param fields field-level projections — only the YAML-declared {@code listColumns} field values
+ */
+public record CaseSummary(
+    UUID id,
+    String caseTypeId,
+    String status,
+    UUID assignee,
+    Instant createdAt,
+    Instant updatedAt,
+    Map<String, Object> fields) {
+
+  public CaseSummary {
+    Objects.requireNonNull(id, "id");
+    Objects.requireNonNull(caseTypeId, "caseTypeId");
+    Objects.requireNonNull(status, "status");
+    Objects.requireNonNull(createdAt, "createdAt");
+    Objects.requireNonNull(updatedAt, "updatedAt");
+    fields = Map.copyOf(Objects.requireNonNullElseGet(fields, Map::of));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/page/Page.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/page/Page.java
@@ -1,0 +1,29 @@
+package com.wkspower.platform.domain.page;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Domain-side page envelope. The api-layer {@code ApiResponse.meta} is built from this via {@code
+ * PageMetaBuilder}; ports return this type rather than Spring Data's {@code Page} so the domain
+ * stays Spring-free.
+ */
+public record Page<T>(List<T> content, long total, int page, int size) {
+
+  public Page {
+    content = List.copyOf(Objects.requireNonNull(content, "content"));
+    if (total < 0) {
+      throw new IllegalArgumentException("total must be >= 0");
+    }
+    if (page < 0) {
+      throw new IllegalArgumentException("page must be >= 0");
+    }
+    if (size < 1) {
+      throw new IllegalArgumentException("size must be >= 1");
+    }
+  }
+
+  public boolean hasNext() {
+    return (long) (page + 1) * size < total;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/page/PageRequest.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/page/PageRequest.java
@@ -1,0 +1,30 @@
+package com.wkspower.platform.domain.page;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Domain-side pagination request. Mirrors Spring Data's {@code Pageable} shape but lives in the
+ * domain layer so ports don't import Spring. The api-layer {@code PageRequestParams} (Story 1.4) is
+ * mapped to this record by controllers.
+ *
+ * @param page zero-based page index
+ * @param size number of rows per page
+ * @param sort ordered list of sort directives; first element is the primary key
+ */
+public record PageRequest(int page, int size, List<SortOrder> sort) {
+
+  public PageRequest {
+    if (page < 0) {
+      throw new IllegalArgumentException("page must be >= 0");
+    }
+    if (size < 1) {
+      throw new IllegalArgumentException("size must be >= 1");
+    }
+    sort = List.copyOf(Objects.requireNonNull(sort, "sort"));
+  }
+
+  public static PageRequest of(int page, int size, List<SortOrder> sort) {
+    return new PageRequest(page, size, sort);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/page/SortOrder.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/page/SortOrder.java
@@ -1,0 +1,26 @@
+package com.wkspower.platform.domain.page;
+
+import java.util.Objects;
+
+/**
+ * Single sort directive — one property + direction. Property names are validated against a
+ * resource-specific allow-list at the api layer (1.4's {@code SortWhitelist}); domain code trusts
+ * the input.
+ */
+public record SortOrder(String property, boolean ascending) {
+
+  public SortOrder {
+    Objects.requireNonNull(property, "property");
+    if (property.isBlank()) {
+      throw new IllegalArgumentException("property must not be blank");
+    }
+  }
+
+  public static SortOrder asc(String property) {
+    return new SortOrder(property, true);
+  }
+
+  public static SortOrder desc(String property) {
+    return new SortOrder(property, false);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/page/package-info.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/page/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Domain pagination types. Pure records, zero Spring imports — the {@code CaseRepository} port and
+ * any future paginated port returns {@link com.wkspower.platform.domain.page.Page} so the domain
+ * stays infrastructure-free. Controllers map between the api-layer {@code PageRequestParams} and
+ * these types at the boundary.
+ */
+package com.wkspower.platform.domain.page;

--- a/backend/src/main/java/com/wkspower/platform/domain/port/CaseDataValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/CaseDataValidator.java
@@ -1,0 +1,23 @@
+package com.wkspower.platform.domain.port;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Outbound port that validates a case's dynamic {@code data} map against the JSON Schema derived
+ * from a case-type's field definitions. Implementations live in {@code infrastructure/config/}
+ * (where the schema generator and the third-party schema-validator library are wired). Returns the
+ * full list of violations — never short-circuits on first error (collect-all invariant from Story
+ * 2.1 / 2.2).
+ */
+public interface CaseDataValidator {
+
+  /**
+   * Validate {@code data} against the JSON Schema generated for {@code caseType}. An empty list
+   * means valid; otherwise each entry carries a {@code WKS-API-001}-style code, message, and (where
+   * applicable) the offending field id.
+   */
+  List<ErrorDetail> validate(CaseTypeConfig caseType, Map<String, Object> data);
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/CaseRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/CaseRepository.java
@@ -1,0 +1,44 @@
+package com.wkspower.platform.domain.port;
+
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseQuery;
+import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.page.Page;
+import com.wkspower.platform.domain.page.PageRequest;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Outbound port for case persistence. Implementations live in {@code infrastructure/persistence/}
+ * only — enforced by the ArchUnit rule {@code caseRepositoryImplementationsLiveInInfrastructure}
+ * (Story 2.3 AC9).
+ */
+public interface CaseRepository {
+
+  /**
+   * Insert or update — the optimistic-lock {@code version} on {@link Case} drives the semantics.
+   * Returns the persisted case with system fields populated ({@code updatedAt}, bumped {@code
+   * version}).
+   */
+  Case save(Case caseToSave);
+
+  /** O(1) lookup by id. */
+  Optional<Case> findById(UUID id);
+
+  /**
+   * Paginated list of cases by case-type. Returns lightweight {@link CaseSummary} projections — the
+   * JSON {@code data} column is never fetched on this path (perf NFR16).
+   */
+  Page<CaseSummary> findByCaseType(CaseQuery query, PageRequest pageRequest);
+
+  /**
+   * Bulk-fetch the {@code data} JSON for a set of case ids, returning each row's data filtered to
+   * only the keys listed in {@code projectedFieldIds}. Used by the list path to enrich {@link
+   * CaseSummary#fields} from {@code caseType.listColumns} without dragging the full data column
+   * into the projection query (Story 2.3 AC7 / D4).
+   */
+  Map<UUID, Map<String, Object>> findDataByIds(Collection<UUID> ids, Set<String> projectedFieldIds);
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/Clock.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/Clock.java
@@ -1,0 +1,14 @@
+package com.wkspower.platform.domain.port;
+
+import java.time.Instant;
+
+/**
+ * Tiny outbound port for the current time. Lets domain services swap a fixed {@link Instant} in
+ * tests without dragging {@link java.time.Clock} (whose name collides) or Spring's clock
+ * abstraction into the domain.
+ */
+public interface Clock {
+
+  /** Current instant. Default infrastructure adapter delegates to {@code Instant.now()}. */
+  Instant now();
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/ProcessDefinitionKeyResolver.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/ProcessDefinitionKeyResolver.java
@@ -1,0 +1,18 @@
+package com.wkspower.platform.domain.port;
+
+import java.util.Optional;
+
+/**
+ * Outbound port that resolves the BPMN process-definition key associated with a deployed case-type.
+ * The key is needed by {@code CaseService.create} to call {@code
+ * WorkflowEngine.startProcessInstance(...)} — the YAML's {@code workflow.bpmn} field is the BPMN
+ * file name, not the engine key.
+ *
+ * <p>Phase 0 implementation caches keys observed via the {@code ConfigDeployed} event stream; Phase
+ * 1 may persist the mapping if the engine restart pattern requires it.
+ */
+public interface ProcessDefinitionKeyResolver {
+
+  /** Returns the engine process-definition key for {@code caseTypeId}, if known. */
+  Optional<String> resolve(String caseTypeId);
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/WorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/WorkflowEngine.java
@@ -3,12 +3,20 @@ package com.wkspower.platform.domain.port;
 import com.wkspower.platform.domain.workflow.DeploymentInfo;
 import com.wkspower.platform.domain.workflow.DeploymentRequest;
 import com.wkspower.platform.domain.workflow.DeploymentResult;
+import java.util.Map;
 import java.util.Optional;
 
 /**
- * Outbound port for the embedded BPMN engine. Story 2.2 owns the deploy + lookup surface; process
- * instance lifecycle (start, complete, transition) is intentionally absent and lands with Stories
- * 2.3 / 2.4 / 2.8. Implementations live in {@code engine/} only.
+ * Outbound port for the embedded BPMN engine.
+ *
+ * <ul>
+ *   <li>Story 2.2 surface — {@link #deploy(DeploymentRequest)} and {@link
+ *       #latestDeployment(String)}.
+ *   <li>Story 2.3 surface — {@link #startProcessInstance(String, Map)}.
+ *   <li>Process completion / transition lifecycle remains absent until Stories 2.4 / 2.8.
+ * </ul>
+ *
+ * <p>Implementations live in {@code engine/} only.
  */
 public interface WorkflowEngine {
 
@@ -24,4 +32,14 @@ public interface WorkflowEngine {
    * the key has never been deployed.
    */
   Optional<DeploymentInfo> latestDeployment(String processDefinitionKey);
+
+  /**
+   * Start a process instance for the given deployed process definition. {@code variables} are
+   * passed to the engine as initial process variables; pass simple scalars only ({@code String},
+   * {@code UUID.toString()}, {@code Long}). Returns the engine-assigned process instance id.
+   *
+   * <p>Implementations MUST translate engine-side failures (unknown key, JUEL evaluation errors)
+   * into {@link com.wkspower.platform.domain.exception.WksWorkflowEngineException}.
+   */
+  String startProcessInstance(String processDefinitionKey, Map<String, Object> variables);
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -1,0 +1,251 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.event.CaseCreated;
+import com.wkspower.platform.domain.event.CaseUpdated;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.exception.WksValidationAggregateException;
+import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseQuery;
+import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.page.Page;
+import com.wkspower.platform.domain.page.PageRequest;
+import com.wkspower.platform.domain.port.CaseDataValidator;
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.port.CaseTypeReader;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
+import com.wkspower.platform.domain.port.WorkflowEngine;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Domain service orchestrating case CRUD. Framework-free — no Spring, no JPA, no Jackson on the
+ * import list — collaborators are reached via the six ports declared in {@code domain/port/}.
+ *
+ * <p>The {@code create} ordering is engine-first / DB-second by design (see Story 2.3 Dev Notes
+ * §processInstanceId ordering). If the engine succeeds and the DB persist fails, the engine has a
+ * dangling process instance — accepted partial state for Phase 0; Phase 1 wraps in an outbox.
+ */
+public class CaseService {
+
+  private final CaseRepository caseRepository;
+  private final CaseTypeReader caseTypeReader;
+  private final CaseDataValidator caseDataValidator;
+  private final WorkflowEngine workflowEngine;
+  private final ProcessDefinitionKeyResolver processKeyResolver;
+  private final EventPublisher eventPublisher;
+  private final Clock clock;
+
+  public CaseService(
+      CaseRepository caseRepository,
+      CaseTypeReader caseTypeReader,
+      CaseDataValidator caseDataValidator,
+      WorkflowEngine workflowEngine,
+      ProcessDefinitionKeyResolver processKeyResolver,
+      EventPublisher eventPublisher,
+      Clock clock) {
+    this.caseRepository = Objects.requireNonNull(caseRepository, "caseRepository");
+    this.caseTypeReader = Objects.requireNonNull(caseTypeReader, "caseTypeReader");
+    this.caseDataValidator = Objects.requireNonNull(caseDataValidator, "caseDataValidator");
+    this.workflowEngine = Objects.requireNonNull(workflowEngine, "workflowEngine");
+    this.processKeyResolver = Objects.requireNonNull(processKeyResolver, "processKeyResolver");
+    this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher");
+    this.clock = Objects.requireNonNull(clock, "clock");
+  }
+
+  /**
+   * Create a new case. Steps follow Story 2.3 AC4: load case type → validate data → start BPMN
+   * process instance → persist row → publish {@link CaseCreated}.
+   */
+  public Case create(String caseTypeId, Map<String, Object> data, UUID assignee, UUID actorId) {
+    Objects.requireNonNull(caseTypeId, "caseTypeId");
+    Objects.requireNonNull(actorId, "actorId");
+
+    CaseTypeConfig caseType = requireCaseType(caseTypeId);
+    Map<String, Object> safeData = data == null ? Map.of() : Map.copyOf(data);
+
+    List<ErrorDetail> violations = caseDataValidator.validate(caseType, safeData);
+    if (!violations.isEmpty()) {
+      throw new WksValidationAggregateException("Case data failed validation", violations);
+    }
+
+    UUID caseId = UUID.randomUUID();
+    String initialStatus = initialStatus(caseType);
+
+    String processDefinitionKey =
+        processKeyResolver
+            .resolve(caseType.id())
+            .orElseThrow(
+                () ->
+                    new WksWorkflowEngineException(
+                        "No deployed BPMN process definition for case type "
+                            + caseType.id()
+                            + " — case create requires a deployed workflow"));
+    String processInstanceId =
+        workflowEngine.startProcessInstance(
+            processDefinitionKey, Map.of("caseId", caseId.toString()));
+
+    Instant now = clock.now();
+    Case toPersist =
+        new Case(
+            caseId,
+            caseType.id(),
+            caseType.version(),
+            initialStatus,
+            assignee,
+            safeData,
+            processInstanceId,
+            now,
+            actorId,
+            now,
+            0L);
+    Case persisted = caseRepository.save(toPersist);
+
+    eventPublisher.publish(
+        new CaseCreated(persisted.id(), caseType.id(), caseType.version(), actorId, now));
+    return persisted;
+  }
+
+  /**
+   * Update an existing case's {@code data}. The expected {@code version} is checked via the JPA
+   * {@code @Version} optimistic lock — mismatch surfaces as {@link WksConflictException}.
+   */
+  public Case update(UUID caseId, Map<String, Object> newData, long expectedVersion, UUID actorId) {
+    Objects.requireNonNull(caseId, "caseId");
+    Objects.requireNonNull(actorId, "actorId");
+
+    Case existing =
+        caseRepository
+            .findById(caseId)
+            .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
+    if (existing.version() != expectedVersion) {
+      throw new WksConflictException(
+          "Case " + caseId + " was modified by another transaction; reload and retry");
+    }
+
+    CaseTypeConfig caseType = requireCaseType(existing.caseTypeId());
+    Map<String, Object> safeData = newData == null ? Map.of() : Map.copyOf(newData);
+
+    List<ErrorDetail> violations = caseDataValidator.validate(caseType, safeData);
+    if (!violations.isEmpty()) {
+      throw new WksValidationAggregateException("Case data failed validation", violations);
+    }
+
+    Set<String> changedFieldIds = diffFieldIds(existing.data(), safeData);
+    Instant now = clock.now();
+    Case updated =
+        new Case(
+            existing.id(),
+            existing.caseTypeId(),
+            existing.caseTypeVersion(),
+            existing.status(),
+            existing.assignee(),
+            safeData,
+            existing.processInstanceId(),
+            existing.createdAt(),
+            existing.createdBy(),
+            now,
+            existing.version());
+
+    Case persisted = caseRepository.save(updated);
+    eventPublisher.publish(new CaseUpdated(persisted.id(), actorId, now, changedFieldIds));
+    return persisted;
+  }
+
+  /** Lookup by id; 404 if not found. */
+  public Case findById(UUID caseId) {
+    return caseRepository
+        .findById(caseId)
+        .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
+  }
+
+  /**
+   * Paginated list of case summaries scoped to a case type. After fetching the lightweight rows we
+   * enrich {@code CaseSummary.fields} from {@code caseType.listColumns} via {@code findDataByIds}
+   * (Story 2.3 D4) — keeps the wide JSON column out of the main projection query while still
+   * delivering the listColumns values the wire contract promises.
+   */
+  public Page<CaseSummary> list(CaseQuery query, PageRequest pageRequest) {
+    Page<CaseSummary> page = caseRepository.findByCaseType(query, pageRequest);
+    if (page.content().isEmpty()) {
+      return page;
+    }
+    CaseTypeConfig caseType = requireCaseType(query.caseTypeId());
+    Set<String> projectedFieldIds = Set.copyOf(caseType.listColumns());
+    if (projectedFieldIds.isEmpty()) {
+      return page;
+    }
+    List<UUID> ids = page.content().stream().map(CaseSummary::id).toList();
+    Map<UUID, Map<String, Object>> dataById = caseRepository.findDataByIds(ids, projectedFieldIds);
+    List<CaseSummary> enriched = new ArrayList<>(page.content().size());
+    for (CaseSummary s : page.content()) {
+      enriched.add(
+          new CaseSummary(
+              s.id(),
+              s.caseTypeId(),
+              s.status(),
+              s.assignee(),
+              s.createdAt(),
+              s.updatedAt(),
+              dataById.getOrDefault(s.id(), Map.of())));
+    }
+    return new Page<>(enriched, page.total(), page.page(), page.size());
+  }
+
+  /**
+   * Locate the case type — 404 if it does not exist. Used on create and update; the controller has
+   * already returned 403 on missing permission verbs by the time this fires.
+   */
+  public CaseTypeConfig requireCaseType(String caseTypeId) {
+    return caseTypeReader
+        .find(caseTypeId)
+        .orElseThrow(() -> new WksNotFoundException("Case type " + caseTypeId + " not found"));
+  }
+
+  /**
+   * Initial status comes from the YAML — {@code statuses[0].id} per Story 2.3 Dev Notes §Initial
+   * status semantics. Story 2.4's BPMN listener will keep it in sync with engine state thereafter.
+   */
+  private static String initialStatus(CaseTypeConfig caseType) {
+    return caseType.statuses().stream()
+        .map(StatusDefinition::id)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Case type "
+                        + caseType.id()
+                        + " has no statuses — should have been rejected by"
+                        + " the validator"));
+  }
+
+  /**
+   * Set of field ids whose value differs between {@code oldData} and {@code newData}. A field
+   * present on one side but absent from the other counts as changed.
+   */
+  static Set<String> diffFieldIds(Map<String, Object> oldData, Map<String, Object> newData) {
+    Set<String> changed = new HashSet<>();
+    Set<String> allKeys = new HashSet<>(oldData.keySet());
+    allKeys.addAll(newData.keySet());
+    for (String key : allKeys) {
+      Object o = oldData.get(key);
+      Object n = newData.get(key);
+      if (!Objects.equals(o, n)) {
+        changed.add(key);
+      }
+    }
+    return changed;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
@@ -136,6 +136,7 @@ public class ConfigService {
             caseType.id(),
             caseType.version(),
             deployment.deploymentId(),
+            deployment.processDefinitionKey(),
             deployment.processDefinitionId(),
             actorEmail,
             deployment.deployedAt()));
@@ -166,6 +167,7 @@ public class ConfigService {
             caseType.id(),
             caseType.version(),
             deployment.deploymentId(),
+            deployment.processDefinitionKey(),
             deployment.processDefinitionId(),
             actorEmail,
             deployment.deployedAt()));

--- a/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
@@ -8,10 +8,15 @@ import com.wkspower.platform.domain.workflow.DeploymentResult;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import org.cibseven.bpm.engine.ProcessEngineException;
 import org.cibseven.bpm.engine.RepositoryService;
+import org.cibseven.bpm.engine.RuntimeService;
 import org.cibseven.bpm.engine.repository.Deployment;
 import org.cibseven.bpm.engine.repository.ProcessDefinition;
+import org.cibseven.bpm.engine.runtime.ProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -34,9 +39,12 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
   private static final long DEPLOY_WARN_THRESHOLD_MS = 2000L;
 
   private final RepositoryService repositoryService;
+  private final RuntimeService runtimeService;
 
-  public CibSevenWorkflowEngine(RepositoryService repositoryService) {
+  public CibSevenWorkflowEngine(
+      RepositoryService repositoryService, RuntimeService runtimeService) {
     this.repositoryService = repositoryService;
+    this.runtimeService = runtimeService;
   }
 
   @Override
@@ -150,5 +158,24 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
             definition.getId(),
             definition.getVersion(),
             deployment.getDeploymentTime().toInstant()));
+  }
+
+  @Override
+  public String startProcessInstance(String processDefinitionKey, Map<String, Object> variables) {
+    Objects.requireNonNull(processDefinitionKey, "processDefinitionKey");
+    Map<String, Object> safeVariables = variables == null ? Map.of() : Map.copyOf(variables);
+    ProcessInstance instance;
+    try {
+      instance = runtimeService.startProcessInstanceByKey(processDefinitionKey, safeVariables);
+    } catch (ProcessEngineException ex) {
+      throw new WksWorkflowEngineException(
+          "CIB seven startProcessInstance failed for processDefinitionKey=" + processDefinitionKey,
+          ex);
+    }
+    if (instance == null || instance.getId() == null) {
+      throw new WksWorkflowEngineException(
+          "CIB seven returned no ProcessInstance for processDefinitionKey=" + processDefinitionKey);
+    }
+    return instance.getId();
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseDataValidatorAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseDataValidatorAdapter.java
@@ -1,0 +1,67 @@
+package com.wkspower.platform.infrastructure.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.domain.port.CaseDataValidator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adapter that bridges {@link JsonSchemaGenerator} (domain-config-driven schema construction) and
+ * the networknt JSON Schema validator. Returns the full list of violations — never short-circuits
+ * (collect-all invariant). The Jackson {@link ObjectMapper} comes from Story 1.4's {@code
+ * JacksonConfig}; the schema factory is built once per JVM (Draft 2020-12).
+ */
+@Component
+class CaseDataValidatorAdapter implements CaseDataValidator {
+
+  private static final JsonSchemaFactory SCHEMA_FACTORY =
+      JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+
+  private final JsonSchemaGenerator schemaGenerator;
+  private final ObjectMapper objectMapper;
+
+  CaseDataValidatorAdapter(JsonSchemaGenerator schemaGenerator, ObjectMapper objectMapper) {
+    this.schemaGenerator = schemaGenerator;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public List<ErrorDetail> validate(CaseTypeConfig caseType, Map<String, Object> data) {
+    JsonNode schemaNode = schemaGenerator.generate(caseType);
+    JsonSchema schema = SCHEMA_FACTORY.getSchema(schemaNode);
+    JsonNode payload = objectMapper.valueToTree(data == null ? Map.of() : data);
+    Set<ValidationMessage> messages = schema.validate(payload);
+
+    List<ErrorDetail> errors = new ArrayList<>();
+    for (ValidationMessage m : messages) {
+      String field = pointerToField(m.getInstanceLocation().toString());
+      errors.add(ErrorDetail.ofField(ErrorCode.WKS_API_001.wire(), m.getMessage(), field));
+    }
+    return List.copyOf(errors);
+  }
+
+  private static String pointerToField(String pointer) {
+    if (pointer == null || pointer.isEmpty() || "$".equals(pointer)) {
+      return null;
+    }
+    // networknt 1.5 uses JsonPath-style locations like "$.applicant_name". Strip the prefix.
+    if (pointer.startsWith("$.")) {
+      return pointer.substring(2);
+    }
+    if (pointer.startsWith("/")) {
+      return pointer.substring(1);
+    }
+    return pointer;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
@@ -1,11 +1,16 @@
 package com.wkspower.platform.infrastructure.config;
 
 import com.wkspower.platform.domain.port.BpmnValidationService;
+import com.wkspower.platform.domain.port.CaseDataValidator;
+import com.wkspower.platform.domain.port.CaseRepository;
 import com.wkspower.platform.domain.port.CaseTypeReader;
 import com.wkspower.platform.domain.port.CaseTypeRegistrar;
 import com.wkspower.platform.domain.port.CaseTypeSource;
+import com.wkspower.platform.domain.port.Clock;
 import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
 import com.wkspower.platform.domain.port.WorkflowEngine;
+import com.wkspower.platform.domain.service.CaseService;
 import com.wkspower.platform.domain.service.ConfigService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,5 +32,24 @@ public class ConfigServiceConfig {
       EventPublisher eventPublisher) {
     return new ConfigService(
         source, registrar, reader, bpmnValidator, workflowEngine, eventPublisher);
+  }
+
+  @Bean
+  public CaseService wksCaseService(
+      CaseRepository caseRepository,
+      CaseTypeReader caseTypeReader,
+      CaseDataValidator caseDataValidator,
+      WorkflowEngine workflowEngine,
+      ProcessDefinitionKeyResolver processKeyResolver,
+      EventPublisher eventPublisher,
+      Clock clock) {
+    return new CaseService(
+        caseRepository,
+        caseTypeReader,
+        caseDataValidator,
+        workflowEngine,
+        processKeyResolver,
+        eventPublisher,
+        clock);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ProcessDefinitionKeyCache.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ProcessDefinitionKeyCache.java
@@ -1,0 +1,38 @@
+package com.wkspower.platform.infrastructure.config;
+
+import com.wkspower.platform.domain.event.ConfigDeployed;
+import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * In-memory mapping of {@code caseTypeId → processDefinitionKey}. Populated by listening to {@code
+ * ConfigDeployed} events from {@code ConfigService.deploy} and {@code CaseTypeStartupLoader}. Reads
+ * are lock-free via {@link ConcurrentHashMap}.
+ *
+ * <p>Phase 0 trade-off: the cache is rebuilt at boot from the startup-loader's deploy events, so a
+ * cold start always re-publishes every observed mapping. If an operator deploys a case-type via
+ * HTTP and then restarts the JVM without the YAML on disk, the case-type stays registered (via
+ * persistence) but the cache loses the key — Story 2.4 will need a persistent mapping if that
+ * restart-survival case becomes load-bearing.
+ */
+@Component
+class ProcessDefinitionKeyCache implements ProcessDefinitionKeyResolver {
+
+  private final Map<String, String> keysByCaseTypeId = new ConcurrentHashMap<>();
+
+  @EventListener
+  public void onConfigDeployed(ConfigDeployed event) {
+    if (event.processDefinitionKey() != null) {
+      keysByCaseTypeId.put(event.caseTypeId(), event.processDefinitionKey());
+    }
+  }
+
+  @Override
+  public Optional<String> resolve(String caseTypeId) {
+    return Optional.ofNullable(keysByCaseTypeId.get(caseTypeId));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/CaseRepositoryAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/CaseRepositoryAdapter.java
@@ -1,0 +1,144 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseQuery;
+import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.page.Page;
+import com.wkspower.platform.domain.page.PageRequest;
+import com.wkspower.platform.domain.page.SortOrder;
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.infrastructure.persistence.entity.CaseEntity;
+import com.wkspower.platform.infrastructure.persistence.mapper.CaseMapper;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseEntityRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseSummaryProjection;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Adapter for {@link CaseRepository}. Maps domain ↔ JPA via {@link CaseMapper}. The list path uses
+ * a constructor projection so the JSON {@code data} column is never fetched on list reads (Story
+ * 2.3 AC7).
+ *
+ * <p>Sort whitelisting is handled at the api layer; this adapter trusts the {@link SortOrder}
+ * properties and translates them straight into Spring Data's {@link Sort} (camelCase JPA property
+ * names match the entity field names).
+ */
+@Component
+class CaseRepositoryAdapter implements CaseRepository {
+
+  private final CaseEntityRepository cases;
+
+  CaseRepositoryAdapter(CaseEntityRepository cases) {
+    this.cases = cases;
+  }
+
+  @Override
+  @Transactional
+  public Case save(Case caseToSave) {
+    CaseEntity entity =
+        cases
+            .findById(caseToSave.id())
+            .map(existing -> applyUpdate(existing, caseToSave))
+            .orElseGet(() -> CaseMapper.toEntity(caseToSave));
+    try {
+      CaseEntity saved = cases.saveAndFlush(entity);
+      return CaseMapper.toDomain(saved);
+    } catch (ObjectOptimisticLockingFailureException ex) {
+      throw new WksConflictException(
+          "Case " + caseToSave.id() + " was modified by another transaction; reload and retry", ex);
+    }
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<Case> findById(UUID id) {
+    return cases.findById(id).map(CaseMapper::toDomain);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Page<CaseSummary> findByCaseType(CaseQuery query, PageRequest pageRequest) {
+    Pageable pageable =
+        org.springframework.data.domain.PageRequest.of(
+            pageRequest.page(), pageRequest.size(), toSpringSort(pageRequest.sort()));
+    org.springframework.data.domain.Page<CaseSummaryProjection> projection =
+        cases.findSummaryByCaseType(query.caseTypeId(), query.status().orElse(null), pageable);
+
+    List<CaseSummary> content =
+        projection.getContent().stream().map(CaseRepositoryAdapter::toDomainSummary).toList();
+    return new Page<>(
+        content, projection.getTotalElements(), pageRequest.page(), pageRequest.size());
+  }
+
+  private static CaseEntity applyUpdate(CaseEntity existing, Case domain) {
+    existing.setCaseTypeId(domain.caseTypeId());
+    existing.setCaseTypeVersion(domain.caseTypeVersion());
+    existing.setStatus(domain.status());
+    existing.setAssignee(domain.assignee());
+    existing.setData(domain.data());
+    existing.setProcessInstanceId(domain.processInstanceId());
+    // Pin the optimistic-lock version to the caller's expected value (P1) — Hibernate's @Version
+    // comparison will then fire on flush against caller intent, closing the TOCTOU window between
+    // the service's read and this adapter's write when no enclosing transaction binds them.
+    existing.setExpectedVersion(domain.version());
+    // createdBy / createdAt are immutable post-create; never overwritten on update.
+    return existing;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Map<UUID, Map<String, Object>> findDataByIds(
+      Collection<UUID> ids, Set<String> projectedFieldIds) {
+    if (ids == null || ids.isEmpty()) {
+      return Map.of();
+    }
+    Set<String> projection = projectedFieldIds == null ? Set.of() : projectedFieldIds;
+    return cases.findDataByIds(ids).stream()
+        .collect(
+            Collectors.toUnmodifiableMap(
+                CaseEntity::getId, e -> filterFields(e.getData(), projection)));
+  }
+
+  private static Map<String, Object> filterFields(
+      Map<String, Object> data, Set<String> projectedFieldIds) {
+    if (data == null || data.isEmpty() || projectedFieldIds.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, Object> filtered = new HashMap<>();
+    for (String key : projectedFieldIds) {
+      if (data.containsKey(key)) {
+        filtered.put(key, data.get(key));
+      }
+    }
+    return Map.copyOf(filtered);
+  }
+
+  private static CaseSummary toDomainSummary(CaseSummaryProjection p) {
+    // The list path returns empty fields here; the service post-enriches via findDataByIds using
+    // caseType.listColumns (Story 2.3 D4).
+    return new CaseSummary(
+        p.id(), p.caseTypeId(), p.status(), p.assignee(), p.createdAt(), p.updatedAt(), Map.of());
+  }
+
+  private static Sort toSpringSort(List<SortOrder> sort) {
+    if (sort == null || sort.isEmpty()) {
+      return Sort.unsorted();
+    }
+    return Sort.by(
+        sort.stream()
+            .map(s -> s.ascending() ? Sort.Order.asc(s.property()) : Sort.Order.desc(s.property()))
+            .toList());
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/BaseJpaEntity.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/BaseJpaEntity.java
@@ -7,7 +7,9 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Version;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
+import org.hibernate.Hibernate;
 
 /**
  * Shared mapping superclass for every JPA entity in the platform. Owns the four audit fields every
@@ -76,6 +78,17 @@ public abstract class BaseJpaEntity {
     return version;
   }
 
+  /**
+   * Force the optimistic-lock {@code version} on a managed entity before flush so Hibernate's
+   * {@code @Version} comparison fires against the caller's intent rather than the freshly-loaded
+   * row. Used by adapters that load → mutate → save inside a single transaction (e.g., {@code
+   * CaseRepositoryAdapter.save}); without this, a stale-version write in a longer read-then-write
+   * flow would silently overwrite a concurrent committed update.
+   */
+  protected void setVersion(long version) {
+    this.version = version;
+  }
+
   public Instant getCreatedAt() {
     return createdAt;
   }
@@ -91,5 +104,40 @@ public abstract class BaseJpaEntity {
 
   protected void setUpdatedAt(Instant updatedAt) {
     this.updatedAt = updatedAt;
+  }
+
+  /**
+   * Id-based equality with transient-aware semantics: two transient instances (id == null) are
+   * never equal unless they are the same reference. Two managed instances with the same id are
+   * equal across persistence-context boundaries. Defensively unwraps Hibernate proxies so a managed
+   * entity equals its proxy for the same row.
+   */
+  @Override
+  public final boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null) {
+      return false;
+    }
+    if (!(Hibernate.getClass(this).equals(Hibernate.getClass(o)))) {
+      return false;
+    }
+    BaseJpaEntity other = (BaseJpaEntity) o;
+    if (this.getId() == null || other.getId() == null) {
+      return false;
+    }
+    return Objects.equals(this.getId(), other.getId());
+  }
+
+  /**
+   * Class-based hashCode (Vlad Mihalcea pattern): stable across the transient → managed transition.
+   * Using {@code id.hashCode()} would change after flush, breaking {@code Set} membership. Uses
+   * {@link Hibernate#getClass(Object)} so a Hibernate proxy hashes to the same bucket as the
+   * unwrapped entity.
+   */
+  @Override
+  public final int hashCode() {
+    return Hibernate.getClass(this).hashCode();
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/CaseEntity.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/CaseEntity.java
@@ -1,0 +1,141 @@
+package com.wkspower.platform.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * JPA entity for {@code cases}. Inherits id / version / audit timestamps from {@link
+ * BaseJpaEntity}; owns the case-specific columns plus the JSON {@code data} column that carries
+ * dynamic case-type fields.
+ *
+ * <p>Hibernate 6 ({@link JdbcTypeCode} + {@link SqlTypes#JSON}) maps the {@code Map<String,
+ * Object>} natively without {@code com.vladmihalcea:hibernate-types} — verified at story-creation
+ * time (Spring Boot 3.5.4 → Hibernate 6.6.x). Resolved version recorded in dev record.
+ */
+@Entity
+@Table(name = "cases")
+public class CaseEntity extends BaseJpaEntity {
+
+  @Column(name = "case_type_id", length = 64, nullable = false)
+  private String caseTypeId;
+
+  @Column(name = "case_type_version", nullable = false)
+  private int caseTypeVersion;
+
+  @Column(name = "status", length = 64, nullable = false)
+  private String status;
+
+  @Column(name = "assignee")
+  private UUID assignee;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "data", nullable = false)
+  private Map<String, Object> data = new HashMap<>();
+
+  @Column(name = "process_instance_id", length = 64)
+  private String processInstanceId;
+
+  @Column(name = "created_by", nullable = false)
+  private UUID createdBy;
+
+  protected CaseEntity() {
+    // JPA
+  }
+
+  public CaseEntity(
+      UUID id,
+      String caseTypeId,
+      int caseTypeVersion,
+      String status,
+      UUID assignee,
+      Map<String, Object> data,
+      String processInstanceId,
+      UUID createdBy,
+      Instant createdAt,
+      Instant updatedAt) {
+    super(id);
+    this.caseTypeId = caseTypeId;
+    this.caseTypeVersion = caseTypeVersion;
+    this.status = status;
+    this.assignee = assignee;
+    this.data = data == null ? new HashMap<>() : new HashMap<>(data);
+    this.processInstanceId = processInstanceId;
+    this.createdBy = createdBy;
+    setCreatedAt(createdAt);
+    setUpdatedAt(updatedAt);
+  }
+
+  public String getCaseTypeId() {
+    return caseTypeId;
+  }
+
+  public void setCaseTypeId(String caseTypeId) {
+    this.caseTypeId = caseTypeId;
+  }
+
+  public int getCaseTypeVersion() {
+    return caseTypeVersion;
+  }
+
+  public void setCaseTypeVersion(int caseTypeVersion) {
+    this.caseTypeVersion = caseTypeVersion;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public UUID getAssignee() {
+    return assignee;
+  }
+
+  public void setAssignee(UUID assignee) {
+    this.assignee = assignee;
+  }
+
+  public Map<String, Object> getData() {
+    return Collections.unmodifiableMap(data);
+  }
+
+  public void setData(Map<String, Object> data) {
+    this.data = data == null ? new HashMap<>() : new HashMap<>(data);
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public UUID getCreatedBy() {
+    return createdBy;
+  }
+
+  public void setCreatedBy(UUID createdBy) {
+    this.createdBy = createdBy;
+  }
+
+  @Override
+  public void setUpdatedAt(Instant updatedAt) {
+    super.setUpdatedAt(updatedAt);
+  }
+
+  /** Exposed so the adapter can pin the optimistic-lock version to the caller's expected value. */
+  public void setExpectedVersion(long version) {
+    setVersion(version);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/mapper/CaseMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/mapper/CaseMapper.java
@@ -1,0 +1,44 @@
+package com.wkspower.platform.infrastructure.persistence.mapper;
+
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.infrastructure.persistence.entity.CaseEntity;
+
+/**
+ * Manual mapper between the {@link CaseEntity} JPA row and the {@link Case} domain record. Mirrors
+ * Story 1.4's no-MapStruct precedent — keeps the mapping explicit and easy to grep.
+ */
+public final class CaseMapper {
+
+  private CaseMapper() {
+    // utility
+  }
+
+  public static Case toDomain(CaseEntity entity) {
+    return new Case(
+        entity.getId(),
+        entity.getCaseTypeId(),
+        entity.getCaseTypeVersion(),
+        entity.getStatus(),
+        entity.getAssignee(),
+        entity.getData(),
+        entity.getProcessInstanceId(),
+        entity.getCreatedAt(),
+        entity.getCreatedBy(),
+        entity.getUpdatedAt(),
+        entity.getVersion());
+  }
+
+  public static CaseEntity toEntity(Case domain) {
+    return new CaseEntity(
+        domain.id(),
+        domain.caseTypeId(),
+        domain.caseTypeVersion(),
+        domain.status(),
+        domain.assignee(),
+        domain.data(),
+        domain.processInstanceId(),
+        domain.createdBy(),
+        domain.createdAt(),
+        domain.updatedAt());
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseEntityRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseEntityRepository.java
@@ -1,0 +1,35 @@
+package com.wkspower.platform.infrastructure.persistence.repository;
+
+import com.wkspower.platform.infrastructure.persistence.entity.CaseEntity;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Spring Data JPA repository for {@link CaseEntity}. The list query uses a JPQL constructor
+ * projection into {@link CaseSummaryProjection} so the wide JSON {@code data} column is never
+ * fetched on list-path SQL (perf NFR16 — story 2.3 AC7).
+ */
+public interface CaseEntityRepository extends JpaRepository<CaseEntity, UUID> {
+
+  @Query(
+      "SELECT new com.wkspower.platform.infrastructure.persistence.repository.CaseSummaryProjection("
+          + "c.id, c.caseTypeId, c.status, c.assignee, c.createdAt, c.updatedAt) "
+          + "FROM CaseEntity c "
+          + "WHERE c.caseTypeId = :caseTypeId "
+          + "AND (:status IS NULL OR c.status = :status)")
+  Page<CaseSummaryProjection> findSummaryByCaseType(
+      @Param("caseTypeId") String caseTypeId, @Param("status") String status, Pageable pageable);
+
+  /**
+   * Fetch only id + data for the visible page (Story 2.3 D4) — keeps the wide JSON column out of
+   * the main list projection while still letting the adapter enrich {@code CaseSummary.fields}.
+   */
+  @Query("SELECT c FROM CaseEntity c WHERE c.id IN :ids")
+  List<CaseEntity> findDataByIds(@Param("ids") Collection<UUID> ids);
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseSummaryProjection.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseSummaryProjection.java
@@ -1,0 +1,24 @@
+package com.wkspower.platform.infrastructure.persistence.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Constructor-projection target for the case-list query. The JSON {@code data} column is omitted by
+ * design (story 2.3 AC7 — never fetched on list path). Field-level projections from {@code
+ * caseType.listColumns} are filled in by the adapter from a follow-up id-list lookup of the
+ * lightweight rows; Phase 0 simplification: the listColumns values are looked up via the JSON path
+ * once we add server-side JSON queries (Phase 1). For Phase 0 the {@code fields} map on the adapter
+ * side is filled by reading the entity's full {@code data} map for visible rows only — but the list
+ * endpoint avoids that via id-bounded fetch (or accepts the trade-off — see Story 2.5).
+ *
+ * <p>For 2.3 we expose a domain {@link com.wkspower.platform.domain.model.CaseSummary} with empty
+ * field projections; Story 2.5 fills the field map via a post-query enrichment step.
+ */
+public record CaseSummaryProjection(
+    UUID id,
+    String caseTypeId,
+    String status,
+    UUID assignee,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/time/SystemClock.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/time/SystemClock.java
@@ -1,0 +1,15 @@
+package com.wkspower.platform.infrastructure.time;
+
+import com.wkspower.platform.domain.port.Clock;
+import java.time.Instant;
+import org.springframework.stereotype.Component;
+
+/** Default {@link Clock} bound to {@link Instant#now()}. */
+@Component
+public class SystemClock implements Clock {
+
+  @Override
+  public Instant now() {
+    return Instant.now();
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/time/package-info.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/time/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Time abstractions. {@link com.wkspower.platform.infrastructure.time.SystemClock} adapts the
+ * domain {@code Clock} port to {@code Instant.now()}; tests can substitute fixed clocks.
+ */
+package com.wkspower.platform.infrastructure.time;

--- a/backend/src/main/java/com/wkspower/platform/security/AdminUserSeeder.java
+++ b/backend/src/main/java/com/wkspower/platform/security/AdminUserSeeder.java
@@ -12,6 +12,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.core.env.Environment;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -73,6 +74,14 @@ public class AdminUserSeeder implements ApplicationRunner {
       log.info("Seeded initial admin user ({}).", creds.email());
     } catch (DataIntegrityViolationException race) {
       log.info("Admin seed raced with a concurrent startup — continuing ({}).", race.getMessage());
+    } catch (ObjectOptimisticLockingFailureException race) {
+      // Pinned debt — Story 1.4 chunk-3 deferred → Story 2.3 Task 9.4. Two concurrent JVMs
+      // racing to seed the same admin row produce an optimistic-locking failure on the
+      // BaseJpaEntity @Version column once both have read-then-written. Treat identically to
+      // the integrity-violation path: at most one row exists by design.
+      log.info(
+          "Admin seed lost an optimistic-lock race with a concurrent startup — continuing ({}).",
+          race.getMessage());
     }
   }
 

--- a/backend/src/main/java/com/wkspower/platform/security/CaseTypePermissionEvaluator.java
+++ b/backend/src/main/java/com/wkspower/platform/security/CaseTypePermissionEvaluator.java
@@ -1,0 +1,49 @@
+package com.wkspower.platform.security;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.port.CaseTypeReader;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Light-weight permission gate for case-type verbs (Story 2.3 AC5). Used from
+ * {@code @PreAuthorize("@caseTypePermissionEvaluator.hasVerb(...)")} on {@code CaseController}.
+ *
+ * <p>Looks up the case type via the {@link CaseTypeReader} port (NOT the registry directly — keeps
+ * the security layer port-only) and checks whether any of the user's roles holds the requested
+ * permission verb. Phase 0 RBAC is role-only — case-level access is Story 5.2.
+ */
+@Component
+public class CaseTypePermissionEvaluator {
+
+  private final CaseTypeReader caseTypeReader;
+
+  public CaseTypePermissionEvaluator(CaseTypeReader caseTypeReader) {
+    this.caseTypeReader = caseTypeReader;
+  }
+
+  /**
+   * @param user authenticated principal
+   * @param caseTypeId case type id from the request body / path
+   * @param verb wire form of the permission (e.g. {@code "create"}, {@code "view"})
+   * @return {@code true} if any of the user's roles holds the verb on this case type. Returns
+   *     {@code false} for null inputs and for unknown case-type ids — the missing-case-type 404 is
+   *     surfaced from the service layer (e.g., {@code CaseService.requireCaseType}) rather than
+   *     thrown from inside SpEL, which Spring Security 6 wraps as 500/403.
+   */
+  public boolean hasVerb(AuthenticatedUser user, String caseTypeId, String verb) {
+    if (user == null || caseTypeId == null || verb == null) {
+      return false;
+    }
+    Optional<CaseTypeConfig> config = caseTypeReader.find(caseTypeId);
+    if (config.isEmpty()) {
+      return false;
+    }
+    return config.get().roles().stream()
+        .filter(r -> user.roles().contains(r.name()))
+        .flatMap(r -> r.permissions().stream())
+        .map(Permission::wire)
+        .anyMatch(verb::equals);
+  }
+}

--- a/backend/src/main/resources/db/migration/common/V202604260001__create_cases_table.sql
+++ b/backend/src/main/resources/db/migration/common/V202604260001__create_cases_table.sql
@@ -1,0 +1,27 @@
+-- Story 2.3 — Case CRUD operations & domain model.
+-- Creates the `cases` table that the Case domain record persists to. The `data` column carries
+-- dynamic case-data fields whose ids come from the case-type YAML schema (Story 2.1) — Hibernate 6
+-- maps it via @JdbcTypeCode(SqlTypes.JSON), which resolves to JSON natively on H2 and to a
+-- starting JSON column on Postgres (later upgraded to JSONB by V202604260002 in postgresql/).
+-- All identifiers lowercase; TIMESTAMP WITH TIME ZONE matches the users / roles convention from
+-- 1.2. No GIN indexes here — server-side JSON queries are Phase 1 (architecture.md §Decision 4).
+
+CREATE TABLE cases (
+    id                  UUID                     PRIMARY KEY,
+    case_type_id        VARCHAR(64)              NOT NULL,
+    case_type_version   INTEGER                  NOT NULL,
+    status              VARCHAR(64)              NOT NULL,
+    assignee            UUID                     REFERENCES users(id) ON DELETE SET NULL,
+    data                JSON                     NOT NULL DEFAULT '{}',
+    process_instance_id VARCHAR(64),
+    created_by          UUID                     NOT NULL REFERENCES users(id),
+    -- created_by FK uses default ON DELETE NO ACTION: blocking user-delete preserves audit trail.
+    version             BIGINT                   NOT NULL DEFAULT 0,
+    created_at          TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at          TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX idx_cases_case_type_id ON cases (case_type_id);
+CREATE INDEX idx_cases_status       ON cases (status);
+CREATE INDEX idx_cases_assignee     ON cases (assignee);
+CREATE INDEX idx_cases_updated_at   ON cases (updated_at DESC);

--- a/backend/src/main/resources/db/migration/postgresql/V202604260002__cases_data_jsonb.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V202604260002__cases_data_jsonb.sql
@@ -1,0 +1,4 @@
+-- Story 2.3 (D6 patch) — upgrade `cases.data` from JSON to JSONB on Postgres only.
+-- Lives in `postgresql/` so the Flyway dialect-segregated layout runs it only under the production
+-- profile (application-production.yml). The H2 profile loads `common/+h2/` and never sees this file.
+ALTER TABLE cases ALTER COLUMN data TYPE JSONB USING data::jsonb;

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
@@ -1,0 +1,282 @@
+package com.wkspower.platform.api.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.GlobalExceptionHandler;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.exception.WksValidationAggregateException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseQuery;
+import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.page.Page;
+import com.wkspower.platform.domain.page.PageRequest;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.CaseService;
+import com.wkspower.platform.security.AuthenticatedUser;
+import com.wkspower.platform.security.CaseTypePermissionEvaluator;
+import com.wkspower.platform.security.JwtAuthenticationFilter;
+import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SecurityConfig;
+import com.wkspower.platform.security.WksUserPrincipal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** Slice test for {@link CaseController}. Covers the four endpoints + the SpEL permission gate. */
+@WebMvcTest(CaseController.class)
+@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@ActiveProfiles("dev")
+class CaseControllerTest {
+
+  private static final UUID ACTOR_ID = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-04-26T10:00:00Z");
+
+  @Autowired MockMvc mockMvc;
+  @Autowired ObjectMapper objectMapper;
+
+  @MockitoBean(name = "wksCaseService")
+  CaseService caseService;
+
+  @MockitoBean(name = "caseTypePermissionEvaluator")
+  CaseTypePermissionEvaluator caseTypePermissionEvaluator;
+
+  @MockitoBean JwtTokenProvider jwtTokenProvider;
+  @MockitoBean UserRepository userRepository;
+
+  // ---- POST /api/cases ---------------------------------------------------
+
+  @Test
+  void postReturns201OnHappyPath() throws Exception {
+    when(caseTypePermissionEvaluator.hasVerb(any(), eq("loan-application"), eq("create")))
+        .thenReturn(true);
+    when(caseService.create(eq("loan-application"), any(), any(), eq(ACTOR_ID)))
+        .thenReturn(sampleCase());
+    when(caseService.requireCaseType(eq("loan-application"))).thenReturn(loanType());
+
+    mockMvc
+        .perform(
+            post("/api/cases")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"caseTypeId\":\"loan-application\",\"data\":{\"name\":\"Asha\"}}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.data.id").exists())
+        .andExpect(jsonPath("$.data.documentCount").value(0))
+        .andExpect(jsonPath("$.data.caseType.displayName").value("Loan Application"));
+  }
+
+  @Test
+  void postReturns403WhenCreateVerbDenied() throws Exception {
+    when(caseTypePermissionEvaluator.hasVerb(any(), anyString(), eq("create"))).thenReturn(false);
+
+    mockMvc
+        .perform(
+            post("/api/cases")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"caseTypeId\":\"loan-application\",\"data\":{}}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void postReturns422OnDataValidationFailure() throws Exception {
+    when(caseTypePermissionEvaluator.hasVerb(any(), anyString(), eq("create"))).thenReturn(true);
+    when(caseService.create(anyString(), any(), any(), any()))
+        .thenThrow(
+            new WksValidationAggregateException(
+                "validation",
+                List.of(ErrorDetail.ofField("WKS-API-001", "must not be blank", "name"))));
+
+    mockMvc
+        .perform(
+            post("/api/cases")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"caseTypeId\":\"loan-application\",\"data\":{}}"))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.error.code").value("WKS-API-002"));
+  }
+
+  // ---- GET /api/cases/{id} -----------------------------------------------
+
+  @Test
+  void getReturns200WithEmbeddedCaseType() throws Exception {
+    Case sample = sampleCase();
+    when(caseService.findById(sample.id())).thenReturn(sample);
+    when(caseService.requireCaseType("loan-application")).thenReturn(loanType());
+    when(caseTypePermissionEvaluator.hasVerb(any(), eq("loan-application"), eq("view")))
+        .thenReturn(true);
+
+    mockMvc
+        .perform(get("/api/cases/" + sample.id()).with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.caseType.id").value("loan-application"))
+        .andExpect(jsonPath("$.data.caseType.statuses[0].id").value("open"));
+  }
+
+  @Test
+  void getReturns404WhenServiceThrows() throws Exception {
+    UUID id = UUID.randomUUID();
+    Case sample = sampleCase(id);
+    when(caseService.findById(id)).thenReturn(sample);
+    when(caseTypePermissionEvaluator.hasVerb(any(), anyString(), eq("view"))).thenReturn(true);
+    when(caseService.requireCaseType(anyString())).thenThrow(new WksNotFoundException("not found"));
+
+    mockMvc
+        .perform(get("/api/cases/" + id).with(officerAuth()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("WKS-API-404"));
+  }
+
+  // ---- GET /api/cases (list) ---------------------------------------------
+
+  @Test
+  void listReturns200WithMeta() throws Exception {
+    when(caseTypePermissionEvaluator.hasVerb(any(), eq("loan-application"), eq("view")))
+        .thenReturn(true);
+    Case s = sampleCase();
+    when(caseService.list(any(CaseQuery.class), any(PageRequest.class)))
+        .thenReturn(
+            new Page<>(
+                List.of(
+                    new CaseSummary(
+                        s.id(),
+                        s.caseTypeId(),
+                        s.status(),
+                        null,
+                        s.createdAt(),
+                        s.updatedAt(),
+                        Map.of())),
+                1,
+                0,
+                20));
+
+    mockMvc
+        .perform(get("/api/cases?caseType=loan-application").with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.length()").value(1))
+        .andExpect(jsonPath("$.meta.total").value(1))
+        .andExpect(jsonPath("$.meta.size").value(20));
+  }
+
+  @Test
+  void listWithoutCaseTypeParamReturns400() throws Exception {
+    mockMvc.perform(get("/api/cases").with(officerAuth())).andExpect(status().isBadRequest());
+  }
+
+  // ---- PUT /api/cases/{id} -----------------------------------------------
+
+  @Test
+  void putReturns200OnHappyPath() throws Exception {
+    Case sample = sampleCase();
+    when(caseService.findById(sample.id())).thenReturn(sample);
+    when(caseService.requireCaseType("loan-application")).thenReturn(loanType());
+    when(caseTypePermissionEvaluator.hasVerb(any(), eq("loan-application"), eq("edit")))
+        .thenReturn(true);
+    when(caseService.update(eq(sample.id()), any(), eq(0L), eq(ACTOR_ID))).thenReturn(sample);
+
+    mockMvc
+        .perform(
+            put("/api/cases/" + sample.id())
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"data\":{\"name\":\"Bob\"},\"version\":0}"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void putReturns409OnVersionMismatch() throws Exception {
+    Case sample = sampleCase();
+    when(caseService.findById(sample.id())).thenReturn(sample);
+    when(caseTypePermissionEvaluator.hasVerb(any(), anyString(), eq("edit"))).thenReturn(true);
+    when(caseService.update(any(), any(), any(Long.class), any()))
+        .thenThrow(new WksConflictException("modified"));
+
+    mockMvc
+        .perform(
+            put("/api/cases/" + sample.id())
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"data\":{\"name\":\"Bob\"},\"version\":99}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.error.code").value("WKS-RTM-409"));
+  }
+
+  // ---- helpers -----------------------------------------------------------
+
+  private static Case sampleCase() {
+    return sampleCase(UUID.randomUUID());
+  }
+
+  private static Case sampleCase(UUID id) {
+    return new Case(
+        id,
+        "loan-application",
+        1,
+        "open",
+        null,
+        Map.of("name", "Asha"),
+        "pi-1",
+        NOW,
+        ACTOR_ID,
+        NOW,
+        0L);
+  }
+
+  private static CaseTypeConfig loanType() {
+    return new CaseTypeConfig(
+        "loan-application",
+        "Loan Application",
+        1,
+        null,
+        new WorkflowRef("loan-application.bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("name"),
+        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))));
+  }
+
+  /** Authenticated post-processor with a valid {@link AuthenticatedUser} principal. */
+  private static org.springframework.test.web.servlet.request.RequestPostProcessor officerAuth() {
+    AuthenticatedUser user = new AuthenticatedUser(ACTOR_ID, "officer@x", Set.of("officer"));
+    WksUserPrincipal principal = new WksUserPrincipal(user);
+    Authentication auth =
+        new UsernamePasswordAuthenticationToken(
+            principal,
+            principal.getPassword(),
+            List.of(new SimpleGrantedAuthority("ROLE_officer")));
+    return authentication(auth);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/architecture/ArchitectureTest.java
+++ b/backend/src/test/java/com/wkspower/platform/architecture/ArchitectureTest.java
@@ -220,6 +220,50 @@ class ArchitectureTest {
   }
 
   @Test
+  void caseDomainHasNoSpringOrJpaImports() {
+    // Story 2.3 AC9 — explicit gate on the new case-domain types. Covered by
+    // domainHasNoFrameworkImports as a blanket; this rule pins it specifically so a regression
+    // surfaces a Story-2.3-attributable failure message.
+    noClasses()
+        .that()
+        .resideInAnyPackage(
+            "..domain.model..",
+            "..domain.service..",
+            "..domain.event..",
+            "..domain.page..",
+            "..domain.exception..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAnyPackage(
+            "org.springframework..",
+            "jakarta.persistence..",
+            "com.fasterxml.jackson.databind..",
+            "com.networknt..",
+            "org.cibseven..")
+        .because(
+            "Case domain (model, service, events, pagination, exceptions) stays framework-free — "
+                + "Story 2.3 AC9. Engine-first ordering and JSON-schema validation live behind"
+                + " ports.")
+        .check(CLASSES);
+  }
+
+  @Test
+  void caseRepositoryImplementationsLiveInInfrastructure() {
+    // Story 2.3 AC9 — defense against a future repository-shaped class showing up in engine/ or
+    // api/. Implementations of CaseRepository must sit in infrastructure/persistence/ only.
+    classes()
+        .that()
+        .implement("com.wkspower.platform.domain.port.CaseRepository")
+        .should()
+        .resideInAPackage("..infrastructure.persistence..")
+        .allowEmptyShould(true)
+        .because(
+            "CaseRepository implementations belong inside infrastructure/persistence/ — Story 2.3"
+                + " AC9.")
+        .check(CLASSES);
+  }
+
+  @Test
   void hexagonalLayering() {
     Architectures.layeredArchitecture()
         .consideringAllDependencies()

--- a/backend/src/test/java/com/wkspower/platform/domain/exception/ErrorCodeTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/exception/ErrorCodeTest.java
@@ -71,6 +71,13 @@ class ErrorCodeTest {
   }
 
   @Test
+  void optimisticLockCodeIsExposed() {
+    // Story 2.3 introduces WKS-RTM-409 for optimistic-lock conflicts on PUT /api/cases/{id}
+    // and any future entity update via BaseJpaEntity.@Version.
+    assertThat(ErrorCode.WKS_RTM_409.wire()).isEqualTo("WKS-RTM-409");
+  }
+
+  @Test
   void multipartUploadCodeIsExposed() {
     // Story 2.2 admin deploy endpoint maps Spring's MaxUploadSizeExceededException to this code.
     assertThat(ErrorCode.WKS_API_413.wire()).isEqualTo("WKS-API-413");

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
@@ -1,0 +1,324 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.event.CaseCreated;
+import com.wkspower.platform.domain.event.CaseUpdated;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.exception.WksValidationAggregateException;
+import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseQuery;
+import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.page.Page;
+import com.wkspower.platform.domain.page.PageRequest;
+import com.wkspower.platform.domain.port.CaseDataValidator;
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.port.CaseTypeReader;
+import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
+import com.wkspower.platform.domain.port.WorkflowEngine;
+import com.wkspower.platform.domain.workflow.DeploymentInfo;
+import com.wkspower.platform.domain.workflow.DeploymentRequest;
+import com.wkspower.platform.domain.workflow.DeploymentResult;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-Java enumeration of {@code CaseService} branches. No Spring context, no engine, no DB —
+ * every collaborator is a hand-rolled stub.
+ */
+class CaseServiceTest {
+
+  private static final UUID ACTOR = UUID.randomUUID();
+  private static final Instant FIXED = Instant.parse("2026-04-26T10:00:00Z");
+
+  private StubRepo repo;
+  private StubValidator validator;
+  private StubEngine engine;
+  private StubPublisher publisher;
+  private StubResolver resolver;
+
+  @BeforeEach
+  void resetStubs() {
+    repo = new StubRepo();
+    validator = new StubValidator();
+    engine = new StubEngine("pi-1", null);
+    publisher = new StubPublisher();
+    resolver = new StubResolver("applicationProcess");
+  }
+
+  private CaseService svc(CaseTypeConfig config) {
+    return new CaseService(
+        repo, reader(config), validator, engine, resolver, publisher, () -> FIXED);
+  }
+
+  @Test
+  void createHappyPathPersistsAndPublishesCaseCreated() {
+    CaseService svc = svc(loanType());
+
+    Case created = svc.create("loan-application", Map.of("name", "Asha"), null, ACTOR);
+
+    assertThat(created.caseTypeId()).isEqualTo("loan-application");
+    assertThat(created.caseTypeVersion()).isEqualTo(1);
+    assertThat(created.status()).isEqualTo("open");
+    assertThat(created.processInstanceId()).isEqualTo("pi-1");
+    assertThat(created.data()).containsEntry("name", "Asha");
+    assertThat(repo.saved).hasSize(1);
+
+    assertThat(publisher.events).hasSize(1);
+    CaseCreated event = (CaseCreated) publisher.events.get(0);
+    assertThat(event.caseId()).isEqualTo(created.id());
+    assertThat(event.actorId()).isEqualTo(ACTOR);
+  }
+
+  @Test
+  void createWithUnknownCaseTypeThrows404() {
+    CaseService svc = svc(loanType());
+
+    assertThatThrownBy(() -> svc.create("no-such-type", Map.of(), null, ACTOR))
+        .isInstanceOf(WksNotFoundException.class);
+  }
+
+  @Test
+  void createWithFailingValidationAggregatesErrors() {
+    validator.queue(
+        List.of(
+            ErrorDetail.ofField("WKS-API-001", "must not be blank", "name"),
+            ErrorDetail.ofField("WKS-API-001", "too long", "notes")));
+    CaseService svc = svc(loanType());
+
+    assertThatThrownBy(() -> svc.create("loan-application", Map.of(), null, ACTOR))
+        .isInstanceOf(WksValidationAggregateException.class)
+        .satisfies(
+            ex -> {
+              WksValidationAggregateException agg = (WksValidationAggregateException) ex;
+              assertThat(agg.getErrors()).hasSize(2);
+            });
+  }
+
+  @Test
+  void createWhenProcessKeyUnknownThrowsEngineException() {
+    resolver = new StubResolver(null);
+    CaseService svc = svc(loanType());
+
+    assertThatThrownBy(() -> svc.create("loan-application", Map.of("name", "x"), null, ACTOR))
+        .isInstanceOf(WksWorkflowEngineException.class);
+  }
+
+  @Test
+  void createWhenEngineFailsPropagates() {
+    engine = new StubEngine(null, new WksWorkflowEngineException("engine down"));
+    CaseService svc = svc(loanType());
+
+    assertThatThrownBy(() -> svc.create("loan-application", Map.of("name", "x"), null, ACTOR))
+        .isInstanceOf(WksWorkflowEngineException.class);
+  }
+
+  @Test
+  void updateHappyPathBumpsVersionAndPublishesCaseUpdated() {
+    CaseTypeConfig loan = loanType();
+    CaseService svc = svc(loan);
+    Case seeded = svc.create("loan-application", Map.of("name", "Asha"), null, ACTOR);
+    publisher.events.clear();
+
+    Case updated =
+        svc.update(seeded.id(), Map.of("name", "Asha", "amount", 250000), seeded.version(), ACTOR);
+
+    assertThat(updated.data()).containsEntry("amount", 250000);
+    assertThat(updated.version()).isGreaterThan(seeded.version());
+    assertThat(publisher.events).hasSize(1);
+    CaseUpdated event = (CaseUpdated) publisher.events.get(0);
+    assertThat(event.changedFieldIds()).contains("amount");
+  }
+
+  @Test
+  void updateWithVersionMismatchThrowsConflict() {
+    CaseService svc = svc(loanType());
+    Case seeded = svc.create("loan-application", Map.of("name", "Asha"), null, ACTOR);
+
+    assertThatThrownBy(
+            () -> svc.update(seeded.id(), Map.of("name", "Bob"), seeded.version() + 99, ACTOR))
+        .isInstanceOf(WksConflictException.class);
+  }
+
+  @Test
+  void updateWhenCaseMissingThrows404() {
+    CaseService svc = svc(loanType());
+
+    assertThatThrownBy(() -> svc.update(UUID.randomUUID(), Map.of(), 0L, ACTOR))
+        .isInstanceOf(WksNotFoundException.class);
+  }
+
+  @Test
+  void updateWithFailingValidationAggregates() {
+    CaseService svc = svc(loanType());
+    Case seeded = svc.create("loan-application", Map.of("name", "Asha"), null, ACTOR);
+
+    validator.queue(List.of(ErrorDetail.ofField("WKS-API-001", "bad value", "name")));
+
+    assertThatThrownBy(() -> svc.update(seeded.id(), Map.of("name", ""), seeded.version(), ACTOR))
+        .isInstanceOf(WksValidationAggregateException.class);
+  }
+
+  @Test
+  void diffFieldIdsHandlesAddedRemovedAndChanged() {
+    Map<String, Object> oldMap = Map.of("a", 1, "b", "two");
+    Map<String, Object> newMap = Map.of("a", 1, "b", "TWO", "c", true);
+
+    var changed = CaseService.diffFieldIds(oldMap, newMap);
+
+    assertThat(changed).contains("b", "c");
+    assertThat(changed).doesNotContain("a");
+  }
+
+  // ---- helpers -----------------------------------------------------------
+
+  private static CaseTypeConfig loanType() {
+    return new CaseTypeConfig(
+        "loan-application",
+        "Loan Application",
+        1,
+        null,
+        new WorkflowRef("loan-application.bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("name"),
+        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))));
+  }
+
+  private static CaseTypeReader reader(CaseTypeConfig config) {
+    return new CaseTypeReader() {
+      @Override
+      public Optional<CaseTypeConfig> find(String id) {
+        return id.equals(config.id()) ? Optional.of(config) : Optional.empty();
+      }
+
+      @Override
+      public Collection<CaseTypeConfig> all() {
+        return List.of(config);
+      }
+    };
+  }
+
+  private static final class StubRepo implements CaseRepository {
+    final List<Case> saved = new ArrayList<>();
+
+    @Override
+    public Case save(Case caseToSave) {
+      saved.removeIf(c -> c.id().equals(caseToSave.id()));
+      Case bumped =
+          new Case(
+              caseToSave.id(),
+              caseToSave.caseTypeId(),
+              caseToSave.caseTypeVersion(),
+              caseToSave.status(),
+              caseToSave.assignee(),
+              caseToSave.data(),
+              caseToSave.processInstanceId(),
+              caseToSave.createdAt(),
+              caseToSave.createdBy(),
+              caseToSave.updatedAt(),
+              caseToSave.version() + 1);
+      saved.add(bumped);
+      return bumped;
+    }
+
+    @Override
+    public Optional<Case> findById(UUID id) {
+      return saved.stream().filter(c -> c.id().equals(id)).findFirst();
+    }
+
+    @Override
+    public Page<CaseSummary> findByCaseType(CaseQuery query, PageRequest pageRequest) {
+      return new Page<>(List.of(), 0, pageRequest.page(), pageRequest.size());
+    }
+
+    @Override
+    public Map<UUID, Map<String, Object>> findDataByIds(
+        java.util.Collection<UUID> ids, java.util.Set<String> projectedFieldIds) {
+      return Map.of();
+    }
+  }
+
+  private static final class StubValidator implements CaseDataValidator {
+    private List<ErrorDetail> next = List.of();
+
+    void queue(List<ErrorDetail> errors) {
+      this.next = errors;
+    }
+
+    @Override
+    public List<ErrorDetail> validate(CaseTypeConfig caseType, Map<String, Object> data) {
+      List<ErrorDetail> r = next;
+      next = List.of();
+      return r;
+    }
+  }
+
+  private static final class StubEngine implements WorkflowEngine {
+    private final String returnedPi;
+    private final RuntimeException failure;
+
+    StubEngine(String returnedPi, RuntimeException failure) {
+      this.returnedPi = returnedPi;
+      this.failure = failure;
+    }
+
+    @Override
+    public DeploymentResult deploy(DeploymentRequest request) {
+      return new DeploymentResult("d", request.processDefinitionKey(), "p", 1, FIXED);
+    }
+
+    @Override
+    public Optional<DeploymentInfo> latestDeployment(String key) {
+      return Optional.empty();
+    }
+
+    @Override
+    public String startProcessInstance(String key, Map<String, Object> variables) {
+      if (failure != null) throw failure;
+      return returnedPi;
+    }
+  }
+
+  private static final class StubPublisher implements EventPublisher {
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public void publish(Object event) {
+      events.add(event);
+    }
+  }
+
+  private static final class StubResolver implements ProcessDefinitionKeyResolver {
+    private final String key;
+
+    StubResolver(String key) {
+      this.key = key;
+    }
+
+    @Override
+    public Optional<String> resolve(String caseTypeId) {
+      return Optional.ofNullable(key);
+    }
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
@@ -335,6 +335,12 @@ class ConfigServiceDeployTest {
     public Optional<DeploymentInfo> latestDeployment(String key) {
       return Optional.empty();
     }
+
+    @Override
+    public String startProcessInstance(
+        String processDefinitionKey, java.util.Map<String, Object> variables) {
+      throw new UnsupportedOperationException("not exercised by ConfigServiceDeployTest");
+    }
   }
 
   private static final class RecordingPublisher implements EventPublisher {

--- a/backend/src/test/java/com/wkspower/platform/engine/CibSevenWorkflowEngineIT.java
+++ b/backend/src/test/java/com/wkspower/platform/engine/CibSevenWorkflowEngineIT.java
@@ -1,7 +1,9 @@
 package com.wkspower.platform.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
 import com.wkspower.platform.domain.port.WorkflowEngine;
 import com.wkspower.platform.domain.workflow.DeploymentInfo;
 import com.wkspower.platform.domain.workflow.DeploymentRequest;
@@ -10,7 +12,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import javax.sql.DataSource;
 import org.cibseven.bpm.engine.ProcessEngine;
 import org.junit.jupiter.api.Test;
@@ -120,6 +124,33 @@ class CibSevenWorkflowEngineIT {
                 + "(local %d ms, CI %d ms)",
             SLA_MS_LOCAL, SLA_MS_CI)
         .isLessThan(ceiling);
+  }
+
+  @Test
+  void startProcessInstanceReturnsEngineProcessInstanceId() {
+    byte[] bpmn = simpleBpmn("start-process").getBytes(StandardCharsets.UTF_8);
+    workflowEngine.deploy(
+        new DeploymentRequest("start-test", "start-process", bpmn, "start-process", 1));
+
+    String pi =
+        workflowEngine.startProcessInstance(
+            "start-process", Map.of("caseId", UUID.randomUUID().toString()));
+
+    assertThat(pi)
+        .as("Story 2.3 AC4: startProcessInstance returns a non-blank engine-assigned id")
+        .isNotBlank();
+  }
+
+  @Test
+  void startProcessInstanceWithUnknownKeyWrapsEngineException() {
+    assertThatThrownBy(
+            () ->
+                workflowEngine.startProcessInstance(
+                    "process-that-does-not-exist", Map.of("caseId", UUID.randomUUID().toString())))
+        .as(
+            "Story 2.3 AC4: ProcessEngineException for unknown key wraps to"
+                + " WksWorkflowEngineException")
+        .isInstanceOf(WksWorkflowEngineException.class);
   }
 
   /** Minimal BPMN 2.0 fixture used by every test in this class. */

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoaderTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoaderTest.java
@@ -119,6 +119,11 @@ class CaseTypeStartupLoaderTest {
           public Optional<DeploymentInfo> latestDeployment(String key) {
             return Optional.empty();
           }
+
+          @Override
+          public String startProcessInstance(String key, java.util.Map<String, Object> variables) {
+            return "pi-noop";
+          }
         },
         event -> {});
   }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/CaseRepositoryIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/CaseRepositoryIT.java
@@ -1,0 +1,155 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseQuery;
+import com.wkspower.platform.domain.page.Page;
+import com.wkspower.platform.domain.page.PageRequest;
+import com.wkspower.platform.domain.page.SortOrder;
+import com.wkspower.platform.infrastructure.persistence.entity.RoleEntity;
+import com.wkspower.platform.infrastructure.persistence.entity.UserEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseEntityRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.RoleEntityRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.UserEntityRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * {@code @DataJpaTest} IT for {@link CaseRepositoryAdapter}. Exercises the JSON column round-trip,
+ * the JPQL constructor projection (no JSON fetch on list), and optimistic-locking conflict
+ * surfacing as {@link com.wkspower.platform.domain.exception.WksConflictException}.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(CaseRepositoryAdapter.class)
+@ActiveProfiles("dev")
+class CaseRepositoryIT {
+
+  @Autowired CaseRepositoryAdapter adapter;
+  @Autowired CaseEntityRepository caseRepo;
+  @Autowired UserEntityRepository userRepo;
+  @Autowired RoleEntityRepository roleRepo;
+  @Autowired EntityManager em;
+
+  private UUID actorId;
+
+  @BeforeEach
+  void seedUser() {
+    RoleEntity role =
+        roleRepo
+            .findByName("admin")
+            .orElseGet(
+                () ->
+                    roleRepo.save(
+                        new RoleEntity(UUID.randomUUID(), "admin", Instant.now(), Instant.now())));
+    UserEntity user =
+        userRepo.save(
+            new UserEntity(
+                UUID.randomUUID(),
+                "ops-" + UUID.randomUUID() + "@x",
+                "x",
+                true,
+                Instant.now(),
+                Instant.now(),
+                new HashSet<>(List.of(role))));
+    actorId = user.getId();
+  }
+
+  @Test
+  void saveAndFindByIdRoundTripsJsonData() {
+    Map<String, Object> data =
+        Map.of(
+            "applicant",
+            Map.of("name", "Asha", "age", 32),
+            "tags",
+            List.of("priority", "first-time"));
+    Case toSave = newCase(data);
+
+    Case saved = adapter.save(toSave);
+    em.flush();
+    em.clear();
+
+    Case reloaded = adapter.findById(saved.id()).orElseThrow();
+
+    assertThat(reloaded.id()).isEqualTo(saved.id());
+    assertThat(reloaded.data()).containsEntry("applicant", Map.of("name", "Asha", "age", 32));
+    assertThat(reloaded.data().get("tags")).asList().containsExactly("priority", "first-time");
+    assertThat(reloaded.version()).isGreaterThanOrEqualTo(0L);
+  }
+
+  @Test
+  void saveAndUpdateBumpsVersion() {
+    Case saved = adapter.save(newCase(Map.of("name", "Asha")));
+    em.flush();
+    em.clear();
+
+    Case fresh = adapter.findById(saved.id()).orElseThrow();
+    Case updated =
+        new Case(
+            fresh.id(),
+            fresh.caseTypeId(),
+            fresh.caseTypeVersion(),
+            fresh.status(),
+            fresh.assignee(),
+            Map.of("name", "Bob"),
+            fresh.processInstanceId(),
+            fresh.createdAt(),
+            fresh.createdBy(),
+            Instant.now(),
+            fresh.version());
+    Case persisted = adapter.save(updated);
+    em.flush();
+    em.clear();
+
+    Case reloaded = adapter.findById(persisted.id()).orElseThrow();
+    assertThat(reloaded.data()).containsEntry("name", "Bob");
+    assertThat(reloaded.version()).isGreaterThan(saved.version());
+  }
+
+  @Test
+  void findByCaseTypeReturnsSummariesWithoutFetchingJsonData() {
+    adapter.save(newCase(Map.of("name", "A")));
+    adapter.save(newCase(Map.of("name", "B")));
+    em.flush();
+    em.clear();
+
+    Page<?> page =
+        adapter.findByCaseType(
+            CaseQuery.of("loan-application"),
+            PageRequest.of(0, 20, List.of(new SortOrder("updatedAt", false))));
+
+    assertThat(page.content()).hasSize(2);
+    assertThat(page.total()).isEqualTo(2);
+    // Summaries carry empty `fields` projections in 2.3 — Story 2.5 enriches.
+    assertThat(((com.wkspower.platform.domain.model.CaseSummary) page.content().get(0)).fields())
+        .isEmpty();
+  }
+
+  private Case newCase(Map<String, Object> data) {
+    Instant now = Instant.now();
+    return new Case(
+        UUID.randomUUID(),
+        "loan-application",
+        1,
+        "open",
+        null,
+        data,
+        "pi-" + UUID.randomUUID(),
+        now,
+        actorId,
+        now,
+        0L);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/CaseRepositoryPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/CaseRepositoryPostgresIT.java
@@ -1,0 +1,119 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.port.CaseRepository;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Story 2.3 D5a — Postgres-backed integration test for {@link CaseRepository}.
+ *
+ * <p>Proves the JSONB upgrade migration in {@code db/migration/postgresql/V202604260002} applies
+ * cleanly on a real Postgres, that the {@code data} column is JSONB (not JSON) post-migration, and
+ * that {@code save → findById → findDataByIds} round-trips a case through the real schema with the
+ * dynamic JSON map intact.
+ *
+ * <p>Skipped automatically when Docker is unavailable.
+ */
+@SpringBootTest
+@ActiveProfiles("production")
+@Testcontainers(disabledWithoutDocker = true)
+class CaseRepositoryPostgresIT {
+
+  @Container
+  @SuppressWarnings("resource")
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("wks")
+          .withUsername("wks")
+          .withPassword("wks");
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("WKS_DB_URL", POSTGRES::getJdbcUrl);
+    registry.add("WKS_DB_USER", POSTGRES::getUsername);
+    registry.add("WKS_DB_PASSWORD", POSTGRES::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    registry.add("WKS_ADMIN_EMAIL", () -> "admin@wkspower.local");
+    registry.add("WKS_ADMIN_PASSWORD", () -> "admin");
+    registry.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+    registry.add("WKS_CORS_ORIGINS", () -> "http://localhost:5173");
+  }
+
+  @Autowired private CaseRepository cases;
+  @Autowired private DataSource dataSource;
+
+  @Test
+  void dataColumnIsJsonbAfterPostgresqlMigration() throws Exception {
+    try (var conn = dataSource.getConnection();
+        var stmt = conn.createStatement();
+        var rs =
+            stmt.executeQuery(
+                "SELECT data_type FROM information_schema.columns "
+                    + "WHERE table_name = 'cases' AND column_name = 'data'")) {
+      assertThat(rs.next()).as("cases.data column should exist").isTrue();
+      assertThat(rs.getString(1).toLowerCase())
+          .as("V202604260002 must upgrade cases.data from JSON to JSONB on Postgres")
+          .isEqualTo("jsonb");
+    }
+  }
+
+  @Test
+  void roundTripCasePreservesJsonData() {
+    UUID actorId = bootstrapAdminId();
+    UUID caseId = UUID.randomUUID();
+    Instant now = Instant.now();
+    Map<String, Object> data =
+        Map.of(
+            "applicant_name",
+            "Alice",
+            "amount",
+            12345,
+            "metadata",
+            Map.of("channel", "web", "tags", java.util.List.of("priority", "vip")));
+    Case toSave =
+        new Case(caseId, "loan-application", 1, "open", null, data, "pi-1", now, actorId, now, 0L);
+
+    Case saved = cases.save(toSave);
+    assertThat(saved.id()).isEqualTo(caseId);
+
+    assertThat(cases.findById(caseId))
+        .hasValueSatisfying(
+            found -> {
+              assertThat(found.data()).containsEntry("applicant_name", "Alice");
+              assertThat(found.data()).containsEntry("amount", 12345);
+              assertThat(found.data().get("metadata")).isInstanceOf(Map.class);
+            });
+
+    Map<UUID, Map<String, Object>> projected =
+        cases.findDataByIds(java.util.List.of(caseId), Set.of("applicant_name", "amount"));
+    assertThat(projected).containsKey(caseId);
+    assertThat(projected.get(caseId)).containsOnlyKeys("applicant_name", "amount");
+  }
+
+  /** Read the seeded admin user id directly so we satisfy the {@code created_by} FK. */
+  private UUID bootstrapAdminId() {
+    try (var conn = dataSource.getConnection();
+        var stmt = conn.createStatement();
+        var rs = stmt.executeQuery("SELECT id FROM users LIMIT 1")) {
+      assertThat(rs.next()).as("at least one user should exist for the FK").isTrue();
+      return UUID.fromString(rs.getString(1));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/entity/BaseJpaEntityIdentityTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/entity/BaseJpaEntityIdentityTest.java
@@ -1,0 +1,93 @@
+package com.wkspower.platform.infrastructure.persistence.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Identity contract for {@link BaseJpaEntity} (AC3, pinned debt from Epic 1 retro action #5 + Story
+ * 1.4 chunk-3 deferred). Pure unit — no Spring, no database. The integration side of the same
+ * contract (Set membership across persist + reload) lives in {@link
+ * com.wkspower.platform.infrastructure.persistence.UserRepositoryPostgresIT}-class repository
+ * tests.
+ */
+class BaseJpaEntityIdentityTest {
+
+  @Test
+  @DisplayName("two transient instances are never equal")
+  void twoTransientInstancesNotEqual() {
+    RoleEntity a = new RoleEntity(null, "ADMIN");
+    RoleEntity b = new RoleEntity(null, "ADMIN");
+
+    assertThat(a).isNotEqualTo(b);
+    assertThat(b).isNotEqualTo(a);
+  }
+
+  @Test
+  @DisplayName("two managed instances with the same id are equal across contexts")
+  void twoManagedInstancesWithSameIdAreEqual() {
+    UUID shared = UUID.randomUUID();
+    RoleEntity a = new RoleEntity(shared, "ADMIN");
+    RoleEntity b = new RoleEntity(shared, "ADMIN");
+
+    assertThat(a).isEqualTo(b);
+    assertThat(b).isEqualTo(a);
+  }
+
+  @Test
+  @DisplayName("transient → managed transition keeps the same hashCode")
+  void hashCodeIsStableAcrossTransientToManagedTransition() {
+    RoleEntity role = new RoleEntity(null, "ADMIN");
+    int beforePersist = role.hashCode();
+
+    // Simulate Hibernate's flush: id is now assigned by the persistence context.
+    role.setId(UUID.randomUUID());
+
+    int afterPersist = role.hashCode();
+    assertThat(afterPersist).isEqualTo(beforePersist);
+  }
+
+  @Test
+  @DisplayName("Set membership: same managed entity reloaded does not duplicate")
+  void setContainsManagedEntityAfterReload() {
+    UUID id = UUID.randomUUID();
+    RoleEntity firstLoad = new RoleEntity(id, "ADMIN");
+    RoleEntity reloaded = new RoleEntity(id, "ADMIN");
+
+    Set<RoleEntity> roles = new HashSet<>();
+    roles.add(firstLoad);
+
+    assertThat(roles).contains(reloaded);
+    roles.add(reloaded);
+    assertThat(roles).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("different concrete entity classes with the same id are not equal")
+  void differentClassesNotEqualEvenWithSameId() {
+    UUID shared = UUID.randomUUID();
+    RoleEntity role = new RoleEntity(shared, "ADMIN");
+    UserEntity user = new UserEntity(shared, "a@b.c", "x", true, null, null, new HashSet<>());
+
+    assertThat(role).isNotEqualTo(user);
+    assertThat(user).isNotEqualTo(role);
+  }
+
+  @Test
+  @DisplayName("equals against null is false")
+  void equalsAgainstNullIsFalse() {
+    RoleEntity role = new RoleEntity(UUID.randomUUID(), "ADMIN");
+    assertThat(role).isNotEqualTo(null);
+  }
+
+  @Test
+  @DisplayName("equals against unrelated type is false")
+  void equalsAgainstUnrelatedTypeIsFalse() {
+    RoleEntity role = new RoleEntity(UUID.randomUUID(), "ADMIN");
+    assertThat(role).isNotEqualTo("ADMIN");
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseAuthIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseAuthIT.java
@@ -63,7 +63,7 @@ import org.springframework.test.context.TestPropertySource;
 class CaseAuthIT {
 
   private static final String EMAIL = "auth-it-admin@wkspower.local";
-  private static final String PASSWORD = "pw-auth-it";
+  private static final String PASSWORD = "admin";
   private static final String CASE_TYPE_ID = "loan-application";
 
   @Autowired private TestRestTemplate rest;

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseAuthIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseAuthIT.java
@@ -1,0 +1,145 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Story 2.3 D5c — real-JWT integration coverage. Closes the Story 2.2 deferred entry "JWT
+ * role-prefix integration coverage" by exercising the full filter chain ({@code
+ * JwtAuthenticationFilter} → {@code WksUserPrincipal} → {@code CaseTypePermissionEvaluator})
+ * end-to-end with a real session cookie.
+ *
+ * <p>Pinned scenarios:
+ *
+ * <ul>
+ *   <li>Anonymous request → 401 with {@code WKS-API-401}.
+ *   <li>Authenticated user with the {@code admin} role + matching YAML grant → 200 (the {@code
+ *       ROLE_OFFICER}/case-folding bridge from Story 1.2 is exercised: filter stamps {@code
+ *       ROLE_ADMIN}, evaluator matches against the lowercase {@code admin} YAML role name).
+ *   <li>Authenticated user requesting an unknown case type → 403 (per code-review P4: the evaluator
+ *       returns false for missing case-types rather than throwing from the gate).
+ * </ul>
+ *
+ * <p>Multi-role-distinction scenarios (e.g. viewer-can't-create) are deferred until the seed
+ * exposes a non-admin role; the slice-level {@code CaseTypePermissionEvaluatorTest} covers that
+ * branch in unit form today.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:caseauth;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ="
+    })
+class CaseAuthIT {
+
+  private static final String EMAIL = "auth-it-admin@wkspower.local";
+  private static final String PASSWORD = "pw-auth-it";
+  private static final String CASE_TYPE_ID = "loan-application";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+
+  @BeforeEach
+  void setup() {
+    if (users.findByEmail(EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+    registry.register(loanType());
+  }
+
+  @Test
+  void anonymousRequestReturns401WithWksCode() {
+    ResponseEntity<String> resp =
+        rest.exchange(
+            "/api/cases?caseType=" + CASE_TYPE_ID,
+            HttpMethod.GET,
+            new HttpEntity<>(new HttpHeaders()),
+            String.class);
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(resp.getBody()).contains("WKS-API-401");
+  }
+
+  @Test
+  void authenticatedAdminWithGrantingYamlRolePasses() {
+    String cookie = login(EMAIL);
+
+    ResponseEntity<String> resp =
+        exchange("/api/cases?caseType=" + CASE_TYPE_ID, HttpMethod.GET, cookie);
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void authenticatedRequestForUnknownCaseTypeReturnsForbidden() {
+    String cookie = login(EMAIL);
+
+    // Per code-review P4: the evaluator returns false for missing case-types — the gate fires
+    // before the service can 404, so callers see 403. Pin that contract here.
+    ResponseEntity<String> resp =
+        exchange("/api/cases?caseType=does-not-exist", HttpMethod.GET, cookie);
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  private String login(String email) {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(email, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", email).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private ResponseEntity<String> exchange(String path, HttpMethod method, String cookie) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(headers), String.class);
+  }
+
+  private static CaseTypeConfig loanType() {
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Loan Application",
+        1,
+        null,
+        new WorkflowRef(CASE_TYPE_ID + ".bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("name"),
+        List.of(new RoleDefinition("admin", List.of(Permission.VIEW, Permission.CREATE))));
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
@@ -54,7 +54,7 @@ class CaseFlowIT {
   // Uses the seeded `admin` role (V202604170001) — the only role that exists out of the box. The
   // case-type below grants admin every verb so the full happy + conflict paths can run end-to-end.
   private static final String EMAIL = "caseflow-admin@wkspower.local";
-  private static final String PASSWORD = "caseflow-pw";
+  private static final String PASSWORD = "admin";
   private static final String CASE_TYPE_ID = "loan-application";
   private static final String PROCESS_KEY = "loan-application-flow";
 

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
@@ -1,0 +1,205 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.event.ConfigDeployed;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.cibseven.bpm.engine.RepositoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * Story 2.3 D5b — end-to-end case flow over HTTP. Boots the full Spring context, registers a
+ * loan-application case type + deploys a minimal BPMN through the engine, then drives {@code POST →
+ * GET → PUT} (happy path) and a second {@code PUT} that races on the optimistic-lock version (409).
+ * Uses cookie-session auth so the real {@code @AuthenticationPrincipal +
+ * CaseTypePermissionEvaluator} chain runs end-to-end.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class CaseFlowIT {
+
+  // Uses the seeded `admin` role (V202604170001) — the only role that exists out of the box. The
+  // case-type below grants admin every verb so the full happy + conflict paths can run end-to-end.
+  private static final String EMAIL = "caseflow-admin@wkspower.local";
+  private static final String PASSWORD = "caseflow-pw";
+  private static final String CASE_TYPE_ID = "loan-application";
+  private static final String PROCESS_KEY = "loan-application-flow";
+
+  @TempDir static java.nio.file.Path dbDir;
+
+  @DynamicPropertySource
+  static void props(DynamicPropertyRegistry reg) {
+    // File-mode H2 mirrors CibSevenWorkflowEngineIT — engine BLOB columns dislike in-memory H2.
+    reg.add(
+        "spring.datasource.url",
+        () -> "jdbc:h2:file:" + dbDir.resolve("caseflow-it") + ";DB_CLOSE_DELAY=-1");
+    reg.add("wks.case-types.dir", () -> "");
+    reg.add("camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+    reg.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+  }
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private RepositoryService repositoryService;
+  @Autowired private ApplicationEventPublisher events;
+  @Autowired private ObjectMapper json;
+
+  @BeforeEach
+  void setup() {
+    if (users.findByEmail(EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+    registry.register(loanType());
+    org.cibseven.bpm.engine.repository.Deployment deployment =
+        repositoryService
+            .createDeployment()
+            .name("flow-it-" + PROCESS_KEY)
+            .addInputStream(
+                PROCESS_KEY + ".bpmn",
+                new java.io.ByteArrayInputStream(
+                    simpleBpmn(PROCESS_KEY).getBytes(StandardCharsets.UTF_8)))
+            .deploy();
+    String processDefinitionId =
+        repositoryService
+            .createProcessDefinitionQuery()
+            .deploymentId(deployment.getId())
+            .singleResult()
+            .getId();
+    events.publishEvent(
+        new ConfigDeployed(
+            CASE_TYPE_ID,
+            1,
+            deployment.getId(),
+            PROCESS_KEY,
+            processDefinitionId,
+            null,
+            Instant.now()));
+  }
+
+  @Test
+  void postGetPutFlowRoundTripsThroughEngineAndRepository() throws Exception {
+    String cookie = login();
+
+    // POST → 201 with id
+    ResponseEntity<String> created =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"name\":\"Alice\"}}");
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    JsonNode body = json.readTree(created.getBody());
+    String id = body.path("data").path("id").asText();
+    assertThat(id).isNotEmpty();
+    assertThat(body.path("data").path("processInstanceId").asText()).isNotEmpty();
+
+    // GET → 200, version starts at 1 after JPA bumps from 0 on insert
+    ResponseEntity<String> got = exchange("/api/cases/" + id, HttpMethod.GET, cookie, null);
+    assertThat(got.getStatusCode()).isEqualTo(HttpStatus.OK);
+    long version = json.readTree(got.getBody()).path("data").path("version").asLong();
+    assertThat(version).isGreaterThanOrEqualTo(0L);
+
+    // PUT → 200 happy path
+    ResponseEntity<String> updated =
+        exchange(
+            "/api/cases/" + id,
+            HttpMethod.PUT,
+            cookie,
+            "{\"data\":{\"name\":\"Bob\"},\"version\":" + version + "}");
+    assertThat(updated.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    // Second PUT with the now-stale version → 409 WKS-RTM-409 (optimistic-lock)
+    ResponseEntity<String> conflict =
+        exchange(
+            "/api/cases/" + id,
+            HttpMethod.PUT,
+            cookie,
+            "{\"data\":{\"name\":\"Carol\"},\"version\":" + version + "}");
+    assertThat(conflict.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(conflict.getBody()).contains("WKS-RTM-409");
+  }
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(EMAIL, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).isNotNull();
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  private static CaseTypeConfig loanType() {
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Loan Application",
+        1,
+        null,
+        new WorkflowRef(PROCESS_KEY + ".bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("name"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.VIEW, Permission.CREATE, Permission.EDIT))));
+  }
+
+  private static String simpleBpmn(String key) {
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<bpmn:definitions xmlns:bpmn=\"http://www.omg.org/spec/BPMN/20100524/MODEL\""
+        + " xmlns:camunda=\"http://camunda.org/schema/1.0/bpmn\""
+        + " targetNamespace=\"http://wkspower.com/bpmn/test\">"
+        + "<bpmn:process id=\""
+        + key
+        + "\" isExecutable=\"true\" camunda:historyTimeToLive=\"30\">"
+        + "<bpmn:startEvent id=\"start\"/>"
+        + "<bpmn:endEvent id=\"end\"/>"
+        + "<bpmn:sequenceFlow id=\"f1\" sourceRef=\"start\" targetRef=\"end\"/>"
+        + "</bpmn:process>"
+        + "</bpmn:definitions>";
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/OpenApiDisabledInProductionIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/OpenApiDisabledInProductionIT.java
@@ -29,6 +29,10 @@ import org.springframework.test.context.TestPropertySource;
       "WKS_DB_PASSWORD=",
       "spring.datasource.driver-class-name=org.h2.Driver",
       "spring.jpa.hibernate.ddl-auto=validate",
+      // Override Flyway locations: production profile defaults to common/+postgresql/, but this
+      // test boots production with an H2 datasource. postgresql/ migrations (V202604260002 JSONB
+      // upgrade) are not H2-compatible, so we narrow to common/+h2/ here.
+      "spring.flyway.locations=classpath:db/migration/common,classpath:db/migration/h2",
       "WKS_CORS_ORIGINS=http://localhost:5173",
       "WKS_ADMIN_EMAIL=admin@wkspower.local",
       "WKS_ADMIN_PASSWORD=admin-test-only",

--- a/backend/src/test/java/com/wkspower/platform/security/CaseTypePermissionEvaluatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/security/CaseTypePermissionEvaluatorTest.java
@@ -1,0 +1,97 @@
+package com.wkspower.platform.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.port.CaseTypeReader;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class CaseTypePermissionEvaluatorTest {
+
+  private static final AuthenticatedUser OFFICER =
+      new AuthenticatedUser(UUID.randomUUID(), "officer@x", Set.of("officer"));
+  private static final AuthenticatedUser CUSTOMER =
+      new AuthenticatedUser(UUID.randomUUID(), "customer@x", Set.of("customer"));
+
+  @Test
+  void hasVerbReturnsTrueWhenRoleHoldsTheVerb() {
+    CaseTypePermissionEvaluator eval = new CaseTypePermissionEvaluator(reader(loanType()));
+
+    assertThat(eval.hasVerb(OFFICER, "loan-application", "create")).isTrue();
+    assertThat(eval.hasVerb(OFFICER, "loan-application", "view")).isTrue();
+  }
+
+  @Test
+  void hasVerbReturnsFalseWhenUserRoleLacksTheVerb() {
+    CaseTypePermissionEvaluator eval = new CaseTypePermissionEvaluator(reader(loanType()));
+
+    assertThat(eval.hasVerb(CUSTOMER, "loan-application", "create")).isFalse();
+  }
+
+  @Test
+  void hasVerbReturnsFalseWhenUserHasNoMatchingRole() {
+    CaseTypePermissionEvaluator eval = new CaseTypePermissionEvaluator(reader(loanType()));
+    AuthenticatedUser stranger = new AuthenticatedUser(UUID.randomUUID(), "x@x", Set.of("auditor"));
+
+    assertThat(eval.hasVerb(stranger, "loan-application", "view")).isFalse();
+  }
+
+  @Test
+  void hasVerbReturnsFalseWhenCaseTypeIsUnknown() {
+    // Per code-review P4: throwing from inside @PreAuthorize SpEL gets wrapped to 500/403 by
+    // Spring Security 6 — instead, return false here and let the service path produce the 404.
+    CaseTypePermissionEvaluator eval = new CaseTypePermissionEvaluator(reader(loanType()));
+
+    assertThat(eval.hasVerb(OFFICER, "no-such-type", "view")).isFalse();
+  }
+
+  @Test
+  void nullInputsReturnFalse() {
+    CaseTypePermissionEvaluator eval = new CaseTypePermissionEvaluator(reader(loanType()));
+
+    assertThat(eval.hasVerb(null, "loan-application", "view")).isFalse();
+    assertThat(eval.hasVerb(OFFICER, null, "view")).isFalse();
+    assertThat(eval.hasVerb(OFFICER, "loan-application", null)).isFalse();
+  }
+
+  private static CaseTypeConfig loanType() {
+    return new CaseTypeConfig(
+        "loan-application",
+        "Loan Application",
+        1,
+        null,
+        new WorkflowRef("loan-application.bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("name"),
+        List.of(
+            new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE)),
+            new RoleDefinition("customer", List.of(Permission.VIEW))));
+  }
+
+  private static CaseTypeReader reader(CaseTypeConfig config) {
+    return new CaseTypeReader() {
+      @Override
+      public Optional<CaseTypeConfig> find(String id) {
+        return id.equals(config.id()) ? Optional.of(config) : Optional.empty();
+      }
+
+      @Override
+      public Collection<CaseTypeConfig> all() {
+        return List.of(config);
+      }
+    };
+  }
+}

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -89,6 +89,7 @@ return PageMetaBuilder.paged(page, MyMapper::toDto);
 | `WKS-API-404` | 404  | Resource not found                                                       |
 | `WKS-API-413` | 413  | Multipart upload exceeds the 1 MB per-part / 2 MB per-request cap        |
 | `WKS-CFG-000` | 422  | Multi-error config aggregate (umbrella for `WksConfigException`)         |
+| `WKS-RTM-409` | 409  | Optimistic-locking conflict (case update raced with another transaction) |
 | `WKS-RTM-500` | 500  | Uncaught exception                                                       |
 
 Codes are defined once in `domain/exception/ErrorCode.java`. Wire strings are part of the public
@@ -135,6 +136,29 @@ until a real validator failure mode needs a stable code.
 > **Variance from `architecture.md` §Decision 14.** That table allocates `WKS-CFG-100..199` to
 > BPMN validation. Story 2.2 follows the epic AC's `010..099` band so all "deploy-time validation"
 > codes stay contiguous below 100. Architecture doc gets a follow-up patch.
+
+## Case CRUD endpoints (Story 2.3)
+
+The case-lifecycle surface is rooted at `/api/cases`:
+
+| Method | Path                | Verb gate (per case-type YAML) | Wire success                                          |
+| ------ | ------------------- | ------------------------------ | ----------------------------------------------------- |
+| `POST` | `/api/cases`        | `create`                       | `201 ApiResponse<CaseDto>`                            |
+| `GET`  | `/api/cases/{id}`   | `view`                         | `200 ApiResponse<CaseDto>` (with embedded `caseType`) |
+| `GET`  | `/api/cases`        | `view`                         | `200 ApiResponse<List<CaseSummaryDto>>` + meta        |
+| `PUT`  | `/api/cases/{id}`   | `view` (Phase 0 simplification — `edit` arrives in Story 5.2) | `200 ApiResponse<CaseDto>` |
+
+`POST` request body: `{ "caseTypeId": "...", "data": { ... }, "assignee": "uuid|null" }`.
+`PUT` request body: `{ "data": { ... }, "version": <expected version> }` — version mismatch surfaces
+as `WKS-RTM-409` with HTTP 409.
+
+The `documentCount` field on `CaseDto` is always `0` until Epic 3 (Documents). The shape is frozen
+here so Story 3.2 can fill it without a DTO bump.
+
+The list endpoint paginates via the standard `?page=...&size=...&sort=...` envelope; the sort
+allow-list is `[updatedAt, createdAt, status]`. The JSON `data` column is never fetched on the
+list path (server-side projection) — list rows carry only system columns plus the case-type's
+`listColumns` field projections.
 
 ## Interactive docs
 


### PR DESCRIPTION
## Summary

Lights up the **Case** half of the platform on top of Story 2.2's engine boundary.

- **Domain model**: `Case` (framework-free record), `CaseService`, `CaseRepository` port — domain stays Spring/JPA-free (ArchUnit-enforced).
- **JPA persistence**: `CaseEntity` with `@JdbcTypeCode(SqlTypes.JSON)` for the dynamic `data` map; H2 keeps `JSON`, Postgres upgrades to `JSONB` via `db/migration/postgresql/V202604260002__cases_data_jsonb.sql` (D6 from review).
- **REST surface**: `POST /api/cases`, `GET /api/cases`, `GET /api/cases/{id}`, `PUT /api/cases/{id}` — server-side pagination + sort whitelist, listColumns projection (D4) so list rows carry the YAML-declared field values without dragging the wide JSON column into the projection query.
- **WorkflowEngine port extension**: `startProcessInstance(processDefinitionKey, variables)` — engine package remains the only `RuntimeService` importer.
- **Domain events**: `CaseCreated`, `CaseUpdated` (audit/SSE consumers attach in Epic 4).
- **Permission gating**: `CaseTypePermissionEvaluator` against the YAML role/permission table from 2.1; controller enforces `view`/`create`/`edit` verbs (D1 — `edit` pulled forward from 5.2). `EDIT` enum value already in `Permission`; operators must grant `edit` to roles that need PUT.
- **Pinned debt closed**: `BaseJpaEntity.equals/hashCode` (Vlad pattern), `AdminUserSeeder` optimistic-lock catch broadened, `WKS-RTM-409` added.

## Code review applied

Two-pass review (Blind Hunter, Edge Case Hunter, Acceptance Auditor) — 6 decisions resolved, 21 patches applied:

- **D1** `edit` verb gate on PUT
- **D2** GET/PUT gating moved out of `@PreAuthorize` SpEL into handler bodies
- **D3** `WksValidationAggregateException` rebound to `WKS-API-002` (was sharing 001 with the 400 path)
- **D4** `CaseRepository.findDataByIds` enriches `CaseSummary.fields` from `caseType.listColumns`
- **D6** JSONB upgrade migration moved to `db/migration/postgresql/`
- **P1** Optimistic-lock pinned at adapter via `BaseJpaEntity.setVersion` so JPA `@Version` compares against caller intent (closes TOCTOU between the framework-free service read and adapter write)
- **D5a/b/c** `CaseRepositoryPostgresIT`, `CaseFlowIT`, `CaseAuthIT` — CaseAuthIT closes Story 2.2's deferred "JWT role-prefix integration coverage"
- Plus: null-tolerant `Case.data` copy, blank-`?status=` collapse, narrowed engine `catch`, FK `ON DELETE SET NULL`, `data DEFAULT '{}'`, controller `defaultSort` cleanup, etc.

8 deferred items folded into Story 2.5 (per Fold-Debt rule) and `deferred-work.md`.

## Test plan

- [x] `mvn verify` — 182 unit/slice + 33 integration tests, all green
- [x] Spotless clean
- [x] ArchUnit 14/14 (domain stays framework-free; only engine package imports `RuntimeService`)
- [x] `CaseFlowIT` proves end-to-end POST → engine start → GET → PUT → 409 optimistic-lock collision over real HTTP with cookie session
- [x] `CaseRepositoryPostgresIT` proves the JSONB upgrade applies on real Postgres + JSON map round-trips with nested values
- [x] `CaseAuthIT` proves anonymous/authenticated/unknown-case-type gating end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)