### PR TITLE
Story 2.4 — Case status transitions via BPMN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,48 @@ Case types are declared as YAML files in a directory mounted into the container.
   the transaction cleanly; DB failure after engine success leaves a dangling process instance
   (accepted Phase 0 partial state — Phase 1 wraps in an outbox).
 
+### Case Transitions & Tasks (Story 2.4)
+
+- **Endpoints**: `POST /api/cases/{id}/transition`, `POST /api/tasks/{id}/complete`,
+  `POST /api/tasks/{id}/claim` — all gate on the `transition` verb (see
+  `docs/api-conventions.md`).
+- **Transition dispatch**: Phase 0 supports BPMN message correlation only — `action` is the
+  `<bpmn:message name="...">` attached to an `intermediateCatchEvent`/`receiveTask`. Signal-based
+  transitions can be added in Story 8.2 if a real template requires them.
+- **Engine-callback hexagonal pattern**: `CaseStatusListener` (a CIB seven `ExecutionListener`)
+  reads `caseId` from the process variable and updates `cases.status` via the `CaseStatusUpdater`
+  port — never via direct JPA writes inside the listener. The JPA adapter
+  (`CaseStatusAdapter`) participates in the engine transaction so a listener failure rolls back
+  both the engine state and the case-row update atomically. The listener is registered on every
+  user-task and end-event `end` event by `CaseStatusEnginePlugin` (a
+  `ProcessEnginePlugin` + `BpmnParseListener`) so BPMN XML stays free of
+  `camunda:executionListener` boilerplate.
+- **Status mapping**: an end event's status comes from `<camunda:property name="status"/>` (or
+  the element id when absent). For user-task end, the listener picks the next active activity id
+  via `runtimeService.getActiveActivityIds(...)`.
+- **Three-archetype response surface**: `TaskActionResponse` carries the `archetype` read from
+  the user task's `<camunda:property name="archetype"/>` so Story 2.8's `TaskLifecycleButton` can
+  drive the right UI state without a follow-up call. Backend never blocks on downstream BPMN work
+  for `submit_for_processing` — the SSE bridge (Story 4.3) confirms eventual completion.
+- **Persistent process-definition mapping** (folded debt #1 from 2.3): the `case_type_deployments`
+  Flyway table holds the `caseTypeId → processDefinitionKey` mapping durably; the in-memory
+  cache becomes a write-through layer. JVM restart no longer drops admin-deployed mappings.
+- **Concurrent-deploy hardening** (folded debt #2 from 2.2): `ConfigService.deploy` now holds a
+  per-`caseTypeId` lock around the `reader.find → registrar.register` window so two concurrent
+  deploys of the same case-type id can no longer interleave.
+
 ## Change Log
+
+- 2026-04-26 — Story 2.4: Case status transitions via BPMN — `POST /api/cases/{id}/transition`,
+  `POST /api/tasks/{id}/complete`, `POST /api/tasks/{id}/claim`. New `Task` domain record +
+  `TaskService`, `WorkflowEngine` port extended with `findTask` / `completeTask` / `claimTask` /
+  `signalTransition`, `CaseStatusListener` engine-callback adapter via the new `CaseStatusUpdater`
+  port + `CaseStatusEnginePlugin`. New `case_type_deployments` Flyway table makes the
+  `caseTypeId → processDefinitionKey` mapping durable (closes 2.3 deferred); per-`caseTypeId` lock
+  in `ConfigService.deploy` closes the 2.2 TOCTOU deferred. ArchUnit rules added for the
+  task-domain and engine-delegate import surfaces (AC8). `CaseFlowIT` extended with the
+  create→complete→transition end-to-end path; `CaseAuthIT` extended with JWT round-trip on the
+  transition endpoint. No new `WKS-*` wire codes — `WKS-RTM-409` is reused for engine conflicts.
 
 - 2026-04-26 — Story 2.3: Case CRUD shipped — `POST/GET/PUT /api/cases`, JSON column for
   dynamic case data (H2 native + Postgres JSONB upgrade via Java Flyway migration),

--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
@@ -2,6 +2,7 @@ package com.wkspower.platform.api.controller;
 
 import com.wkspower.platform.api.dto.ApiResponse;
 import com.wkspower.platform.api.dto.request.CreateCaseRequest;
+import com.wkspower.platform.api.dto.request.TransitionRequest;
 import com.wkspower.platform.api.dto.request.UpdateCaseRequest;
 import com.wkspower.platform.api.dto.response.CaseDto;
 import com.wkspower.platform.api.dto.response.CaseSummaryDto;
@@ -134,6 +135,25 @@ public class CaseController {
     Case found = caseService.findById(id);
     requireVerb(actor, found.caseTypeId(), "edit");
     Case updated = caseService.update(id, request.data(), request.version(), actor.id());
+    CaseTypeConfig caseType = caseService.requireCaseType(updated.caseTypeId());
+    return ApiResponse.success(CaseDtoMapper.toDto(updated, caseType));
+  }
+
+  /**
+   * Story 2.4 AC1 — advance the case through its BPMN process. Loads the case first so an unknown
+   * id surfaces 404 before the verb check; the {@code transition} verb gates message dispatch.
+   * Engine-side conflicts (no enabled receiver, optimistic lock) are translated to {@code
+   * WKS-RTM-409} inside {@code CibSevenWorkflowEngine}; missing process instance surfaces {@code
+   * WKS-RTM-500}.
+   */
+  @PostMapping("/{id}/transition")
+  public ApiResponse<CaseDto> transition(
+      @PathVariable("id") UUID id,
+      @Valid @RequestBody TransitionRequest request,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    Case found = caseService.findById(id);
+    requireVerb(actor, found.caseTypeId(), "transition");
+    Case updated = caseService.transition(id, request.action(), request.variables(), actor.id());
     CaseTypeConfig caseType = caseService.requireCaseType(updated.caseTypeId());
     return ApiResponse.success(CaseDtoMapper.toDto(updated, caseType));
   }

--- a/backend/src/main/java/com/wkspower/platform/api/controller/TaskController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/TaskController.java
@@ -1,0 +1,87 @@
+package com.wkspower.platform.api.controller;
+
+import com.wkspower.platform.api.dto.ApiResponse;
+import com.wkspower.platform.api.dto.request.CompleteTaskRequest;
+import com.wkspower.platform.api.dto.response.TaskActionResponse;
+import com.wkspower.platform.domain.model.Task;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.service.TaskService;
+import com.wkspower.platform.security.CaseTypePermissionEvaluator;
+import com.wkspower.platform.security.WksUserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST surface for BPMN user-task lifecycle (Story 2.4 AC2 / AC3). Permission gating: load the task
+ * first so unknown id surfaces 404, then check the {@code transition} verb against the task's
+ * case-type. Engine-side conflicts (already-completed, claimed-by-other) are translated inside
+ * {@code CibSevenWorkflowEngine} and surface as {@code WKS-RTM-409}.
+ */
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+  private final TaskService taskService;
+  private final CaseTypePermissionEvaluator evaluator;
+  private final Clock clock;
+
+  public TaskController(
+      TaskService taskService, CaseTypePermissionEvaluator evaluator, Clock clock) {
+    this.taskService = taskService;
+    this.evaluator = evaluator;
+    this.clock = clock;
+  }
+
+  @PostMapping("/{id}/complete")
+  public ResponseEntity<ApiResponse<TaskActionResponse>> complete(
+      @PathVariable("id") String id,
+      @RequestBody(required = false) CompleteTaskRequest request,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    Task task = taskService.findById(id);
+    requireVerb(actor, task.caseTypeId());
+    Task completed =
+        taskService.complete(id, request == null ? null : request.variables(), actor.id());
+    // Snapshot is taken before engine.complete, so processInstanceId is still populated. The
+    // assignee surfaced on /complete is the actor (which the service has just verified) — null
+    // would suggest the action was anonymous, which it never is.
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            new TaskActionResponse(
+                completed.id(),
+                completed.processInstanceId(),
+                completed.caseId(),
+                completed.archetype(),
+                actor.id(),
+                clock.now())));
+  }
+
+  @PostMapping("/{id}/claim")
+  public ResponseEntity<ApiResponse<TaskActionResponse>> claim(
+      @PathVariable("id") String id, @AuthenticationPrincipal WksUserPrincipal actor) {
+    Task task = taskService.findById(id);
+    requireVerb(actor, task.caseTypeId());
+    Task claimed = taskService.claim(id, actor.id());
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            new TaskActionResponse(
+                claimed.id(),
+                claimed.processInstanceId(),
+                claimed.caseId(),
+                claimed.archetype(),
+                claimed.assignee(),
+                clock.now())));
+  }
+
+  private void requireVerb(WksUserPrincipal actor, String caseTypeId) {
+    if (actor == null || !evaluator.hasVerb(actor.authenticated(), caseTypeId, "transition")) {
+      throw new AccessDeniedException(
+          "Forbidden: missing verb 'transition' on case type " + caseTypeId);
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/request/CompleteTaskRequest.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/request/CompleteTaskRequest.java
@@ -1,0 +1,9 @@
+package com.wkspower.platform.api.dto.request;
+
+import java.util.Map;
+
+/**
+ * Request body for {@code POST /api/tasks/{id}/complete} (Story 2.4 AC2). {@code variables} are
+ * merged into the engine's process variables on completion and may be {@code null} or empty.
+ */
+public record CompleteTaskRequest(Map<String, Object> variables) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/request/TransitionRequest.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/request/TransitionRequest.java
@@ -1,0 +1,12 @@
+package com.wkspower.platform.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.Map;
+
+/**
+ * Request body for {@code POST /api/cases/{id}/transition} (Story 2.4 AC1). {@code action} is the
+ * BPMN message name (Phase 0 supports message correlation only — see Story 2.4 Dev Notes
+ * §Transition dispatch); {@code variables} are merged into the engine's process variables and may
+ * be {@code null} or empty.
+ */
+public record TransitionRequest(@NotBlank String action, Map<String, Object> variables) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/TaskActionResponse.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/TaskActionResponse.java
@@ -1,0 +1,28 @@
+package com.wkspower.platform.api.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Response payload for {@code POST /api/tasks/{id}/complete} and {@code POST /api/tasks/{id}/claim}
+ * (Story 2.4 AC2 / AC3 / AC4). {@code archetype} is read from the user task's {@code
+ * camunda:property name="archetype"} so Story 2.8's {@code TaskLifecycleButton} can render the
+ * right Layer-3 UI state without a follow-up round trip (architecture.md §Decision 9).
+ *
+ * @param taskId engine-assigned task id
+ * @param processInstanceId BPMN process instance id (correlates with engine logs)
+ * @param caseId case the task belongs to
+ * @param archetype one of {@code draft_section}, {@code submit_for_processing}, {@code
+ *     business_final}; may be {@code null} on the claim path if the task definition is malformed
+ *     (deploy-time gate prevents this in practice)
+ * @param assignee post-action assignee — populated on the {@code /claim} response, may be {@code
+ *     null} on the {@code /complete} response (the engine has already removed the task)
+ * @param at action timestamp (claim or complete)
+ */
+public record TaskActionResponse(
+    String taskId,
+    String processInstanceId,
+    UUID caseId,
+    String archetype,
+    UUID assignee,
+    Instant at) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/event/CaseStatusChanged.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/CaseStatusChanged.java
@@ -1,0 +1,26 @@
+package com.wkspower.platform.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Emitted when a BPMN execution crosses a status boundary — i.e. when the engine commits the
+ * transition out of a user task or end event whose id (or {@code camunda:property name="status"})
+ * maps to a YAML-declared status id. Story 2.4's {@code CaseStatusListener} fires it on the
+ * engine's transaction-commit pathway so subscribers see the new status atomically with the engine
+ * state and the {@code cases.status} update.
+ *
+ * <p>Schema follows {@code architecture.md §Decision 11} — entity ids, transition metadata,
+ * timestamp. Activity-feed / audit listeners attach in Story 4.1; SSE transport in Story 4.3.
+ *
+ * @param caseId case whose status changed
+ * @param oldStatus previous status id (may be {@code null} on the very first transition out of the
+ *     start event if no prior user-task fired)
+ * @param newStatus new status id read from the next active activity (or the end event's status
+ *     property)
+ * @param processInstanceId BPMN process instance id — useful for correlating with engine logs
+ * @param timestamp commit timestamp from the engine (taken via {@code Clock.now()} inside the
+ *     listener)
+ */
+public record CaseStatusChanged(
+    UUID caseId, String oldStatus, String newStatus, String processInstanceId, Instant timestamp) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/model/Task.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/Task.java
@@ -1,0 +1,53 @@
+package com.wkspower.platform.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Domain record for a single BPMN user task. Plain Java — no Spring, no JPA, no engine SDK on the
+ * import list. The ArchUnit rule {@code caseDomainHasNoSpringOrJpaImports} (Story 2.3 AC9) covers
+ * this; the explicit AC8 rule for Story 2.4 reasserts it.
+ *
+ * <p>The {@code archetype} field carries one of {@code draft_section}, {@code
+ * submit_for_processing}, {@code business_final} as declared in the BPMN user task's {@code
+ * camunda:properties}. Story 2.2's {@code BpmnValidator} rejects deploys with missing or
+ * contradictory archetypes ({@code WKS-CFG-020} / {@code WKS-CFG-021}); Story 2.4's runtime path
+ * therefore reads the property without re-validating.
+ *
+ * @param id engine-assigned task id (CIB seven uses string ids)
+ * @param processInstanceId BPMN process instance id (correlates with engine logs); used to populate
+ *     {@code TaskActionResponse.processInstanceId} on the {@code /complete} and {@code /claim}
+ *     responses since the snapshot is taken before completion (Story 2.4 review).
+ * @param caseId case the task belongs to (read from the {@code caseId} process variable set by
+ *     {@code CaseService.create} in Story 2.3)
+ * @param caseTypeId case type id from the case row — needed by the API layer's permission gate
+ * @param taskDefinitionKey BPMN element id of the {@code bpmn:userTask}
+ * @param name human-readable task name from the BPMN
+ * @param assignee user id assigned to the task, or {@code null} when unassigned (claim required)
+ * @param archetype one of {@code draft_section}, {@code submit_for_processing}, {@code
+ *     business_final}; {@code null} only if the deploy-time gate was somehow bypassed
+ * @param createdAt task creation timestamp from the engine
+ * @param dueAt due date from the BPMN, or {@code null} when no due date is configured
+ */
+public record Task(
+    String id,
+    String processInstanceId,
+    UUID caseId,
+    String caseTypeId,
+    String taskDefinitionKey,
+    String name,
+    UUID assignee,
+    String archetype,
+    Instant createdAt,
+    Instant dueAt) {
+
+  public Task {
+    Objects.requireNonNull(id, "id");
+    Objects.requireNonNull(processInstanceId, "processInstanceId");
+    Objects.requireNonNull(caseId, "caseId");
+    Objects.requireNonNull(caseTypeId, "caseTypeId");
+    Objects.requireNonNull(taskDefinitionKey, "taskDefinitionKey");
+    Objects.requireNonNull(createdAt, "createdAt");
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/CaseStatusUpdater.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/CaseStatusUpdater.java
@@ -1,0 +1,27 @@
+package com.wkspower.platform.domain.port;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Outbound port for atomically updating {@code cases.status} from inside the engine-callback
+ * pathway. Story 2.4's {@code CaseStatusListener} (CIB seven {@code ExecutionListener}) calls this
+ * port instead of issuing JPA writes directly — see Story 2.4 Dev Notes §Engine-callback hexagonal
+ * pattern.
+ *
+ * <p>The JPA adapter implements this interface and runs inside the engine's transaction, so a
+ * listener failure rolls back both the engine state and the {@code cases.status} write atomically.
+ *
+ * <p>Returning the previous status lets the listener publish {@code CaseStatusChanged} with both
+ * old + new values without an extra round trip.
+ */
+public interface CaseStatusUpdater {
+
+  /**
+   * Update the row's {@code status} column to {@code newStatus}. Returns the previous value (or
+   * {@link Optional#empty()} if the row did not exist — engine state should never get this far if
+   * the case row was created normally, so the empty branch is a defensive escape hatch). Returns
+   * the previous status as {@link Optional} of the prior column value when the row exists.
+   */
+  Optional<String> updateStatus(UUID caseId, String newStatus);
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/WorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/WorkflowEngine.java
@@ -1,10 +1,12 @@
 package com.wkspower.platform.domain.port;
 
+import com.wkspower.platform.domain.model.Task;
 import com.wkspower.platform.domain.workflow.DeploymentInfo;
 import com.wkspower.platform.domain.workflow.DeploymentRequest;
 import com.wkspower.platform.domain.workflow.DeploymentResult;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Outbound port for the embedded BPMN engine.
@@ -13,7 +15,9 @@ import java.util.Optional;
  *   <li>Story 2.2 surface — {@link #deploy(DeploymentRequest)} and {@link
  *       #latestDeployment(String)}.
  *   <li>Story 2.3 surface — {@link #startProcessInstance(String, Map)}.
- *   <li>Process completion / transition lifecycle remains absent until Stories 2.4 / 2.8.
+ *   <li>Story 2.4 surface — {@link #findTask(String)}, {@link #completeTask(String, Map)}, {@link
+ *       #claimTask(String, UUID)}, {@link #signalTransition(String, String, Map)} for case status
+ *       transitions and user-task lifecycle.
  * </ul>
  *
  * <p>Implementations live in {@code engine/} only.
@@ -42,4 +46,39 @@ public interface WorkflowEngine {
    * into {@link com.wkspower.platform.domain.exception.WksWorkflowEngineException}.
    */
   String startProcessInstance(String processDefinitionKey, Map<String, Object> variables);
+
+  /**
+   * Lookup a single user task by engine-assigned id. Returns {@link Optional#empty()} when the task
+   * does not exist (already completed, or never existed); the calling service translates that to
+   * {@link com.wkspower.platform.domain.exception.WksNotFoundException}. Implementations MUST
+   * translate engine exceptions other than not-found into {@link
+   * com.wkspower.platform.domain.exception.WksWorkflowEngineException}.
+   */
+  Optional<Task> findTask(String taskId);
+
+  /**
+   * Complete a user task. {@code variables} are merged into process variables — pass simple scalars
+   * only. Implementations MUST translate already-completed / wrong-assignee / optimistic lock
+   * failures into {@link com.wkspower.platform.domain.exception.WksConflictException} and
+   * unknown-task into {@link com.wkspower.platform.domain.exception.WksNotFoundException}.
+   */
+  void completeTask(String taskId, Map<String, Object> variables);
+
+  /**
+   * Claim an unassigned user task for {@code userId}. Implementations MUST translate
+   * already-claimed into {@link com.wkspower.platform.domain.exception.WksConflictException} (with
+   * a message identifying the current assignee) and unknown-task into {@link
+   * com.wkspower.platform.domain.exception.WksNotFoundException}.
+   */
+  void claimTask(String taskId, UUID userId);
+
+  /**
+   * Advance a process instance via message correlation (Story 2.4 Phase 0 supports message
+   * correlation only — see Dev Notes §Transition dispatch). The {@code action} string is the BPMN
+   * message name. {@code variables} flow into the correlation as process variables.
+   *
+   * <p>Implementations MUST translate "no enabled receiver" / mismatching-correlation into {@link
+   * com.wkspower.platform.domain.exception.WksConflictException}.
+   */
+  void signalTransition(String processInstanceId, String action, Map<String, Object> variables);
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -95,7 +95,7 @@ public class CaseService {
                             + " — case create requires a deployed workflow"));
     String processInstanceId =
         workflowEngine.startProcessInstance(
-            processDefinitionKey, Map.of("caseId", caseId.toString()));
+            processDefinitionKey, Map.of("caseId", caseId.toString(), "caseTypeId", caseType.id()));
 
     Instant now = clock.now();
     Case toPersist =
@@ -162,6 +162,32 @@ public class CaseService {
     Case persisted = caseRepository.save(updated);
     eventPublisher.publish(new CaseUpdated(persisted.id(), actorId, now, changedFieldIds));
     return persisted;
+  }
+
+  /**
+   * Advance a case through its BPMN process via message correlation (Story 2.4 AC1). The {@code
+   * action} string is the BPMN message name. The transactional {@code CaseStatusListener} fires
+   * inside {@code workflowEngine.signalTransition} and updates {@code cases.status}; this method
+   * re-loads the row so callers receive the post-transition state.
+   */
+  public Case transition(UUID caseId, String action, Map<String, Object> variables, UUID actorId) {
+    Objects.requireNonNull(caseId, "caseId");
+    Objects.requireNonNull(action, "action");
+    Objects.requireNonNull(actorId, "actorId");
+    Case existing =
+        caseRepository
+            .findById(caseId)
+            .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
+    if (existing.processInstanceId() == null || existing.processInstanceId().isBlank()) {
+      throw new WksWorkflowEngineException(
+          "Case " + caseId + " has no associated process instance — cannot transition");
+    }
+    Map<String, Object> safeVars = TaskService.sanitiseVariables(variables);
+    workflowEngine.signalTransition(existing.processInstanceId(), action, safeVars);
+    return caseRepository
+        .findById(caseId)
+        .orElseThrow(
+            () -> new WksNotFoundException("Case " + caseId + " not found after transition"));
   }
 
   /** Lookup by id; 404 if not found. */

--- a/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
@@ -18,7 +18,11 @@ import com.wkspower.platform.domain.workflow.DeploymentResult;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Orchestrates load + validate + register for case-type YAML and the joint YAML+BPMN deploy. Pure
@@ -31,12 +35,22 @@ import java.util.Optional;
  */
 public class ConfigService {
 
+  private static final Logger log = LoggerFactory.getLogger(ConfigService.class);
+
   private final CaseTypeSource source;
   private final CaseTypeRegistrar registrar;
   private final CaseTypeReader reader;
   private final BpmnValidationService bpmnValidator;
   private final WorkflowEngine workflowEngine;
   private final EventPublisher eventPublisher;
+
+  /**
+   * Per-{@code caseTypeId} mutex (Story 2.4 folded debt #2 — TOCTOU on concurrent deploys of the
+   * same case-type id). Two threads racing the {@code reader.find → registrar.register} window
+   * could both observe the same prior state, leading to interleaved registry writes. Locking on a
+   * stable per-key monitor closes that window.
+   */
+  private final Map<String, Object> deployLocks = new ConcurrentHashMap<>();
 
   public ConfigService(
       CaseTypeSource source,
@@ -109,37 +123,45 @@ public class ConfigService {
       return DeployResult.invalid(aggregate);
     }
 
-    Optional<CaseTypeConfig> priorState = reader.find(caseType.id());
-
-    RegistrationResult reg = registrar.register(caseType);
-    if (reg.outcome() == RegistrationResult.Outcome.REJECTED_OLDER_VERSION) {
-      return DeployResult.invalid(reg.errors());
-    }
-
+    Object lock = deployLocks.computeIfAbsent(caseType.id(), k -> new Object());
+    Optional<CaseTypeConfig> priorState;
+    RegistrationResult reg;
     DeploymentResult deployment;
-    try {
-      deployment =
-          workflowEngine.deploy(
-              new DeploymentRequest(
-                  caseType.id() + " v" + caseType.version(),
-                  bpmnResult.processDefinitionKey().orElseThrow(),
-                  bpmnBytes,
-                  caseType.id(),
-                  caseType.version()));
-    } catch (RuntimeException ex) {
-      restoreRegistryAfterEngineFailure(caseType.id(), priorState);
-      throw ex;
-    }
+    synchronized (lock) {
+      priorState = reader.find(caseType.id());
 
-    eventPublisher.publish(
-        new ConfigDeployed(
-            caseType.id(),
-            caseType.version(),
-            deployment.deploymentId(),
-            deployment.processDefinitionKey(),
-            deployment.processDefinitionId(),
-            actorEmail,
-            deployment.deployedAt()));
+      reg = registrar.register(caseType);
+      if (reg.outcome() == RegistrationResult.Outcome.REJECTED_OLDER_VERSION) {
+        return DeployResult.invalid(reg.errors());
+      }
+
+      try {
+        deployment =
+            workflowEngine.deploy(
+                new DeploymentRequest(
+                    caseType.id() + " v" + caseType.version(),
+                    bpmnResult.processDefinitionKey().orElseThrow(),
+                    bpmnBytes,
+                    caseType.id(),
+                    caseType.version()));
+      } catch (RuntimeException ex) {
+        restoreRegistryAfterEngineFailure(caseType.id(), priorState);
+        throw ex;
+      }
+
+      // Publish inside the lock so two concurrent deploys of the same caseTypeId cannot interleave
+      // their event publication and leave the ProcessDefinitionKeyCache stuck on an older mapping
+      // (Story 2.4 review).
+      eventPublisher.publish(
+          new ConfigDeployed(
+              caseType.id(),
+              caseType.version(),
+              deployment.deploymentId(),
+              deployment.processDefinitionKey(),
+              deployment.processDefinitionId(),
+              actorEmail,
+              deployment.deployedAt()));
+    }
 
     return DeployResult.ok(caseType, deployment);
   }
@@ -184,10 +206,15 @@ public class ConfigService {
       if (prior.isPresent()) {
         registrar.register(prior.get());
       }
-    } catch (RuntimeException ignored) {
-      // Best-effort restore. Cascading the secondary failure would mask the original engine
-      // exception. The caller still sees the original WksWorkflowEngineException; the registry
-      // may briefly advertise an unbacked config — see Dev Notes §Atomic deploy.
+    } catch (RuntimeException secondary) {
+      // Best-effort restore. Cascading would mask the original engine exception, so we log at
+      // ERROR and let the original bubble. The registry may end up empty for this caseTypeId
+      // until the next successful deploy — operators can see this in the logs (Story 2.4 review).
+      log.error(
+          "ConfigService: registry rollback after engine failure for caseTypeId={} also failed —"
+              + " registry may have no entry for this id until the next successful deploy",
+          id,
+          secondary);
     }
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/service/TaskService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/TaskService.java
@@ -1,0 +1,107 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.exception.WksValidationException;
+import com.wkspower.platform.domain.model.Task;
+import com.wkspower.platform.domain.port.WorkflowEngine;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Domain service for BPMN user-task lifecycle (Story 2.4 AC6). Framework-free — collaborators are
+ * reached via the {@link WorkflowEngine} port; engine-side exception translation lives inside the
+ * adapter so this service sees only the {@code Wks*Exception} hierarchy.
+ *
+ * <p>The service intentionally does not gate permissions — that is the controller's job (verb gate
+ * via {@code CaseTypePermissionEvaluator}). Keeping authz at the edge keeps the service usable from
+ * background jobs and tests without a security context.
+ */
+public class TaskService {
+
+  /**
+   * Engine-managed process variables that callers MUST NOT inject via {@code variables}. Allowing
+   * client-supplied {@code caseId} would let the {@code CaseStatusListener} write the status of a
+   * different case (Story 2.4 review — variable injection cross-case corruption).
+   */
+  static final Set<String> RESERVED_PROCESS_VARIABLES =
+      Set.of("caseId", "caseTypeId", "taskAssignee", "caseStatus");
+
+  private final WorkflowEngine workflowEngine;
+
+  public TaskService(WorkflowEngine workflowEngine) {
+    this.workflowEngine = Objects.requireNonNull(workflowEngine, "workflowEngine");
+  }
+
+  /** Lookup a task by id; 404 if unknown. */
+  public Task findById(String taskId) {
+    Objects.requireNonNull(taskId, "taskId");
+    return workflowEngine
+        .findTask(taskId)
+        .orElseThrow(() -> new WksNotFoundException("Task " + taskId + " not found"));
+  }
+
+  /**
+   * Complete a user task and return the {@link Task} snapshot taken before the engine completed it
+   * (so callers — i.e. the controller — can read the {@code archetype} and {@code caseId} for the
+   * response without a follow-up query that the engine would now answer with not-found). The
+   * post-completion {@code cases.status} update fires asynchronously to this call from the {@code
+   * CaseStatusListener} engine-callback (AC5).
+   */
+  public Task complete(String taskId, Map<String, Object> variables, UUID actorId) {
+    Objects.requireNonNull(taskId, "taskId");
+    Objects.requireNonNull(actorId, "actorId");
+    Map<String, Object> safeVars = sanitiseVariables(variables);
+    Task snapshot =
+        workflowEngine
+            .findTask(taskId)
+            .orElseThrow(() -> new WksNotFoundException("Task " + taskId + " not found"));
+    // AC2 — caller is the assignee, OR caller holds the verb (controller's job) AND the task is
+    // unassigned. The controller already enforces the verb; this layer enforces the assignee
+    // contract so a caller with the verb cannot complete a task assigned to someone else.
+    UUID assignee = snapshot.assignee();
+    if (assignee != null && !assignee.equals(actorId)) {
+      throw new WksConflictException(
+          "Task " + taskId + " is assigned to another user; complete denied");
+    }
+    workflowEngine.completeTask(taskId, safeVars);
+    return snapshot;
+  }
+
+  /**
+   * Reject client-supplied keys that the engine treats as system variables. Without this guard, a
+   * caller could pass {@code "caseId":"<other-uuid>"} and the {@code CaseStatusListener} would
+   * update the wrong case's status row on the next transition (Story 2.4 review — critical).
+   */
+  static Map<String, Object> sanitiseVariables(Map<String, Object> variables) {
+    if (variables == null || variables.isEmpty()) {
+      return Map.of();
+    }
+    for (String key : variables.keySet()) {
+      if (RESERVED_PROCESS_VARIABLES.contains(key)) {
+        throw new WksValidationException(
+            ErrorCode.WKS_API_001,
+            "Process variable '" + key + "' is reserved and cannot be supplied by the client",
+            "variables." + key);
+      }
+    }
+    return Map.copyOf(variables);
+  }
+
+  /**
+   * Claim an unassigned user task. Returns the post-claim {@link Task} snapshot — re-fetched after
+   * the claim so {@link Task#assignee()} reflects the new owner.
+   */
+  public Task claim(String taskId, UUID actorId) {
+    Objects.requireNonNull(taskId, "taskId");
+    Objects.requireNonNull(actorId, "actorId");
+    workflowEngine.claimTask(taskId, actorId);
+    return workflowEngine
+        .findTask(taskId)
+        .orElseThrow(
+            () -> new WksNotFoundException("Task " + taskId + " not found after claim — race?"));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/engine/BpmnValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/BpmnValidator.java
@@ -53,7 +53,7 @@ public class BpmnValidator implements BpmnValidationService {
    * matches the wire-shape documented in Dev Notes §Variable binding.
    */
   private static final Set<String> WELL_KNOWN_VARIABLES =
-      Set.of("taskAssignee", "caseId", "caseStatus");
+      Set.of("taskAssignee", "caseId", "caseTypeId", "caseStatus");
 
   private static final Pattern EXPRESSION_TOKEN = Pattern.compile("[\\$#]\\{([^}]+)\\}");
 

--- a/backend/src/main/java/com/wkspower/platform/engine/CaseStatusEnginePlugin.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/CaseStatusEnginePlugin.java
@@ -1,0 +1,35 @@
+package com.wkspower.platform.engine;
+
+import com.wkspower.platform.engine.listeners.CaseStatusBpmnParseListener;
+import com.wkspower.platform.engine.listeners.CaseStatusListener;
+import java.util.ArrayList;
+import org.cibseven.bpm.engine.impl.bpmn.parser.BpmnParseListener;
+import org.cibseven.bpm.engine.impl.cfg.AbstractProcessEnginePlugin;
+import org.cibseven.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.springframework.stereotype.Component;
+
+/**
+ * CIB seven {@link AbstractProcessEnginePlugin} that registers our case-status BPMN parse listener
+ * with the engine at boot. Story 2.4 Dev Notes §Listener registration: programmatic registration
+ * keeps BPMN XML free of {@code camunda:executionListener class="..."} boilerplate and guarantees
+ * every deployed process is wired identically.
+ */
+@Component
+public class CaseStatusEnginePlugin extends AbstractProcessEnginePlugin {
+
+  private final CaseStatusListener caseStatusListener;
+
+  public CaseStatusEnginePlugin(CaseStatusListener caseStatusListener) {
+    this.caseStatusListener = caseStatusListener;
+  }
+
+  @Override
+  public void preInit(ProcessEngineConfigurationImpl configuration) {
+    if (configuration.getCustomPostBPMNParseListeners() == null) {
+      configuration.setCustomPostBPMNParseListeners(new ArrayList<BpmnParseListener>());
+    }
+    configuration
+        .getCustomPostBPMNParseListeners()
+        .add(new CaseStatusBpmnParseListener(caseStatusListener));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
@@ -1,6 +1,9 @@
 package com.wkspower.platform.engine;
 
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
+import com.wkspower.platform.domain.model.Task;
 import com.wkspower.platform.domain.port.WorkflowEngine;
 import com.wkspower.platform.domain.workflow.DeploymentInfo;
 import com.wkspower.platform.domain.workflow.DeploymentRequest;
@@ -8,15 +11,27 @@ import com.wkspower.platform.domain.workflow.DeploymentResult;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
+import org.cibseven.bpm.engine.MismatchingMessageCorrelationException;
+import org.cibseven.bpm.engine.OptimisticLockingException;
 import org.cibseven.bpm.engine.ProcessEngineException;
 import org.cibseven.bpm.engine.RepositoryService;
 import org.cibseven.bpm.engine.RuntimeService;
+import org.cibseven.bpm.engine.TaskAlreadyClaimedException;
+import org.cibseven.bpm.engine.TaskService;
+import org.cibseven.bpm.engine.exception.NullValueException;
 import org.cibseven.bpm.engine.repository.Deployment;
 import org.cibseven.bpm.engine.repository.ProcessDefinition;
 import org.cibseven.bpm.engine.runtime.ProcessInstance;
+import org.cibseven.bpm.model.bpmn.BpmnModelInstance;
+import org.cibseven.bpm.model.bpmn.instance.ExtensionElements;
+import org.cibseven.bpm.model.bpmn.instance.UserTask;
+import org.cibseven.bpm.model.bpmn.instance.cibseven.CamundaProperties;
+import org.cibseven.bpm.model.bpmn.instance.cibseven.CamundaProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -24,11 +39,16 @@ import org.springframework.stereotype.Component;
 /**
  * CIB seven adapter for the {@link WorkflowEngine} port. Sole class outside the test tree allowed
  * to import {@code org.cibseven.*} (enforced by {@code
- * ArchitectureTest.onlyEngineImportsCibSeven}).
+ * ArchitectureTest.onlyEngineAdapterImportsTheBpmnEngineSdk}).
  *
  * <p>{@code enableDuplicateFiltering(true)} makes redeploy of an unchanged BPMN a no-op — CIB seven
  * hashes the resource bytes. This is the engine-side counterpart to the case-type registry's
  * idempotent same-version path.
+ *
+ * <p>Story 2.4 expands the surface with task lifecycle ({@link #findTask}, {@link #completeTask},
+ * {@link #claimTask}) and message-correlation transitions ({@link #signalTransition}). Engine-side
+ * exceptions translate inside this adapter so domain/api code never sees an {@code org.cibseven.*}
+ * type.
  */
 @Component
 public class CibSevenWorkflowEngine implements WorkflowEngine {
@@ -40,11 +60,13 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
 
   private final RepositoryService repositoryService;
   private final RuntimeService runtimeService;
+  private final TaskService taskService;
 
   public CibSevenWorkflowEngine(
-      RepositoryService repositoryService, RuntimeService runtimeService) {
+      RepositoryService repositoryService, RuntimeService runtimeService, TaskService taskService) {
     this.repositoryService = repositoryService;
     this.runtimeService = runtimeService;
+    this.taskService = taskService;
   }
 
   @Override
@@ -177,5 +199,209 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
           "CIB seven returned no ProcessInstance for processDefinitionKey=" + processDefinitionKey);
     }
     return instance.getId();
+  }
+
+  @Override
+  public Optional<Task> findTask(String taskId) {
+    Objects.requireNonNull(taskId, "taskId");
+    org.cibseven.bpm.engine.task.Task engineTask;
+    try {
+      engineTask = taskService.createTaskQuery().taskId(taskId).singleResult();
+    } catch (ProcessEngineException ex) {
+      throw new WksWorkflowEngineException("CIB seven task query failed for taskId=" + taskId, ex);
+    }
+    if (engineTask == null) {
+      return Optional.empty();
+    }
+
+    Map<String, Object> processVars;
+    try {
+      processVars = runtimeService.getVariables(engineTask.getProcessInstanceId());
+    } catch (NullValueException ex) {
+      // Process instance completed between the task query and the variable read — surface as
+      // not-found rather than 500 (Story 2.4 review — findTask TOCTOU).
+      return Optional.empty();
+    } catch (ProcessEngineException ex) {
+      String msg = ex.getMessage() == null ? "" : ex.getMessage();
+      if (msg.contains("execution") && msg.contains("doesn't exist")) {
+        // Defensive: some CIB seven paths surface execution-gone as ProcessEngineException without
+        // a NullValueException subtype.
+        return Optional.empty();
+      }
+      throw new WksWorkflowEngineException(
+          "CIB seven process-variable lookup failed for taskId=" + taskId, ex);
+    }
+    UUID caseId = parseCaseId(processVars.get("caseId"), taskId);
+    String caseTypeId = (String) processVars.get("caseTypeId");
+    if (caseTypeId == null) {
+      throw new WksWorkflowEngineException(
+          "Process instance "
+              + engineTask.getProcessInstanceId()
+              + " is missing the 'caseTypeId' variable expected on every WKS process — task="
+              + taskId);
+    }
+
+    String archetype =
+        readArchetype(engineTask.getProcessDefinitionId(), engineTask.getTaskDefinitionKey());
+    UUID assignee = parseAssignee(engineTask.getAssignee());
+
+    Instant createdAt =
+        engineTask.getCreateTime() == null ? Instant.EPOCH : engineTask.getCreateTime().toInstant();
+    Instant dueAt = engineTask.getDueDate() == null ? null : engineTask.getDueDate().toInstant();
+
+    return Optional.of(
+        new Task(
+            engineTask.getId(),
+            engineTask.getProcessInstanceId(),
+            caseId,
+            caseTypeId,
+            engineTask.getTaskDefinitionKey(),
+            engineTask.getName(),
+            assignee,
+            archetype,
+            createdAt,
+            dueAt));
+  }
+
+  @Override
+  public void completeTask(String taskId, Map<String, Object> variables) {
+    Objects.requireNonNull(taskId, "taskId");
+    Map<String, Object> safeVars = variables == null ? Map.of() : Map.copyOf(variables);
+    try {
+      taskService.complete(taskId, safeVars);
+    } catch (NullValueException ex) {
+      // CIB seven's TaskService.complete throws NullValueException when the task does not exist
+      // (already completed or never existed).
+      throw new WksNotFoundException(
+          "Task " + taskId + " not found (already completed or unknown)");
+    } catch (TaskAlreadyClaimedException ex) {
+      // Spec Task 2.2 names this exception explicitly. Surfaces when complete() runs against a
+      // task whose assignee differs from the actor at the engine boundary (defence-in-depth on
+      // top of the service-layer assignee check).
+      throw new WksConflictException(
+          "Task " + taskId + " is assigned to another user — complete denied", ex);
+    } catch (OptimisticLockingException ex) {
+      throw new WksConflictException(
+          "Task " + taskId + " was modified by another transaction; reload and retry", ex);
+    } catch (ProcessEngineException ex) {
+      // ProcessEngineException with no specific subtype here is genuine engine failure (DB error,
+      // expression evaluation, etc.) — surface as 500. The two known client-fixable conditions
+      // (not-found, claimed-by-other) are caught above by their explicit subtypes.
+      throw new WksWorkflowEngineException(
+          "CIB seven completeTask failed for taskId=" + taskId, ex);
+    }
+  }
+
+  @Override
+  public void claimTask(String taskId, UUID userId) {
+    Objects.requireNonNull(taskId, "taskId");
+    Objects.requireNonNull(userId, "userId");
+    try {
+      taskService.claim(taskId, userId.toString());
+    } catch (TaskAlreadyClaimedException ex) {
+      throw new WksConflictException(
+          "Task " + taskId + " is already claimed (current assignee follows engine state)", ex);
+    } catch (NullValueException ex) {
+      throw new WksNotFoundException("Task " + taskId + " not found");
+    } catch (ProcessEngineException ex) {
+      // Genuine engine failure (DB / persistence). Surface as 500 — the two client-fixable
+      // conditions (not-found, already-claimed) are caught above by their explicit subtypes.
+      throw new WksWorkflowEngineException(
+          "CIB seven claimTask failed for taskId=" + taskId, ex);
+    }
+  }
+
+  @Override
+  public void signalTransition(
+      String processInstanceId, String action, Map<String, Object> variables) {
+    Objects.requireNonNull(processInstanceId, "processInstanceId");
+    Objects.requireNonNull(action, "action");
+    Map<String, Object> safeVars = variables == null ? Map.of() : Map.copyOf(variables);
+    try {
+      runtimeService
+          .createMessageCorrelation(action)
+          .processInstanceId(processInstanceId)
+          .setVariables(safeVars)
+          .correlate();
+    } catch (MismatchingMessageCorrelationException ex) {
+      throw new WksConflictException(
+          "No active receiver for action '" + action + "' on process instance " + processInstanceId,
+          ex);
+    } catch (OptimisticLockingException ex) {
+      throw new WksConflictException(
+          "Process instance "
+              + processInstanceId
+              + " was modified by another transaction; reload and retry",
+          ex);
+    } catch (ProcessEngineException ex) {
+      // Genuine engine failure — DB/persistence/expression. Conflict-shaped errors are caught
+      // above by their explicit subtypes (Story 2.4 review — narrow conflict mapping).
+      throw new WksWorkflowEngineException(
+          "CIB seven signalTransition failed for processInstanceId=" + processInstanceId, ex);
+    }
+  }
+
+  /** Read the {@code archetype} camunda:property of a user task from the parsed BPMN model. */
+  private String readArchetype(String processDefinitionId, String taskDefinitionKey) {
+    if (processDefinitionId == null || taskDefinitionKey == null) {
+      return null;
+    }
+    BpmnModelInstance model;
+    try {
+      model = repositoryService.getBpmnModelInstance(processDefinitionId);
+    } catch (ProcessEngineException ex) {
+      throw new WksWorkflowEngineException(
+          "CIB seven BPMN model lookup failed for processDefinitionId=" + processDefinitionId, ex);
+    }
+    if (model == null) {
+      return null;
+    }
+    var element = model.getModelElementById(taskDefinitionKey);
+    if (!(element instanceof UserTask userTask)) {
+      return null;
+    }
+    ExtensionElements ext = userTask.getExtensionElements();
+    if (ext == null) {
+      return null;
+    }
+    Collection<CamundaProperties> blocks = ext.getChildElementsByType(CamundaProperties.class);
+    for (CamundaProperties block : blocks) {
+      for (CamundaProperty p : block.getCamundaProperties()) {
+        if ("archetype".equals(p.getCamundaName())) {
+          return p.getCamundaValue();
+        }
+      }
+    }
+    return null;
+  }
+
+  private static UUID parseCaseId(Object raw, String taskId) {
+    if (raw == null) {
+      throw new WksWorkflowEngineException(
+          "Process instance is missing the 'caseId' variable expected on every WKS process — task="
+              + taskId);
+    }
+    try {
+      return UUID.fromString(raw.toString());
+    } catch (IllegalArgumentException ex) {
+      throw new WksWorkflowEngineException(
+          "Process variable 'caseId' is not a UUID for task=" + taskId + " value=" + raw, ex);
+    }
+  }
+
+  private static UUID parseAssignee(String engineAssignee) {
+    if (engineAssignee == null || engineAssignee.isBlank()) {
+      return null;
+    }
+    try {
+      return UUID.fromString(engineAssignee);
+    } catch (IllegalArgumentException ex) {
+      // Engine accepts arbitrary string assignees; non-UUID strings are pre-2.4 / external. Map to
+      // null so the API surfaces "unassigned" rather than 500. Logged at debug to aid diagnosis.
+      log.debug(
+          "Task assignee '{}' is not a UUID; surfacing as unassigned in domain Task",
+          engineAssignee);
+      return null;
+    }
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
@@ -306,8 +306,7 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
     } catch (ProcessEngineException ex) {
       // Genuine engine failure (DB / persistence). Surface as 500 — the two client-fixable
       // conditions (not-found, already-claimed) are caught above by their explicit subtypes.
-      throw new WksWorkflowEngineException(
-          "CIB seven claimTask failed for taskId=" + taskId, ex);
+      throw new WksWorkflowEngineException("CIB seven claimTask failed for taskId=" + taskId, ex);
     }
   }
 

--- a/backend/src/main/java/com/wkspower/platform/engine/listeners/CaseStatusBpmnParseListener.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/listeners/CaseStatusBpmnParseListener.java
@@ -1,0 +1,31 @@
+package com.wkspower.platform.engine.listeners;
+
+import org.cibseven.bpm.engine.delegate.ExecutionListener;
+import org.cibseven.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener;
+import org.cibseven.bpm.engine.impl.pvm.process.ActivityImpl;
+import org.cibseven.bpm.engine.impl.pvm.process.ScopeImpl;
+import org.cibseven.bpm.engine.impl.util.xml.Element;
+
+/**
+ * Programmatic registration of {@link CaseStatusListener} on every parsed user task and end event.
+ * Wires once at engine boot via {@code CaseStatusEnginePlugin} (Story 2.4 Dev Notes §Listener
+ * registration) — keeps BPMN XML clean and prevents per-template drift.
+ */
+public class CaseStatusBpmnParseListener extends AbstractBpmnParseListener {
+
+  private final ExecutionListener listener;
+
+  public CaseStatusBpmnParseListener(ExecutionListener listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  public void parseUserTask(Element userTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    activity.addExecutionListener(ExecutionListener.EVENTNAME_END, listener);
+  }
+
+  @Override
+  public void parseEndEvent(Element endEventElement, ScopeImpl scope, ActivityImpl activity) {
+    activity.addExecutionListener(ExecutionListener.EVENTNAME_END, listener);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/engine/listeners/CaseStatusListener.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/listeners/CaseStatusListener.java
@@ -1,0 +1,180 @@
+package com.wkspower.platform.engine.listeners;
+
+import com.wkspower.platform.domain.event.CaseStatusChanged;
+import com.wkspower.platform.domain.port.CaseStatusUpdater;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.cibseven.bpm.engine.delegate.DelegateExecution;
+import org.cibseven.bpm.engine.delegate.ExecutionListener;
+import org.cibseven.bpm.model.bpmn.instance.EndEvent;
+import org.cibseven.bpm.model.bpmn.instance.ExtensionElements;
+import org.cibseven.bpm.model.bpmn.instance.FlowElement;
+import org.cibseven.bpm.model.bpmn.instance.UserTask;
+import org.cibseven.bpm.model.bpmn.instance.cibseven.CamundaProperties;
+import org.cibseven.bpm.model.bpmn.instance.cibseven.CamundaProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Engine-callback adapter that fires on user-task and end-event {@code end} events. Reads the
+ * {@code caseId} process variable, resolves the next status (per Story 2.4 Dev Notes §What counts
+ * as a status boundary), updates {@code cases.status} via the {@link CaseStatusUpdater} port, and
+ * publishes a {@link CaseStatusChanged} domain event.
+ *
+ * <p>The listener participates in the engine's transaction — a thrown exception rolls back both the
+ * engine state and the case-row update atomically (Story 2.4 AC5). Per Story 2.4 Dev Notes
+ * §Engine-callback hexagonal pattern, NO direct JPA writes happen here — the JPA adapter implements
+ * the port and runs inside the same transaction.
+ *
+ * <p>This listener is registered against every parsed user task and end event by {@link
+ * CaseStatusBpmnParseListener}.
+ */
+@Component
+public class CaseStatusListener implements ExecutionListener {
+
+  private static final Logger log = LoggerFactory.getLogger(CaseStatusListener.class);
+
+  private final CaseStatusUpdater caseStatusUpdater;
+  private final EventPublisher eventPublisher;
+  private final Clock clock;
+
+  public CaseStatusListener(
+      CaseStatusUpdater caseStatusUpdater, EventPublisher eventPublisher, Clock clock) {
+    this.caseStatusUpdater = caseStatusUpdater;
+    this.eventPublisher = eventPublisher;
+    this.clock = clock;
+  }
+
+  @Override
+  public void notify(DelegateExecution execution) {
+    Object caseIdRaw = execution.getVariable("caseId");
+    if (caseIdRaw == null) {
+      // Not a WKS-managed process — silently no-op so embedded test fixtures and admin BPMNs
+      // without our convention don't trip.
+      return;
+    }
+    UUID caseId;
+    try {
+      caseId = UUID.fromString(caseIdRaw.toString());
+    } catch (IllegalArgumentException ex) {
+      log.warn(
+          "CaseStatusListener: 'caseId' variable is not a UUID (value={}); skipping update",
+          caseIdRaw);
+      return;
+    }
+
+    String currentElementId = execution.getCurrentActivityId();
+    FlowElement element = execution.getBpmnModelElementInstance();
+    String newStatus = resolveNewStatus(execution, element, currentElementId);
+    if (newStatus == null || newStatus.isBlank()) {
+      // Nothing meaningful to write — e.g. user-task end with no further active activity (parallel
+      // gateway race) or end-event with no derivable id.
+      return;
+    }
+
+    Optional<String> previous = caseStatusUpdater.updateStatus(caseId, newStatus);
+    if (previous.isEmpty()) {
+      // Engine fired the listener for a process whose case row is missing — likely a partial-state
+      // create that did not persist. Avoid emitting a CaseStatusChanged for a non-existent case
+      // (Story 2.4 review).
+      log.warn(
+          "CaseStatusListener: no case row for caseId={} (process={}) — skipping event publish",
+          caseId,
+          execution.getProcessInstanceId());
+      return;
+    }
+    // Publish only after the engine transaction commits — subscribers must not observe a status
+    // change that the engine subsequently rolls back (Story 2.4 review decision 1).
+    Instant now = clock.now();
+    String processInstanceId = execution.getProcessInstanceId();
+    UUID committedCaseId = caseId;
+    String committedNewStatus = newStatus;
+    String committedPrevious = previous.orElse(null);
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              eventPublisher.publish(
+                  new CaseStatusChanged(
+                      committedCaseId,
+                      committedPrevious,
+                      committedNewStatus,
+                      processInstanceId,
+                      now));
+            }
+          });
+    } else {
+      // Test harnesses (or any path that runs the listener outside a Spring TX) — fall back to
+      // synchronous publication so behaviour is observable. Production always has a TX bound.
+      eventPublisher.publish(
+          new CaseStatusChanged(
+              committedCaseId, committedPrevious, committedNewStatus, processInstanceId, now));
+    }
+  }
+
+  /**
+   * Per Story 2.4 Dev Notes §What counts as a status boundary:
+   *
+   * <ul>
+   *   <li>End event: status is the end-event's {@code camunda:property name="status"} when present,
+   *       otherwise the element id.
+   *   <li>User task end: peek the next active activity via the runtime service and use its id.
+   * </ul>
+   */
+  private static String resolveNewStatus(
+      DelegateExecution execution, FlowElement element, String currentElementId) {
+    if (element instanceof EndEvent endEvent) {
+      String declared = readStatusProperty(endEvent.getExtensionElements());
+      return declared != null ? declared : currentElementId;
+    }
+    if (element instanceof UserTask) {
+      List<String> active =
+          execution
+              .getProcessEngineServices()
+              .getRuntimeService()
+              .getActiveActivityIds(execution.getProcessInstanceId());
+      // The current user task is still listed as active during the 'end' event (the engine has
+      // not removed it yet). Filter it out and pick the first remaining activity — matches the
+      // Phase 0 convention of "next active activity id is the new status".
+      List<String> remaining =
+          active.stream().filter(id -> id != null && !id.equals(currentElementId)).toList();
+      if (remaining.size() > 1) {
+        // TODO(Story 2.5/2.7): parallel-gateway fork — multiple sibling activities are active and
+        // findFirst() picks one non-deterministically. Reject parallel forks in BpmnValidator or
+        // adopt a composite status when this is first exercised by a real fixture.
+        log.warn(
+            "CaseStatusListener: process {} has {} simultaneously active activities after"
+                + " user-task end ({}); status mapping is non-deterministic — picking first",
+            execution.getProcessInstanceId(),
+            remaining.size(),
+            remaining);
+      }
+      return remaining.stream().findFirst().orElse(null);
+    }
+    return null;
+  }
+
+  private static String readStatusProperty(ExtensionElements ext) {
+    if (ext == null) {
+      return null;
+    }
+    Collection<CamundaProperties> blocks = ext.getChildElementsByType(CamundaProperties.class);
+    for (CamundaProperties block : blocks) {
+      for (CamundaProperty p : block.getCamundaProperties()) {
+        if ("status".equals(p.getCamundaName())) {
+          return p.getCamundaValue();
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
@@ -12,6 +12,7 @@ import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
 import com.wkspower.platform.domain.port.WorkflowEngine;
 import com.wkspower.platform.domain.service.CaseService;
 import com.wkspower.platform.domain.service.ConfigService;
+import com.wkspower.platform.domain.service.TaskService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,6 +33,11 @@ public class ConfigServiceConfig {
       EventPublisher eventPublisher) {
     return new ConfigService(
         source, registrar, reader, bpmnValidator, workflowEngine, eventPublisher);
+  }
+
+  @Bean
+  public TaskService wksTaskService(WorkflowEngine workflowEngine) {
+    return new TaskService(workflowEngine);
   }
 
   @Bean

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ProcessDefinitionKeyCache.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ProcessDefinitionKeyCache.java
@@ -2,37 +2,115 @@ package com.wkspower.platform.infrastructure.config;
 
 import com.wkspower.platform.domain.event.ConfigDeployed;
 import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
+import com.wkspower.platform.infrastructure.persistence.entity.CaseTypeDeploymentEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseTypeDeploymentJpaRepository;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
- * In-memory mapping of {@code caseTypeId → processDefinitionKey}. Populated by listening to {@code
- * ConfigDeployed} events from {@code ConfigService.deploy} and {@code CaseTypeStartupLoader}. Reads
- * are lock-free via {@link ConcurrentHashMap}.
+ * Write-through cache mapping {@code caseTypeId → processDefinitionKey}. The hot path is a
+ * lock-free {@link ConcurrentHashMap} read; misses fall back to the JPA-backed {@code
+ * case_type_deployments} table populated on every {@link ConfigDeployed} event.
  *
- * <p>Phase 0 trade-off: the cache is rebuilt at boot from the startup-loader's deploy events, so a
- * cold start always re-publishes every observed mapping. If an operator deploys a case-type via
- * HTTP and then restarts the JVM without the YAML on disk, the case-type stays registered (via
- * persistence) but the cache loses the key — Story 2.4 will need a persistent mapping if that
- * restart-survival case becomes load-bearing.
+ * <p>Story 2.4 folded debt #1: before this story the cache was in-memory only, so a JVM restart
+ * lost the mapping for a case-type that had been admin-deployed without YAML on disk. The Flyway
+ * table {@code case_type_deployments} (V202604270001) makes the mapping durable; this class hides
+ * the table behind the {@link ProcessDefinitionKeyResolver} port so callers don't change.
  */
 @Component
 class ProcessDefinitionKeyCache implements ProcessDefinitionKeyResolver {
 
-  private final Map<String, String> keysByCaseTypeId = new ConcurrentHashMap<>();
+  private static final Logger log = LoggerFactory.getLogger(ProcessDefinitionKeyCache.class);
 
-  @EventListener
-  public void onConfigDeployed(ConfigDeployed event) {
-    if (event.processDefinitionKey() != null) {
-      keysByCaseTypeId.put(event.caseTypeId(), event.processDefinitionKey());
+  private final Map<String, String> keysByCaseTypeId = new ConcurrentHashMap<>();
+  private final CaseTypeDeploymentJpaRepository repository;
+
+  ProcessDefinitionKeyCache(CaseTypeDeploymentJpaRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Populate the cache from the durable mapping after the application context is fully ready.
+   * Driven by {@link ApplicationReadyEvent} (rather than {@code @PostConstruct}) so that (a) the
+   * Spring transactional proxy is wired by the time we touch JPA, and (b) any {@link
+   * ConfigDeployed} event already fired during boot has had a chance to populate the cache —
+   * {@code putIfAbsent} avoids clobbering an entry the deploy stream has already advanced past
+   * the row we are about to read (Story 2.4 review).
+   */
+  @EventListener(ApplicationReadyEvent.class)
+  @Transactional(readOnly = true)
+  public void hydrateFromDatabase() {
+    int hydrated = 0;
+    for (CaseTypeDeploymentEntity row : repository.findAll()) {
+      String previous =
+          keysByCaseTypeId.putIfAbsent(row.getCaseTypeId(), row.getProcessDefinitionKey());
+      if (previous == null) {
+        hydrated++;
+      }
     }
+    if (hydrated > 0) {
+      log.info(
+          "ProcessDefinitionKeyCache hydrated {} caseType→processDefinitionKey rows", hydrated);
+    }
+  }
+
+  /**
+   * On every successful deploy: write the mapping through to the table (upsert by primary key) and
+   * update the in-memory cache. The repository's {@code save} performs the upsert because the
+   * primary key is the caller-supplied {@code caseTypeId}.
+   */
+  @EventListener
+  @Transactional
+  public void onConfigDeployed(ConfigDeployed event) {
+    if (event.processDefinitionKey() == null) {
+      return;
+    }
+    Instant deployedAt = event.timestamp() == null ? Instant.now() : event.timestamp();
+    String deploymentId = event.deploymentId() == null ? "" : event.deploymentId();
+    repository
+        .findById(event.caseTypeId())
+        .ifPresentOrElse(
+            existing -> {
+              existing.setCaseTypeVersion(event.version());
+              existing.setProcessDefinitionKey(event.processDefinitionKey());
+              existing.setDeploymentId(deploymentId);
+              existing.setDeployedAt(deployedAt);
+              repository.save(existing);
+            },
+            () ->
+                repository.save(
+                    new CaseTypeDeploymentEntity(
+                        event.caseTypeId(),
+                        event.version(),
+                        event.processDefinitionKey(),
+                        deploymentId,
+                        deployedAt)));
+    keysByCaseTypeId.put(event.caseTypeId(), event.processDefinitionKey());
   }
 
   @Override
   public Optional<String> resolve(String caseTypeId) {
-    return Optional.ofNullable(keysByCaseTypeId.get(caseTypeId));
+    String cached = keysByCaseTypeId.get(caseTypeId);
+    if (cached != null) {
+      return Optional.of(cached);
+    }
+    // Cold-cache miss after boot — defensive fallback that re-reads the table. Hot-path stays
+    // lock-free; this branch only fires if the @PostConstruct hydration was bypassed (e.g. test
+    // harnesses that wire the bean manually) or the row landed after hydration via another node.
+    return repository
+        .findById(caseTypeId)
+        .map(
+            row -> {
+              keysByCaseTypeId.put(row.getCaseTypeId(), row.getProcessDefinitionKey());
+              return row.getProcessDefinitionKey();
+            });
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ProcessDefinitionKeyCache.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ProcessDefinitionKeyCache.java
@@ -41,9 +41,9 @@ class ProcessDefinitionKeyCache implements ProcessDefinitionKeyResolver {
    * Populate the cache from the durable mapping after the application context is fully ready.
    * Driven by {@link ApplicationReadyEvent} (rather than {@code @PostConstruct}) so that (a) the
    * Spring transactional proxy is wired by the time we touch JPA, and (b) any {@link
-   * ConfigDeployed} event already fired during boot has had a chance to populate the cache —
-   * {@code putIfAbsent} avoids clobbering an entry the deploy stream has already advanced past
-   * the row we are about to read (Story 2.4 review).
+   * ConfigDeployed} event already fired during boot has had a chance to populate the cache — {@code
+   * putIfAbsent} avoids clobbering an entry the deploy stream has already advanced past the row we
+   * are about to read (Story 2.4 review).
    */
   @EventListener(ApplicationReadyEvent.class)
   @Transactional(readOnly = true)

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/CaseStatusAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/CaseStatusAdapter.java
@@ -1,0 +1,43 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import com.wkspower.platform.domain.port.CaseStatusUpdater;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.infrastructure.persistence.entity.CaseEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseEntityRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA adapter for {@link CaseStatusUpdater}. Runs in {@link Propagation#MANDATORY} so it joins the
+ * existing engine transaction — when invoked from {@code CaseStatusListener} during BPMN execution,
+ * the engine and the row update commit (or roll back) atomically.
+ */
+@Component
+public class CaseStatusAdapter implements CaseStatusUpdater {
+
+  private final CaseEntityRepository repository;
+  private final Clock clock;
+
+  public CaseStatusAdapter(CaseEntityRepository repository, Clock clock) {
+    this.repository = repository;
+    this.clock = clock;
+  }
+
+  @Override
+  @Transactional(propagation = Propagation.MANDATORY)
+  public Optional<String> updateStatus(UUID caseId, String newStatus) {
+    Optional<CaseEntity> found = repository.findById(caseId);
+    if (found.isEmpty()) {
+      return Optional.empty();
+    }
+    CaseEntity entity = found.get();
+    String previous = entity.getStatus();
+    entity.setStatus(newStatus);
+    entity.setUpdatedAt(clock.now());
+    repository.save(entity);
+    return Optional.ofNullable(previous);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/CaseTypeDeploymentEntity.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/CaseTypeDeploymentEntity.java
@@ -1,0 +1,90 @@
+package com.wkspower.platform.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/**
+ * JPA entity for {@code case_type_deployments} (Story 2.4 folded debt #1). Stores the caseTypeId →
+ * processDefinitionKey mapping durably so {@code POST /api/cases} resolves a key for admin-deployed
+ * case types after a JVM restart, even when no YAML is on disk.
+ *
+ * <p>Does NOT extend {@link BaseJpaEntity} — the primary key is a string ({@code case_type_id})
+ * rather than a UUID, and there is no edit lifecycle (rows are upserted by the deploy event), so
+ * the shared audit columns and version field would be dead weight.
+ */
+@Entity
+@Table(name = "case_type_deployments")
+public class CaseTypeDeploymentEntity {
+
+  @Id
+  @Column(name = "case_type_id", length = 64, nullable = false)
+  private String caseTypeId;
+
+  @Column(name = "case_type_version", nullable = false)
+  private int caseTypeVersion;
+
+  @Column(name = "process_definition_key", length = 255, nullable = false)
+  private String processDefinitionKey;
+
+  @Column(name = "deployment_id", length = 64, nullable = false)
+  private String deploymentId;
+
+  @Column(name = "deployed_at", nullable = false)
+  private Instant deployedAt;
+
+  protected CaseTypeDeploymentEntity() {
+    // JPA
+  }
+
+  public CaseTypeDeploymentEntity(
+      String caseTypeId,
+      int caseTypeVersion,
+      String processDefinitionKey,
+      String deploymentId,
+      Instant deployedAt) {
+    this.caseTypeId = caseTypeId;
+    this.caseTypeVersion = caseTypeVersion;
+    this.processDefinitionKey = processDefinitionKey;
+    this.deploymentId = deploymentId;
+    this.deployedAt = deployedAt;
+  }
+
+  public String getCaseTypeId() {
+    return caseTypeId;
+  }
+
+  public int getCaseTypeVersion() {
+    return caseTypeVersion;
+  }
+
+  public void setCaseTypeVersion(int caseTypeVersion) {
+    this.caseTypeVersion = caseTypeVersion;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getDeploymentId() {
+    return deploymentId;
+  }
+
+  public void setDeploymentId(String deploymentId) {
+    this.deploymentId = deploymentId;
+  }
+
+  public Instant getDeployedAt() {
+    return deployedAt;
+  }
+
+  public void setDeployedAt(Instant deployedAt) {
+    this.deployedAt = deployedAt;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseTypeDeploymentJpaRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseTypeDeploymentJpaRepository.java
@@ -1,0 +1,13 @@
+package com.wkspower.platform.infrastructure.persistence.repository;
+
+import com.wkspower.platform.infrastructure.persistence.entity.CaseTypeDeploymentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Spring Data JPA repository for {@link CaseTypeDeploymentEntity}. Story 2.4 folded debt #1 — used
+ * by {@code ProcessDefinitionKeyCache} as a write-through layer over a durable mapping, so
+ * admin-deployed case types resolve to a process-definition key after a JVM restart even with no
+ * YAML on disk.
+ */
+public interface CaseTypeDeploymentJpaRepository
+    extends JpaRepository<CaseTypeDeploymentEntity, String> {}

--- a/backend/src/main/resources/db/migration/common/V202604270001__case_type_deployments.sql
+++ b/backend/src/main/resources/db/migration/common/V202604270001__case_type_deployments.sql
@@ -1,0 +1,21 @@
+-- Story 2.4 (folded debt #1) — Persistent case-type → process-definition mapping.
+-- Solves the cold-start window where ProcessDefinitionKeyCache (in-memory only, populated by the
+-- ConfigDeployed event stream) lost the mapping after a JVM restart for a case-type that was
+-- admin-deployed via HTTP without a YAML file on disk. With this table the cache becomes a
+-- write-through layer over a durable mapping, so POST /api/cases never 500s on cold start for
+-- admin-deployed case types.
+
+CREATE TABLE case_type_deployments (
+    case_type_id           VARCHAR(64)              PRIMARY KEY,
+    case_type_version      INTEGER                  NOT NULL,
+    process_definition_key VARCHAR(255)             NOT NULL,
+    deployment_id          VARCHAR(64)              NOT NULL,
+    deployed_at            TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT case_type_deployments_version_positive
+        CHECK (case_type_version >= 1)
+);
+
+-- Reverse lookup index: occasional ops need "which case type advertises this processDefinitionKey?"
+-- Cheap to add now while the table is empty; harder later (Story 2.4 review).
+CREATE INDEX idx_case_type_deployments_process_definition_key
+    ON case_type_deployments (process_definition_key);

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
@@ -1,0 +1,210 @@
+package com.wkspower.platform.api.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wkspower.platform.api.GlobalExceptionHandler;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.CaseService;
+import com.wkspower.platform.security.AuthenticatedUser;
+import com.wkspower.platform.security.CaseTypePermissionEvaluator;
+import com.wkspower.platform.security.JwtAuthenticationFilter;
+import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SecurityConfig;
+import com.wkspower.platform.security.WksUserPrincipal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** Slice test for {@link CaseController#transition}. Covers Story 2.4 AC1 contract. */
+@WebMvcTest(CaseController.class)
+@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@ActiveProfiles("dev")
+class CaseTransitionControllerTest {
+
+  private static final UUID ACTOR_ID = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-04-26T10:00:00Z");
+
+  @Autowired MockMvc mockMvc;
+
+  @MockitoBean(name = "wksCaseService")
+  CaseService caseService;
+
+  @MockitoBean(name = "caseTypePermissionEvaluator")
+  CaseTypePermissionEvaluator evaluator;
+
+  @MockitoBean JwtTokenProvider jwtTokenProvider;
+  @MockitoBean UserRepository userRepository;
+
+  @Test
+  void transitionReturns200WithUpdatedCase() throws Exception {
+    Case existing = sampleCase("open");
+    Case advanced = withStatus(existing, "review");
+    when(caseService.findById(existing.id())).thenReturn(existing);
+    when(evaluator.hasVerb(any(), eq("loan-application"), eq("transition"))).thenReturn(true);
+    when(caseService.transition(eq(existing.id()), eq("submit"), any(), eq(ACTOR_ID)))
+        .thenReturn(advanced);
+    when(caseService.requireCaseType(eq("loan-application"))).thenReturn(loanType());
+
+    mockMvc
+        .perform(
+            post("/api/cases/" + existing.id() + "/transition")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"action\":\"submit\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.status").value("review"));
+  }
+
+  @Test
+  void transitionReturns403WhenVerbDenied() throws Exception {
+    Case existing = sampleCase("open");
+    when(caseService.findById(existing.id())).thenReturn(existing);
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(false);
+
+    mockMvc
+        .perform(
+            post("/api/cases/" + existing.id() + "/transition")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"action\":\"submit\"}"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.error.code").value("WKS-API-403"));
+  }
+
+  @Test
+  void transitionReturns404WhenCaseUnknown() throws Exception {
+    UUID id = UUID.randomUUID();
+    when(caseService.findById(id)).thenThrow(new WksNotFoundException("not found"));
+
+    mockMvc
+        .perform(
+            post("/api/cases/" + id + "/transition")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"action\":\"submit\"}"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void transitionReturns409WhenEngineRejects() throws Exception {
+    Case existing = sampleCase("open");
+    when(caseService.findById(existing.id())).thenReturn(existing);
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+    when(caseService.transition(eq(existing.id()), anyString(), any(), any()))
+        .thenThrow(new WksConflictException("no enabled receiver"));
+
+    mockMvc
+        .perform(
+            post("/api/cases/" + existing.id() + "/transition")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"action\":\"unknown\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.error.code").value("WKS-RTM-409"));
+  }
+
+  @Test
+  void transitionReturns400WhenActionMissing() throws Exception {
+    Case existing = sampleCase("open");
+    when(caseService.findById(existing.id())).thenReturn(existing);
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+
+    mockMvc
+        .perform(
+            post("/api/cases/" + existing.id() + "/transition")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  // ---- helpers -----------------------------------------------------------
+
+  private static Case sampleCase(String status) {
+    return new Case(
+        UUID.randomUUID(),
+        "loan-application",
+        1,
+        status,
+        null,
+        Map.of("name", "Asha"),
+        "pi-1",
+        NOW,
+        ACTOR_ID,
+        NOW,
+        0L);
+  }
+
+  private static Case withStatus(Case c, String status) {
+    return new Case(
+        c.id(),
+        c.caseTypeId(),
+        c.caseTypeVersion(),
+        status,
+        c.assignee(),
+        c.data(),
+        c.processInstanceId(),
+        c.createdAt(),
+        c.createdBy(),
+        c.updatedAt(),
+        c.version());
+  }
+
+  private static CaseTypeConfig loanType() {
+    return new CaseTypeConfig(
+        "loan-application",
+        "Loan Application",
+        1,
+        null,
+        new WorkflowRef("loan-application.bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(
+            new StatusDefinition("open", "Open", StatusColor.ZINC),
+            new StatusDefinition("review", "Review", StatusColor.AMBER)),
+        List.of("name"),
+        List.of(
+            new RoleDefinition(
+                "officer", List.of(Permission.VIEW, Permission.CREATE, Permission.TRANSITION))));
+  }
+
+  private static org.springframework.test.web.servlet.request.RequestPostProcessor officerAuth() {
+    AuthenticatedUser user = new AuthenticatedUser(ACTOR_ID, "officer@x", Set.of("officer"));
+    WksUserPrincipal principal = new WksUserPrincipal(user);
+    Authentication auth =
+        new UsernamePasswordAuthenticationToken(
+            principal,
+            principal.getPassword(),
+            List.of(new SimpleGrantedAuthority("ROLE_officer")));
+    return authentication(auth);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/api/controller/TaskControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/TaskControllerTest.java
@@ -1,0 +1,241 @@
+package com.wkspower.platform.api.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wkspower.platform.api.GlobalExceptionHandler;
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.model.Task;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.TaskService;
+import com.wkspower.platform.security.AuthenticatedUser;
+import com.wkspower.platform.security.CaseTypePermissionEvaluator;
+import com.wkspower.platform.security.JwtAuthenticationFilter;
+import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SecurityConfig;
+import com.wkspower.platform.security.WksUserPrincipal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Slice test for {@link TaskController}. Covers complete + claim contract incl. all error codes.
+ */
+@WebMvcTest(TaskController.class)
+@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@ActiveProfiles("dev")
+class TaskControllerTest {
+
+  private static final UUID ACTOR_ID = UUID.randomUUID();
+  private static final UUID CASE_ID = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-04-26T10:00:00Z");
+
+  @Autowired MockMvc mockMvc;
+
+  @MockitoBean(name = "wksTaskService")
+  TaskService taskService;
+
+  @MockitoBean(name = "caseTypePermissionEvaluator")
+  CaseTypePermissionEvaluator evaluator;
+
+  @MockitoBean Clock clock;
+
+  @MockitoBean JwtTokenProvider jwtTokenProvider;
+  @MockitoBean UserRepository userRepository;
+
+  // ---- POST /api/tasks/{id}/complete -------------------------------------
+
+  @Test
+  void completeReturns200AndCarriesArchetype() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("draft_section", null));
+    when(evaluator.hasVerb(any(), eq("loan-application"), eq("transition"))).thenReturn(true);
+    when(taskService.complete(eq("t1"), any(), eq(ACTOR_ID)))
+        .thenReturn(sampleTask("draft_section", null));
+    when(clock.now()).thenReturn(NOW);
+
+    mockMvc
+        .perform(
+            post("/api/tasks/t1/complete")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"variables\":{\"approved\":true}}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.taskId").value("t1"))
+        .andExpect(jsonPath("$.data.archetype").value("draft_section"))
+        .andExpect(jsonPath("$.data.caseId").value(CASE_ID.toString()));
+  }
+
+  @Test
+  void completeWithEmptyBodyWorks() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("submit_for_processing", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+    when(taskService.complete(eq("t1"), any(), any()))
+        .thenReturn(sampleTask("submit_for_processing", null));
+    when(clock.now()).thenReturn(NOW);
+
+    mockMvc
+        .perform(post("/api/tasks/t1/complete").with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.archetype").value("submit_for_processing"));
+  }
+
+  @Test
+  void completeReturns403WhenVerbDenied() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("draft_section", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(false);
+
+    mockMvc
+        .perform(post("/api/tasks/t1/complete").with(officerAuth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.error.code").value("WKS-API-403"));
+  }
+
+  @Test
+  void completeReturns404WhenTaskUnknown() throws Exception {
+    when(taskService.findById("nope")).thenThrow(new WksNotFoundException("task missing"));
+
+    mockMvc
+        .perform(post("/api/tasks/nope/complete").with(officerAuth()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("WKS-API-404"));
+  }
+
+  @Test
+  void completeReturns409WhenEngineConflict() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("draft_section", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+    when(taskService.complete(eq("t1"), any(), any()))
+        .thenThrow(new WksConflictException("already completed"));
+
+    mockMvc
+        .perform(post("/api/tasks/t1/complete").with(officerAuth()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.error.code").value("WKS-RTM-409"));
+  }
+
+  @Test
+  void completeReturnsArchetypeForBusinessFinal() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("business_final", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+    when(taskService.complete(eq("t1"), any(), any()))
+        .thenReturn(sampleTask("business_final", null));
+    when(clock.now()).thenReturn(NOW);
+
+    mockMvc
+        .perform(post("/api/tasks/t1/complete").with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.archetype").value("business_final"));
+  }
+
+  // ---- POST /api/tasks/{id}/claim ----------------------------------------
+
+  @Test
+  void claimReturns200WithAssignee() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("draft_section", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+    when(taskService.claim(eq("t1"), eq(ACTOR_ID)))
+        .thenReturn(sampleTask("draft_section", ACTOR_ID));
+    when(clock.now()).thenReturn(NOW);
+
+    mockMvc
+        .perform(post("/api/tasks/t1/claim").with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.assignee").value(ACTOR_ID.toString()));
+  }
+
+  @Test
+  void claimSurfacesSubmitForProcessingArchetype() throws Exception {
+    // Story 2.4 Task 6.3 — every archetype must propagate on the claim response.
+    when(taskService.findById("t1")).thenReturn(sampleTask("submit_for_processing", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+    when(taskService.claim(eq("t1"), eq(ACTOR_ID)))
+        .thenReturn(sampleTask("submit_for_processing", ACTOR_ID));
+    when(clock.now()).thenReturn(NOW);
+
+    mockMvc
+        .perform(post("/api/tasks/t1/claim").with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.archetype").value("submit_for_processing"));
+  }
+
+  @Test
+  void claimSurfacesBusinessFinalArchetype() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("business_final", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+    when(taskService.claim(eq("t1"), eq(ACTOR_ID)))
+        .thenReturn(sampleTask("business_final", ACTOR_ID));
+    when(clock.now()).thenReturn(NOW);
+
+    mockMvc
+        .perform(post("/api/tasks/t1/claim").with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.archetype").value("business_final"));
+  }
+
+  @Test
+  void claimReturns409WhenAlreadyClaimed() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("draft_section", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+    when(taskService.claim(eq("t1"), any())).thenThrow(new WksConflictException("already claimed"));
+
+    mockMvc
+        .perform(post("/api/tasks/t1/claim").with(officerAuth()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.error.code").value("WKS-RTM-409"));
+  }
+
+  @Test
+  void claimReturns404WhenUnknownTask() throws Exception {
+    when(taskService.findById("nope")).thenThrow(new WksNotFoundException("task missing"));
+
+    mockMvc
+        .perform(post("/api/tasks/nope/claim").with(officerAuth()))
+        .andExpect(status().isNotFound());
+  }
+
+  // ---- helpers -----------------------------------------------------------
+
+  private static Task sampleTask(String archetype, UUID assignee) {
+    return new Task(
+        "t1",
+        "pi-1",
+        CASE_ID,
+        "loan-application",
+        "draft",
+        "Draft",
+        assignee,
+        archetype,
+        NOW,
+        null);
+  }
+
+  private static org.springframework.test.web.servlet.request.RequestPostProcessor officerAuth() {
+    AuthenticatedUser user = new AuthenticatedUser(ACTOR_ID, "officer@x", Set.of("officer"));
+    WksUserPrincipal principal = new WksUserPrincipal(user);
+    Authentication auth =
+        new UsernamePasswordAuthenticationToken(
+            principal,
+            principal.getPassword(),
+            List.of(new SimpleGrantedAuthority("ROLE_officer")));
+    return authentication(auth);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/architecture/ArchitectureTest.java
+++ b/backend/src/test/java/com/wkspower/platform/architecture/ArchitectureTest.java
@@ -59,6 +59,55 @@ class ArchitectureTest {
   }
 
   @Test
+  void taskDomainHasNoSpringOrEngineImports() {
+    // Story 2.4 AC8 — explicit gate on the new task-domain types. Covered by the blanket
+    // domainHasNoFrameworkImports rule; this rule pins it specifically so a regression surfaces a
+    // Story-2.4-attributable failure message.
+    noClasses()
+        .that()
+        .haveSimpleName("Task")
+        .or()
+        .haveSimpleName("TaskService")
+        .should()
+        .dependOnClassesThat()
+        .resideInAnyPackage("org.springframework..", "org.cibseven..")
+        .because(
+            "Task domain model + TaskService stay framework-free — Story 2.4 AC8. CIB seven types"
+                + " never reach domain code; the engine adapter translates engine exceptions into"
+                + " WksConflictException / WksNotFoundException at the boundary.")
+        .check(CLASSES);
+  }
+
+  @Test
+  void onlyEngineAdapterAndListenersImportTheEngineDelegateApi() {
+    // Story 2.4 AC8 — the engine-callback hexagonal pattern requires that ONLY the engine adapter
+    // (CibSevenWorkflowEngine + CaseStatusEnginePlugin) and engine/listeners/* hold imports of
+    // org.cibseven.bpm.engine.delegate.* (the API CIB seven calls into via reflection).
+    // Everything else goes through the WorkflowEngine port + the CaseStatusUpdater port.
+    //
+    // Scope is narrower than ..engine.. on purpose (Story 2.4 review): a regression that adds a
+    // delegate import to a sibling class under engine/ (e.g. engine/CibSevenJobAdapter) would
+    // otherwise pass the rule.
+    noClasses()
+        .that()
+        .resideOutsideOfPackage("..engine.listeners..")
+        .and()
+        .haveSimpleNameNotEndingWith("WorkflowEngine")
+        .and()
+        .haveSimpleNameNotEndingWith("EnginePlugin")
+        .and()
+        .haveSimpleNameNotEndingWith("BpmnParseListener")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("org.cibseven.bpm.engine.delegate..")
+        .because(
+            "ExecutionListener + DelegateExecution are engine-callback types — they belong inside"
+                + " CibSevenWorkflowEngine, CaseStatusEnginePlugin, the BpmnParseListener, and"
+                + " engine/listeners/ (the CaseStatusListener). Story 2.4 AC8.")
+        .check(CLASSES);
+  }
+
+  @Test
   void apiAndSecurityDoNotDependOnPersistenceEntities() {
     noClasses()
         .that()

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
@@ -298,6 +298,21 @@ class CaseServiceTest {
       if (failure != null) throw failure;
       return returnedPi;
     }
+
+    @Override
+    public Optional<com.wkspower.platform.domain.model.Task> findTask(String taskId) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void completeTask(String taskId, Map<String, Object> variables) {}
+
+    @Override
+    public void claimTask(String taskId, UUID userId) {}
+
+    @Override
+    public void signalTransition(
+        String processInstanceId, String action, Map<String, Object> variables) {}
   }
 
   private static final class StubPublisher implements EventPublisher {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
@@ -212,10 +212,10 @@ class ConfigServiceDeployTest {
 
   /**
    * Folded debt #2 — Story 2.4 review decision 4. The per-{@code caseTypeId} mutex in {@code
-   * ConfigService.deploy} must serialize concurrent deploys of the same id so that the
-   * {@code reader.find → registrar.register → workflowEngine.deploy} window is atomic. A
-   * deterministic two-thread test (latch-coordinated, not stress) is the way to assert the lock
-   * actually holds — a stress test would be flaky and architecturally redundant.
+   * ConfigService.deploy} must serialize concurrent deploys of the same id so that the {@code
+   * reader.find → registrar.register → workflowEngine.deploy} window is atomic. A deterministic
+   * two-thread test (latch-coordinated, not stress) is the way to assert the lock actually holds —
+   * a stress test would be flaky and architecturally redundant.
    */
   @Test
   void concurrentDeploysOfSameCaseTypeAreSerialized() throws Exception {
@@ -243,7 +243,11 @@ class ConfigServiceDeployTest {
             int n = deployCount.incrementAndGet();
             concurrentInDeploy.decrementAndGet();
             return new DeploymentResult(
-                "deployment-" + n, request.processDefinitionKey(), "procDef-" + n, 1, Instant.now());
+                "deployment-" + n,
+                request.processDefinitionKey(),
+                "procDef-" + n,
+                1,
+                Instant.now());
           }
 
           @Override
@@ -272,7 +276,8 @@ class ConfigServiceDeployTest {
         };
 
     ConfigService svc =
-        new ConfigService(source, registrar, new StubReader(), bpmn, engine, new RecordingPublisher());
+        new ConfigService(
+            source, registrar, new StubReader(), bpmn, engine, new RecordingPublisher());
 
     ExecutorService pool = Executors.newFixedThreadPool(2);
     try {
@@ -280,7 +285,8 @@ class ConfigServiceDeployTest {
       // Wait until thread A is parked inside engine.deploy holding the per-id lock.
       assertThat(insideEngineDeploy.await(2, TimeUnit.SECONDS)).isTrue();
       Future<DeployResult> b = pool.submit(() -> svc.deploy(YAML_BYTES, BPMN_BYTES, "thread-b"));
-      // Give B a chance to attempt to enter; if the lock is broken it would barge into engine.deploy.
+      // Give B a chance to attempt to enter; if the lock is broken it would barge into
+      // engine.deploy.
       Thread.sleep(100);
       assertThat(concurrentInDeploy.get())
           .as("Thread B must NOT have entered engine.deploy while A holds the per-caseTypeId lock")

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
@@ -33,6 +33,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -202,6 +208,96 @@ class ConfigServiceDeployTest {
     assertThat(registrar.removed).contains(incoming.id());
   }
 
+  // ---- folded debt #2: per-caseTypeId deploy serialization (Story 2.4 Task 7.2) ----------
+
+  /**
+   * Folded debt #2 — Story 2.4 review decision 4. The per-{@code caseTypeId} mutex in {@code
+   * ConfigService.deploy} must serialize concurrent deploys of the same id so that the
+   * {@code reader.find → registrar.register → workflowEngine.deploy} window is atomic. A
+   * deterministic two-thread test (latch-coordinated, not stress) is the way to assert the lock
+   * actually holds — a stress test would be flaky and architecturally redundant.
+   */
+  @Test
+  void concurrentDeploysOfSameCaseTypeAreSerialized() throws Exception {
+    StubSource source = new StubSource(ValidationResult.ok(caseType()));
+    StubBpmn bpmn = new StubBpmn(BpmnValidationResult.ok("applicationProcess"));
+    StubRegistrar registrar = new StubRegistrar();
+    AtomicInteger concurrentInDeploy = new AtomicInteger(0);
+    AtomicInteger maxObservedConcurrency = new AtomicInteger(0);
+    CountDownLatch insideEngineDeploy = new CountDownLatch(1);
+    CountDownLatch holdInEngineDeploy = new CountDownLatch(1);
+    AtomicInteger deployCount = new AtomicInteger(0);
+
+    WorkflowEngine engine =
+        new WorkflowEngine() {
+          @Override
+          public DeploymentResult deploy(DeploymentRequest request) {
+            int now = concurrentInDeploy.incrementAndGet();
+            maxObservedConcurrency.updateAndGet(prev -> Math.max(prev, now));
+            insideEngineDeploy.countDown();
+            try {
+              holdInEngineDeploy.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+            int n = deployCount.incrementAndGet();
+            concurrentInDeploy.decrementAndGet();
+            return new DeploymentResult(
+                "deployment-" + n, request.processDefinitionKey(), "procDef-" + n, 1, Instant.now());
+          }
+
+          @Override
+          public Optional<DeploymentInfo> latestDeployment(String key) {
+            return Optional.empty();
+          }
+
+          @Override
+          public String startProcessInstance(String key, Map<String, Object> vars) {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public Optional<com.wkspower.platform.domain.model.Task> findTask(String taskId) {
+            return Optional.empty();
+          }
+
+          @Override
+          public void completeTask(String taskId, Map<String, Object> variables) {}
+
+          @Override
+          public void claimTask(String taskId, java.util.UUID userId) {}
+
+          @Override
+          public void signalTransition(String pid, String action, Map<String, Object> vars) {}
+        };
+
+    ConfigService svc =
+        new ConfigService(source, registrar, new StubReader(), bpmn, engine, new RecordingPublisher());
+
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      Future<DeployResult> a = pool.submit(() -> svc.deploy(YAML_BYTES, BPMN_BYTES, "thread-a"));
+      // Wait until thread A is parked inside engine.deploy holding the per-id lock.
+      assertThat(insideEngineDeploy.await(2, TimeUnit.SECONDS)).isTrue();
+      Future<DeployResult> b = pool.submit(() -> svc.deploy(YAML_BYTES, BPMN_BYTES, "thread-b"));
+      // Give B a chance to attempt to enter; if the lock is broken it would barge into engine.deploy.
+      Thread.sleep(100);
+      assertThat(concurrentInDeploy.get())
+          .as("Thread B must NOT have entered engine.deploy while A holds the per-caseTypeId lock")
+          .isEqualTo(1);
+      holdInEngineDeploy.countDown();
+      a.get(2, TimeUnit.SECONDS);
+      b.get(2, TimeUnit.SECONDS);
+    } finally {
+      pool.shutdown();
+    }
+
+    assertThat(maxObservedConcurrency.get())
+        .as("Per-caseTypeId lock must serialize concurrent deploys (max concurrency = 1)")
+        .isEqualTo(1);
+    assertThat(deployCount.get()).isEqualTo(2);
+  }
+
   // ---- helpers + stubs ---------------------------------------------------
 
   private static ValidationResult invalidYaml(String code, String msg) {
@@ -341,6 +437,21 @@ class ConfigServiceDeployTest {
         String processDefinitionKey, java.util.Map<String, Object> variables) {
       throw new UnsupportedOperationException("not exercised by ConfigServiceDeployTest");
     }
+
+    @Override
+    public Optional<com.wkspower.platform.domain.model.Task> findTask(String taskId) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void completeTask(String taskId, java.util.Map<String, Object> variables) {}
+
+    @Override
+    public void claimTask(String taskId, java.util.UUID userId) {}
+
+    @Override
+    public void signalTransition(
+        String processInstanceId, String action, java.util.Map<String, Object> variables) {}
   }
 
   private static final class RecordingPublisher implements EventPublisher {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/TaskServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/TaskServiceTest.java
@@ -1,0 +1,296 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.exception.WksValidationException;
+import com.wkspower.platform.domain.model.Task;
+import com.wkspower.platform.domain.port.WorkflowEngine;
+import com.wkspower.platform.domain.workflow.DeploymentInfo;
+import com.wkspower.platform.domain.workflow.DeploymentRequest;
+import com.wkspower.platform.domain.workflow.DeploymentResult;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-Java enumeration of {@code TaskService} branches. No Spring context, no engine — every
+ * collaborator is a hand-rolled stub.
+ */
+class TaskServiceTest {
+
+  private static final UUID ACTOR = UUID.randomUUID();
+  private static final UUID CASE = UUID.randomUUID();
+  private static final Instant NOW = Instant.parse("2026-04-26T10:00:00Z");
+
+  @Test
+  void findByIdReturnsTaskWhenEngineFindsIt() {
+    Task task = sampleTask("t1");
+    StubEngine engine = new StubEngine();
+    engine.tasks.put("t1", task);
+
+    Task found = new TaskService(engine).findById("t1");
+
+    assertThat(found.id()).isEqualTo("t1");
+    assertThat(found.archetype()).isEqualTo("draft_section");
+  }
+
+  @Test
+  void findByIdThrows404WhenEngineEmpty() {
+    assertThatThrownBy(() -> new TaskService(new StubEngine()).findById("missing"))
+        .isInstanceOf(WksNotFoundException.class);
+  }
+
+  @Test
+  void completeRetainsSnapshotAndCallsEngineComplete() {
+    Task task = sampleTask("t1");
+    StubEngine engine = new StubEngine();
+    engine.tasks.put("t1", task);
+
+    Task returned = new TaskService(engine).complete("t1", Map.of("k", "v"), ACTOR);
+
+    assertThat(returned.id()).isEqualTo("t1");
+    assertThat(returned.archetype()).isEqualTo("draft_section");
+    assertThat(engine.completed).hasSize(1);
+    assertThat(engine.completed.get(0).id).isEqualTo("t1");
+    assertThat(engine.completed.get(0).variables).containsEntry("k", "v");
+  }
+
+  @Test
+  void completeThrows404WhenSnapshotMissing() {
+    assertThatThrownBy(() -> new TaskService(new StubEngine()).complete("none", Map.of(), ACTOR))
+        .isInstanceOf(WksNotFoundException.class);
+  }
+
+  @Test
+  void completeNullVariablesAreCoercedToEmpty() {
+    Task task = sampleTask("t1");
+    StubEngine engine = new StubEngine();
+    engine.tasks.put("t1", task);
+
+    new TaskService(engine).complete("t1", null, ACTOR);
+
+    assertThat(engine.completed.get(0).variables).isEmpty();
+  }
+
+  @Test
+  void completeRejectsCompletionByNonAssignee() {
+    // Story 2.4 review — AC2 assignee enforcement. A task assigned to user X cannot be completed
+    // by user Y even if Y holds the `transition` verb.
+    UUID otherUser = UUID.randomUUID();
+    Task assignedToOther =
+        new Task(
+            "t1",
+            "pi-1",
+            CASE,
+            "loan-application",
+            "draft",
+            "Draft",
+            otherUser,
+            "draft_section",
+            NOW,
+            null);
+    StubEngine engine = new StubEngine();
+    engine.tasks.put("t1", assignedToOther);
+
+    assertThatThrownBy(() -> new TaskService(engine).complete("t1", Map.of(), ACTOR))
+        .isInstanceOf(WksConflictException.class)
+        .hasMessageContaining("assigned to another user");
+    assertThat(engine.completed)
+        .as("engine.complete must NOT be called when assignee mismatch is detected")
+        .isEmpty();
+  }
+
+  @Test
+  void completeAllowsAssigneeToComplete() {
+    // Same actor as assignee — happy path of the AC2 contract.
+    Task assignedToActor =
+        new Task(
+            "t1",
+            "pi-1",
+            CASE,
+            "loan-application",
+            "draft",
+            "Draft",
+            ACTOR,
+            "draft_section",
+            NOW,
+            null);
+    StubEngine engine = new StubEngine();
+    engine.tasks.put("t1", assignedToActor);
+
+    new TaskService(engine).complete("t1", Map.of(), ACTOR);
+
+    assertThat(engine.completed).hasSize(1);
+  }
+
+  @Test
+  void completeRejectsReservedProcessVariables() {
+    // Story 2.4 review — variable-injection guard. caseId/caseTypeId/taskAssignee/caseStatus
+    // would let a caller corrupt another case's status row via the listener.
+    Task task = sampleTask("t1");
+    StubEngine engine = new StubEngine();
+    engine.tasks.put("t1", task);
+
+    assertThatThrownBy(
+            () ->
+                new TaskService(engine)
+                    .complete("t1", Map.of("caseId", UUID.randomUUID().toString()), ACTOR))
+        .isInstanceOf(WksValidationException.class)
+        .hasMessageContaining("reserved");
+    assertThat(engine.completed)
+        .as("engine.complete must NOT be called when reserved variables are supplied")
+        .isEmpty();
+  }
+
+  @Test
+  void completePropagatesEngineConflict() {
+    Task task = sampleTask("t1");
+    StubEngine engine = new StubEngine();
+    engine.tasks.put("t1", task);
+    engine.completeFailure = new WksConflictException("already completed");
+
+    assertThatThrownBy(() -> new TaskService(engine).complete("t1", Map.of(), ACTOR))
+        .isInstanceOf(WksConflictException.class);
+  }
+
+  @Test
+  void claimReturnsTaskAfterEngineClaim() {
+    StubEngine engine = new StubEngine();
+    engine.tasks.put("t1", sampleTask("t1"));
+    engine.afterClaim =
+        new Task(
+            "t1",
+            "pi-1",
+            CASE,
+            "loan-application",
+            "draft",
+            "Draft section",
+            ACTOR,
+            "draft_section",
+            NOW,
+            null);
+
+    Task claimed = new TaskService(engine).claim("t1", ACTOR);
+
+    assertThat(claimed.assignee()).isEqualTo(ACTOR);
+    assertThat(engine.claimed).hasSize(1);
+    assertThat(engine.claimed.get(0).userId).isEqualTo(ACTOR);
+  }
+
+  @Test
+  void claimPropagatesEngineConflict() {
+    StubEngine engine = new StubEngine();
+    engine.claimFailure = new WksConflictException("already claimed");
+
+    assertThatThrownBy(() -> new TaskService(engine).claim("t1", ACTOR))
+        .isInstanceOf(WksConflictException.class);
+  }
+
+  @Test
+  void claimThrows404WhenPostClaimSnapshotMissing() {
+    StubEngine engine = new StubEngine();
+    // claim succeeds, but the post-claim find returns empty (engine race)
+    engine.afterClaimMissing = true;
+
+    assertThatThrownBy(() -> new TaskService(engine).claim("t1", ACTOR))
+        .isInstanceOf(WksNotFoundException.class);
+  }
+
+  // ---- helpers -----------------------------------------------------------
+
+  private static Task sampleTask(String id) {
+    return new Task(
+        id,
+        "pi-1",
+        CASE,
+        "loan-application",
+        "draft",
+        "Draft section",
+        null,
+        "draft_section",
+        NOW,
+        null);
+  }
+
+  private static final class CompleteCall {
+    final String id;
+    final Map<String, Object> variables;
+
+    CompleteCall(String id, Map<String, Object> variables) {
+      this.id = id;
+      this.variables = variables;
+    }
+  }
+
+  private static final class ClaimCall {
+    final String id;
+    final UUID userId;
+
+    ClaimCall(String id, UUID userId) {
+      this.id = id;
+      this.userId = userId;
+    }
+  }
+
+  private static final class StubEngine implements WorkflowEngine {
+    final Map<String, Task> tasks = new HashMap<>();
+    final List<CompleteCall> completed = new ArrayList<>();
+    final List<ClaimCall> claimed = new ArrayList<>();
+    RuntimeException completeFailure;
+    RuntimeException claimFailure;
+    Task afterClaim;
+    boolean afterClaimMissing;
+
+    @Override
+    public DeploymentResult deploy(DeploymentRequest request) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<DeploymentInfo> latestDeployment(String key) {
+      return Optional.empty();
+    }
+
+    @Override
+    public String startProcessInstance(String key, Map<String, Object> variables) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Task> findTask(String taskId) {
+      if (afterClaim != null && !claimed.isEmpty()) {
+        return Optional.of(afterClaim);
+      }
+      if (afterClaimMissing && !claimed.isEmpty()) {
+        return Optional.empty();
+      }
+      return Optional.ofNullable(tasks.get(taskId));
+    }
+
+    @Override
+    public void completeTask(String taskId, Map<String, Object> variables) {
+      if (completeFailure != null) throw completeFailure;
+      completed.add(new CompleteCall(taskId, variables));
+    }
+
+    @Override
+    public void claimTask(String taskId, UUID userId) {
+      if (claimFailure != null) throw claimFailure;
+      claimed.add(new ClaimCall(taskId, userId));
+    }
+
+    @Override
+    public void signalTransition(
+        String processInstanceId, String action, Map<String, Object> variables) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/engine/CibSevenWorkflowEngineIT.java
+++ b/backend/src/test/java/com/wkspower/platform/engine/CibSevenWorkflowEngineIT.java
@@ -3,7 +3,10 @@ package com.wkspower.platform.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
+import com.wkspower.platform.domain.model.Task;
 import com.wkspower.platform.domain.port.WorkflowEngine;
 import com.wkspower.platform.domain.workflow.DeploymentInfo;
 import com.wkspower.platform.domain.workflow.DeploymentRequest;
@@ -139,6 +142,97 @@ class CibSevenWorkflowEngineIT {
     assertThat(pi)
         .as("Story 2.3 AC4: startProcessInstance returns a non-blank engine-assigned id")
         .isNotBlank();
+  }
+
+  // ---- Story 2.4 — task lifecycle + transition --------------------------
+
+  @Test
+  void findTaskReturnsEmptyWhenUnknown() {
+    assertThat(workflowEngine.findTask("does-not-exist")).isEmpty();
+  }
+
+  @Test
+  void findTaskReadsCaseIdAndArchetypeFromBpmn() {
+    UUID caseId = UUID.randomUUID();
+    String pi = startWithUserTask("find-task-process", caseId, "loan-application");
+
+    String taskId = currentTaskId(pi);
+    Optional<Task> resolved = workflowEngine.findTask(taskId);
+
+    assertThat(resolved).isPresent();
+    assertThat(resolved.get().caseId()).isEqualTo(caseId);
+    assertThat(resolved.get().caseTypeId()).isEqualTo("loan-application");
+    assertThat(resolved.get().taskDefinitionKey()).isEqualTo("draft");
+    assertThat(resolved.get().archetype()).isEqualTo("submit_for_processing");
+  }
+
+  @Test
+  void claimTaskAssignsThenSecondClaimConflicts() {
+    UUID caseId = UUID.randomUUID();
+    String pi = startWithUserTask("claim-process", caseId, "loan-application");
+    String taskId = currentTaskId(pi);
+    UUID userOne = UUID.randomUUID();
+    UUID userTwo = UUID.randomUUID();
+
+    workflowEngine.claimTask(taskId, userOne);
+    Optional<Task> claimed = workflowEngine.findTask(taskId);
+    assertThat(claimed).isPresent();
+    assertThat(claimed.get().assignee()).isEqualTo(userOne);
+
+    assertThatThrownBy(() -> workflowEngine.claimTask(taskId, userTwo))
+        .isInstanceOf(WksConflictException.class);
+  }
+
+  @Test
+  void claimUnknownTaskThrowsNotFound() {
+    assertThatThrownBy(() -> workflowEngine.claimTask("nope", UUID.randomUUID()))
+        .isInstanceOfAny(WksNotFoundException.class, WksConflictException.class);
+  }
+
+  @Test
+  void completeTaskRemovesItFromQuery() {
+    UUID caseId = UUID.randomUUID();
+    String pi = startWithUserTask("complete-process", caseId, "loan-application");
+    String taskId = currentTaskId(pi);
+
+    workflowEngine.completeTask(taskId, Map.of());
+
+    assertThat(workflowEngine.findTask(taskId)).isEmpty();
+  }
+
+  @Test
+  void completeUnknownTaskThrowsNotFound() {
+    assertThatThrownBy(() -> workflowEngine.completeTask("nope", Map.of()))
+        .isInstanceOf(WksNotFoundException.class);
+  }
+
+  @Test
+  void signalTransitionWithUnknownActionConflicts() {
+    UUID caseId = UUID.randomUUID();
+    String pi = startWithUserTask("signal-process", caseId, "loan-application");
+
+    assertThatThrownBy(() -> workflowEngine.signalTransition(pi, "no-such-message", Map.of()))
+        .isInstanceOf(WksConflictException.class);
+  }
+
+  private String startWithUserTask(String key, UUID caseId, String caseTypeId) {
+    byte[] bpmn = simpleBpmn(key).getBytes(StandardCharsets.UTF_8);
+    workflowEngine.deploy(new DeploymentRequest(key, key, bpmn, caseTypeId, 1));
+    return workflowEngine.startProcessInstance(
+        key, Map.of("caseId", caseId.toString(), "caseTypeId", caseTypeId));
+  }
+
+  private String currentTaskId(String processInstanceId) {
+    org.cibseven.bpm.engine.task.Task t =
+        processEngine
+            .getTaskService()
+            .createTaskQuery()
+            .processInstanceId(processInstanceId)
+            .singleResult();
+    if (t == null) {
+      throw new AssertionError("expected a single task on process instance " + processInstanceId);
+    }
+    return t.getId();
   }
 
   @Test

--- a/backend/src/test/java/com/wkspower/platform/engine/listeners/CaseStatusListenerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/engine/listeners/CaseStatusListenerTest.java
@@ -1,0 +1,150 @@
+package com.wkspower.platform.engine.listeners;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.wkspower.platform.domain.event.CaseStatusChanged;
+import com.wkspower.platform.domain.port.CaseStatusUpdater;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.cibseven.bpm.engine.ProcessEngineServices;
+import org.cibseven.bpm.engine.RuntimeService;
+import org.cibseven.bpm.engine.delegate.DelegateExecution;
+import org.cibseven.bpm.model.bpmn.instance.EndEvent;
+import org.cibseven.bpm.model.bpmn.instance.UserTask;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class CaseStatusListenerTest {
+
+  private static final Instant NOW = Instant.parse("2026-04-26T10:00:00Z");
+  private static final UUID CASE = UUID.randomUUID();
+
+  private final CaseStatusUpdater updater = mock(CaseStatusUpdater.class);
+  private final EventPublisher publisher = mock(EventPublisher.class);
+  private final Clock clock = () -> NOW;
+  private final CaseStatusListener listener = new CaseStatusListener(updater, publisher, clock);
+
+  @Test
+  void noOpWhenCaseIdVariableMissing() {
+    DelegateExecution exec = mock(DelegateExecution.class);
+    when(exec.getVariable("caseId")).thenReturn(null);
+
+    listener.notify(exec);
+
+    verify(updater, never()).updateStatus(any(), anyString());
+    verify(publisher, never()).publish(any());
+  }
+
+  @Test
+  void noOpWhenCaseIdNotUuid() {
+    DelegateExecution exec = mock(DelegateExecution.class);
+    when(exec.getVariable("caseId")).thenReturn("not-a-uuid");
+
+    listener.notify(exec);
+
+    verify(updater, never()).updateStatus(any(), anyString());
+  }
+
+  @Test
+  void endEventUsesElementIdWhenNoStatusProperty() {
+    EndEvent endEvent = mock(EndEvent.class);
+    when(endEvent.getExtensionElements()).thenReturn(null);
+
+    DelegateExecution exec = mock(DelegateExecution.class);
+    when(exec.getVariable("caseId")).thenReturn(CASE.toString());
+    when(exec.getCurrentActivityId()).thenReturn("approved");
+    when(exec.getProcessInstanceId()).thenReturn("pi-1");
+    when(exec.getBpmnModelElementInstance()).thenReturn(endEvent);
+    when(updater.updateStatus(eq(CASE), eq("approved"))).thenReturn(Optional.of("review"));
+
+    listener.notify(exec);
+
+    verify(updater).updateStatus(CASE, "approved");
+    ArgumentCaptor<Object> evt = ArgumentCaptor.forClass(Object.class);
+    verify(publisher).publish(evt.capture());
+    CaseStatusChanged published = (CaseStatusChanged) evt.getValue();
+    assertThat(published.caseId()).isEqualTo(CASE);
+    assertThat(published.oldStatus()).isEqualTo("review");
+    assertThat(published.newStatus()).isEqualTo("approved");
+    assertThat(published.processInstanceId()).isEqualTo("pi-1");
+    assertThat(published.timestamp()).isEqualTo(NOW);
+  }
+
+  @Test
+  void userTaskEndPicksNextActiveActivity() {
+    UserTask userTask = mock(UserTask.class);
+
+    RuntimeService runtimeService = mock(RuntimeService.class);
+    when(runtimeService.getActiveActivityIds("pi-1")).thenReturn(List.of("draft", "review"));
+
+    ProcessEngineServices services = mock(ProcessEngineServices.class);
+    when(services.getRuntimeService()).thenReturn(runtimeService);
+
+    DelegateExecution exec = mock(DelegateExecution.class);
+    when(exec.getVariable("caseId")).thenReturn(CASE.toString());
+    when(exec.getCurrentActivityId()).thenReturn("draft");
+    when(exec.getProcessInstanceId()).thenReturn("pi-1");
+    when(exec.getBpmnModelElementInstance()).thenReturn(userTask);
+    when(exec.getProcessEngineServices()).thenReturn(services);
+    when(updater.updateStatus(CASE, "review")).thenReturn(Optional.of("draft"));
+
+    listener.notify(exec);
+
+    verify(updater).updateStatus(CASE, "review");
+    verify(publisher).publish(any(CaseStatusChanged.class));
+  }
+
+  @Test
+  void noEventPublishedWhenCaseRowMissing() {
+    // Story 2.4 review — listener fires for a process whose case row never persisted (engine-first
+    // create with DB write that didn't commit). Should skip event publication so subscribers don't
+    // see CaseStatusChanged for a non-existent case.
+    EndEvent endEvent = mock(EndEvent.class);
+    when(endEvent.getExtensionElements()).thenReturn(null);
+
+    DelegateExecution exec = mock(DelegateExecution.class);
+    when(exec.getVariable("caseId")).thenReturn(CASE.toString());
+    when(exec.getCurrentActivityId()).thenReturn("approved");
+    when(exec.getProcessInstanceId()).thenReturn("pi-1");
+    when(exec.getBpmnModelElementInstance()).thenReturn(endEvent);
+    when(updater.updateStatus(CASE, "approved")).thenReturn(Optional.empty());
+
+    listener.notify(exec);
+
+    verify(updater).updateStatus(CASE, "approved");
+    verify(publisher, never()).publish(any());
+  }
+
+  @Test
+  void userTaskEndWithNoOtherActiveActivityIsNoOp() {
+    UserTask userTask = mock(UserTask.class);
+
+    RuntimeService runtimeService = mock(RuntimeService.class);
+    when(runtimeService.getActiveActivityIds("pi-1")).thenReturn(List.of("draft"));
+
+    ProcessEngineServices services = mock(ProcessEngineServices.class);
+    when(services.getRuntimeService()).thenReturn(runtimeService);
+
+    DelegateExecution exec = mock(DelegateExecution.class);
+    when(exec.getVariable("caseId")).thenReturn(CASE.toString());
+    when(exec.getCurrentActivityId()).thenReturn("draft");
+    when(exec.getProcessInstanceId()).thenReturn("pi-1");
+    when(exec.getBpmnModelElementInstance()).thenReturn(userTask);
+    when(exec.getProcessEngineServices()).thenReturn(services);
+
+    listener.notify(exec);
+
+    verify(updater, never()).updateStatus(any(), anyString());
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoaderTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoaderTest.java
@@ -124,6 +124,21 @@ class CaseTypeStartupLoaderTest {
           public String startProcessInstance(String key, java.util.Map<String, Object> variables) {
             return "pi-noop";
           }
+
+          @Override
+          public Optional<com.wkspower.platform.domain.model.Task> findTask(String taskId) {
+            return Optional.empty();
+          }
+
+          @Override
+          public void completeTask(String taskId, java.util.Map<String, Object> variables) {}
+
+          @Override
+          public void claimTask(String taskId, java.util.UUID userId) {}
+
+          @Override
+          public void signalTransition(
+              String processInstanceId, String action, java.util.Map<String, Object> variables) {}
         },
         event -> {});
   }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ProcessDefinitionKeyPersistenceIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ProcessDefinitionKeyPersistenceIT.java
@@ -1,0 +1,109 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.event.ConfigDeployed;
+import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
+import com.wkspower.platform.infrastructure.persistence.entity.CaseTypeDeploymentEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseTypeDeploymentJpaRepository;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * Story 2.4 folded debt #1 — verifies the {@code case_type_deployments} mapping is durable across
+ * the in-memory cache. Two cases:
+ *
+ * <ul>
+ *   <li>Pre-existing row in {@code case_type_deployments} resolves via the {@code
+ *       ProcessDefinitionKeyResolver} (proves boot-time hydration / cold-cache fallback).
+ *   <li>{@link ConfigDeployed} event upserts the table AND the cache, so subsequent calls hit the
+ *       in-memory map.
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+class ProcessDefinitionKeyPersistenceIT {
+
+  @TempDir static Path dbDir;
+
+  @DynamicPropertySource
+  static void props(DynamicPropertyRegistry reg) {
+    reg.add(
+        "spring.datasource.url",
+        () -> "jdbc:h2:file:" + dbDir.resolve("pdk-it") + ";DB_CLOSE_DELAY=-1");
+    reg.add("wks.case-types.dir", () -> "");
+    reg.add("camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+  }
+
+  @Autowired private CaseTypeDeploymentJpaRepository deployments;
+  @Autowired private ProcessDefinitionKeyResolver resolver;
+  @Autowired private ApplicationEventPublisher events;
+
+  @Test
+  void rowsLandedDirectlyAreResolvedViaCacheFallback() {
+    CaseTypeDeploymentEntity row =
+        new CaseTypeDeploymentEntity(
+            "pre-seeded", 1, "pre-seeded-process", "deployment-x", Instant.now());
+    deployments.save(row);
+
+    assertThat(resolver.resolve("pre-seeded")).contains("pre-seeded-process");
+  }
+
+  @Test
+  void configDeployedEventPersistsAndPopulatesCache() {
+    events.publishEvent(
+        new ConfigDeployed(
+            "event-deployed",
+            2,
+            "deployment-y",
+            "event-deployed-process",
+            "procDef-y",
+            null,
+            Instant.now()));
+
+    assertThat(resolver.resolve("event-deployed")).contains("event-deployed-process");
+    assertThat(deployments.findById("event-deployed"))
+        .as("durable mapping persisted via the event listener")
+        .isPresent()
+        .hasValueSatisfying(
+            row -> {
+              assertThat(row.getCaseTypeVersion()).isEqualTo(2);
+              assertThat(row.getProcessDefinitionKey()).isEqualTo("event-deployed-process");
+              assertThat(row.getDeploymentId()).isEqualTo("deployment-y");
+            });
+  }
+
+  @Test
+  void configDeployedSecondTimeUpdatesExistingRow() {
+    events.publishEvent(
+        new ConfigDeployed(
+            "double-deployed",
+            1,
+            "deployment-1",
+            "double-deployed-process-v1",
+            "procDef-1",
+            null,
+            Instant.now()));
+    events.publishEvent(
+        new ConfigDeployed(
+            "double-deployed",
+            2,
+            "deployment-2",
+            "double-deployed-process-v2",
+            "procDef-2",
+            null,
+            Instant.now()));
+
+    assertThat(resolver.resolve("double-deployed")).contains("double-deployed-process-v2");
+    assertThat(deployments.findById("double-deployed"))
+        .hasValueSatisfying(row -> assertThat(row.getCaseTypeVersion()).isEqualTo(2));
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseAuthIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseAuthIT.java
@@ -104,6 +104,41 @@ class CaseAuthIT {
   }
 
   @Test
+  void transitionEndpointRequiresJwt() {
+    // Anonymous POST to transition → 401 (proves the JwtAuthenticationFilter sits in front of the
+    // 2.4 endpoint). Closes Story 2.2 deferred "JWT role-prefix integration coverage on a
+    // role-gated mutation".
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+    ResponseEntity<String> resp =
+        rest.exchange(
+            "/api/cases/" + UUID.randomUUID() + "/transition",
+            HttpMethod.POST,
+            new HttpEntity<>("{\"action\":\"submit\"}", headers),
+            String.class);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(resp.getBody()).contains("WKS-API-401");
+  }
+
+  @Test
+  void authenticatedTransitionAgainstUnknownCaseHits404() {
+    // Auth pipeline reaches the controller — unknown case-id 404s before the verb gate fires.
+    // Proves the JWT filter → WksUserPrincipal → handler chain works end-to-end on the new POST
+    // endpoint (the 401 path is covered above; this case proves auth passed all the way through).
+    String cookie = login(EMAIL);
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    ResponseEntity<String> resp =
+        rest.exchange(
+            "/api/cases/" + UUID.randomUUID() + "/transition",
+            HttpMethod.POST,
+            new HttpEntity<>("{\"action\":\"submit\"}", headers),
+            String.class);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
   void authenticatedRequestForUnknownCaseTypeReturnsForbidden() {
     String cookie = login(EMAIL);
 

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
@@ -13,15 +13,22 @@ import com.wkspower.platform.domain.config.model.RoleDefinition;
 import com.wkspower.platform.domain.config.model.StatusColor;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.event.CaseStatusChanged;
 import com.wkspower.platform.domain.event.ConfigDeployed;
 import com.wkspower.platform.domain.model.User;
 import com.wkspower.platform.domain.port.UserRepository;
 import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseEntityRepository;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.awaitility.Awaitility;
+import org.cibseven.bpm.engine.ProcessEngine;
 import org.cibseven.bpm.engine.RepositoryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,8 +36,12 @@ import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -49,6 +60,8 @@ import org.springframework.test.context.DynamicPropertySource;
  * CaseTypePermissionEvaluator} chain runs end-to-end.
  */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@org.springframework.test.context.ActiveProfiles("dev")
+@Import(CaseFlowIT.RecorderConfig.class)
 class CaseFlowIT {
 
   // Uses the seeded `admin` role (V202604170001) — the only role that exists out of the box. The
@@ -57,6 +70,7 @@ class CaseFlowIT {
   private static final String PASSWORD = "admin";
   private static final String CASE_TYPE_ID = "loan-application";
   private static final String PROCESS_KEY = "loan-application-flow";
+  private static final String TRANSITION_CASE_TYPE_ID = "case-transition-fixture";
 
   @TempDir static java.nio.file.Path dbDir;
 
@@ -76,8 +90,11 @@ class CaseFlowIT {
   @Autowired private PasswordEncoder encoder;
   @Autowired private CaseTypeRegistry registry;
   @Autowired private RepositoryService repositoryService;
+  @Autowired private ProcessEngine processEngine;
+  @Autowired private CaseEntityRepository caseEntities;
   @Autowired private ApplicationEventPublisher events;
   @Autowired private ObjectMapper json;
+  @Autowired private StatusEventRecorder recorder;
 
   @BeforeEach
   void setup() {
@@ -186,6 +203,143 @@ class CaseFlowIT {
         List.of(
             new RoleDefinition(
                 "admin", List.of(Permission.VIEW, Permission.CREATE, Permission.EDIT))));
+  }
+
+  // ---- Story 2.4 — full create → transition end-to-end ----------------
+
+  @Test
+  void createTransitionRoundTripUpdatesStatusAndPublishesEvent() throws Exception {
+    registerTransitionCaseType();
+    deployTransitionFixture();
+    String cookie = login();
+    recorder.events.clear();
+
+    // POST create — engine starts the process; user task `draft` becomes active.
+    ResponseEntity<String> created =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + TRANSITION_CASE_TYPE_ID + "\",\"data\":{\"name\":\"Asha\"}}");
+    assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    String caseId = json.readTree(created.getBody()).path("data").path("id").asText();
+    UUID caseUuid = UUID.fromString(caseId);
+
+    // The current user task is `draft`. Complete it through the public API so the listener fires.
+    String taskId =
+        processEngine
+            .getTaskService()
+            .createTaskQuery()
+            .processInstanceId(caseEntities.findById(caseUuid).orElseThrow().getProcessInstanceId())
+            .singleResult()
+            .getId();
+    ResponseEntity<String> completed =
+        exchange("/api/tasks/" + taskId + "/complete", HttpMethod.POST, cookie, "{}");
+    assertThat(completed.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(completed.getBody()).contains("\"archetype\":\"draft_section\"");
+
+    // POST transition correlates the `submit` message → process advances to the `approved` end
+    // event → CaseStatusListener writes status="approved" and publishes CaseStatusChanged.
+    long transitionStartNanos = System.nanoTime();
+    ResponseEntity<String> tx =
+        exchange(
+            "/api/cases/" + caseId + "/transition",
+            HttpMethod.POST,
+            cookie,
+            "{\"action\":\"submit\"}");
+    long transitionElapsedMs = (System.nanoTime() - transitionStartNanos) / 1_000_000L;
+    assertThat(tx.getStatusCode()).isEqualTo(HttpStatus.OK);
+    // Story 2.4 AC1 — transition wall-clock latency must be < 500 ms for the fixture process.
+    assertThat(transitionElapsedMs)
+        .as("Story 2.4 AC1 — POST /transition wall-clock latency must be < 500 ms")
+        .isLessThan(500L);
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(caseEntities.findById(caseUuid).orElseThrow().getStatus())
+                    .isEqualTo("approved"));
+
+    assertThat(recorder.events)
+        .anySatisfy(
+            evt -> {
+              assertThat(evt.caseId()).isEqualTo(caseUuid);
+              assertThat(evt.newStatus()).isEqualTo("approved");
+            });
+  }
+
+  private void registerTransitionCaseType() {
+    registry.register(transitionCaseType());
+  }
+
+  private void deployTransitionFixture() throws java.io.IOException {
+    byte[] bytes;
+    try (InputStream in = getClass().getResourceAsStream("/bpmn/case-transition-fixture.bpmn")) {
+      if (in == null) {
+        throw new IllegalStateException("BPMN fixture missing on classpath");
+      }
+      bytes = in.readAllBytes();
+    }
+    org.cibseven.bpm.engine.repository.Deployment deployment =
+        repositoryService
+            .createDeployment()
+            .name("transition-it-" + TRANSITION_CASE_TYPE_ID)
+            .addInputStream(
+                TRANSITION_CASE_TYPE_ID + ".bpmn", new java.io.ByteArrayInputStream(bytes))
+            .deploy();
+    String processDefinitionId =
+        repositoryService
+            .createProcessDefinitionQuery()
+            .deploymentId(deployment.getId())
+            .singleResult()
+            .getId();
+    events.publishEvent(
+        new ConfigDeployed(
+            TRANSITION_CASE_TYPE_ID,
+            1,
+            deployment.getId(),
+            TRANSITION_CASE_TYPE_ID,
+            processDefinitionId,
+            null,
+            Instant.now()));
+  }
+
+  private static CaseTypeConfig transitionCaseType() {
+    return new CaseTypeConfig(
+        TRANSITION_CASE_TYPE_ID,
+        "Case Transition Fixture",
+        1,
+        null,
+        new WorkflowRef(TRANSITION_CASE_TYPE_ID + ".bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(
+            new StatusDefinition("open", "Open", StatusColor.ZINC),
+            new StatusDefinition("approved", "Approved", StatusColor.EMERALD)),
+        List.of("name"),
+        List.of(
+            new RoleDefinition(
+                "admin",
+                List.of(
+                    Permission.VIEW, Permission.CREATE, Permission.EDIT, Permission.TRANSITION))));
+  }
+
+  /** Captures published CaseStatusChanged events so the test can assert listener firing. */
+  static class StatusEventRecorder {
+    final java.util.List<CaseStatusChanged> events = new CopyOnWriteArrayList<>();
+
+    @EventListener
+    public void on(CaseStatusChanged e) {
+      events.add(e);
+    }
+  }
+
+  @TestConfiguration
+  static class RecorderConfig {
+    @Bean
+    StatusEventRecorder statusEventRecorder() {
+      return new StatusEventRecorder();
+    }
   }
 
   private static String simpleBpmn(String key) {

--- a/backend/src/test/resources/bpmn/case-transition-fixture.bpmn
+++ b/backend/src/test/resources/bpmn/case-transition-fixture.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  targetNamespace="http://wkspower.com/bpmn/test"
+                  id="Definitions_case_transition_fixture">
+  <bpmn:message id="Message_submit" name="submit"/>
+  <bpmn:process id="case-transition-fixture" isExecutable="true" camunda:historyTimeToLive="30">
+    <bpmn:startEvent id="start"/>
+    <bpmn:userTask id="draft" name="Draft section">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="archetype" value="draft_section"/>
+        </camunda:properties>
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+    <bpmn:intermediateCatchEvent id="awaiting-submit" name="Awaiting submit">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_submit" messageRef="Message_submit"/>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="approved" name="Approved">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="status" value="approved"/>
+        </camunda:properties>
+      </bpmn:extensionElements>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="f1" sourceRef="start" targetRef="draft"/>
+    <bpmn:sequenceFlow id="f2" sourceRef="draft" targetRef="awaiting-submit"/>
+    <bpmn:sequenceFlow id="f3" sourceRef="awaiting-submit" targetRef="approved"/>
+  </bpmn:process>
+</bpmn:definitions>

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -160,6 +160,52 @@ allow-list is `[updatedAt, createdAt, status]`. The JSON `data` column is never 
 list path (server-side projection) — list rows carry only system columns plus the case-type's
 `listColumns` field projections.
 
+## Case transitions and tasks (Story 2.4)
+
+Three endpoints expose BPMN-driven case lifecycle. All three gate on the `transition` verb (per
+case-type YAML role grants).
+
+| Method | Path                                  | Verb gate    | Wire success                                          |
+| ------ | ------------------------------------- | ------------ | ----------------------------------------------------- |
+| `POST` | `/api/cases/{id}/transition`          | `transition` | `200 ApiResponse<CaseDto>` (post-transition state)    |
+| `POST` | `/api/tasks/{id}/complete`            | `transition` | `200 ApiResponse<TaskActionResponse>`                 |
+| `POST` | `/api/tasks/{id}/claim`               | `transition` | `200 ApiResponse<TaskActionResponse>` (with assignee) |
+
+`POST /api/cases/{id}/transition` body: `{ "action": "<bpmn-message-name>", "variables": { ... } }`.
+**Phase 0 supports message correlation only** — `action` is the BPMN message name attached to an
+`<bpmn:intermediateCatchEvent>`/`<bpmn:receiveTask>` of type `messageEventDefinition`. Signal-based
+transitions arrive in Story 8.2 if a real BPMN template requires them. Unknown / non-enabled
+actions surface `WKS-RTM-409` (no enabled receiver).
+
+`POST /api/tasks/{id}/complete` body: `{ "variables": { ... } }` (variables optional). Response:
+
+```json
+{
+  "data": {
+    "taskId": "engine-task-id",
+    "processInstanceId": null,
+    "caseId": "uuid",
+    "archetype": "draft_section | submit_for_processing | business_final",
+    "assignee": null,
+    "at": "2026-04-26T10:00:00Z"
+  }
+}
+```
+
+`archetype` is read from the user task's `<camunda:property name="archetype" .../>` and reflects
+the deploy-time invariant enforced by the BPMN validator (`WKS-CFG-020` / `WKS-CFG-021`); the
+runtime path does **not** re-validate. The frontend's `TaskLifecycleButton` (Story 2.8) uses this
+field to drive the three-layer async UI states defined in `architecture.md §Decision 9` — the
+backend never blocks on downstream BPMN work for `submit_for_processing`.
+
+`POST /api/tasks/{id}/claim` has no body. Response carries the new `assignee`. Already-claimed
+tasks (by anyone, including the same caller) surface `WKS-RTM-409`.
+
+Status changes are pushed by an engine-side `ExecutionListener` (`CaseStatusListener`) that fires
+on user-task and end-event commit. The listener writes `cases.status` through the
+`CaseStatusUpdater` port and publishes `CaseStatusChanged` via `EventPublisher`. Subscribers (audit
+log in Story 4.1, SSE bridge in Story 4.3) attach without touching this code.
+
 ## Interactive docs
 
 `GET /v3/api-docs` returns the OpenAPI 3 JSON; Swagger UI lives at `GET /swagger-ui/index.html`.


### PR DESCRIPTION
## Summary

- REST surface for case lifecycle: `POST /api/cases/{id}/transition`, `POST /api/tasks/{id}/complete`, `POST /api/tasks/{id}/claim`. Engine-side conflicts (already-completed, claimed-by-other, no-such-action) translate to `WKS-RTM-409`; unknown ids to `WKS-API-404`; permission failures to `WKS-API-403`.
- CIB-seven `ExecutionListener` wired via a `ProcessEnginePlugin` + `BpmnParseListener` updates `cases.status` atomically with the engine TX and publishes `CaseStatusChanged` via the `EventPublisher` port. Hexagonal pattern: listener → `CaseStatusUpdater` port → JPA adapter (no JPA inside the listener).
- Folded debt closed: persistent `case_type_deployments` table + write-through cache (closes 2-3 cold-start), per-`caseTypeId` deploy lock (closes 2-2 TOCTOU), `CaseFlowIT` + `CaseAuthIT` round-trips (closes 2-2/2-3 deferreds).

## Code review (applied this branch — 4 decisions resolved, 21 patches, 5 deferred-with-rationale)

- **Critical:** `TaskService.sanitiseVariables` rejects reserved engine variables (`caseId` / `caseTypeId` / `taskAssignee` / `caseStatus`) at both `/transition` and `/complete` to block cross-case status corruption via the listener.
- **AC2:** assignee enforcement in `TaskService.complete` (caller must equal `task.assignee`, or task must be unassigned).
- **Decision 1 → AFTER_COMMIT:** `CaseStatusListener` registers a `TransactionSynchronization` so subscribers never observe rolled-back transitions.
- **Decision 2 → defer + WARN:** parallel-gateway non-determinism in `resolveNewStatus` logs a `WARN` and the limitation is folded into deferred-work for Story 2.5/2.7.
- **Decision 3 → populate from snapshot:** `TaskActionResponse.processInstanceId` is no longer hard-coded `null` on either endpoint.
- **Decision 4 → deterministic test:** new `concurrentDeploysOfSameCaseTypeAreSerialized` (CountDownLatch-coordinated, no stress) closes Task 7.2.
- `CibSevenWorkflowEngine`: `signalTransition` no longer maps generic `ProcessEngineException` to 409; `findTask` returns `Optional.empty()` on variable-read TOCTOU instead of 500; explicit `TaskAlreadyClaimedException` translation in `completeTask`.
- `ConfigService`: `ConfigDeployed` published inside the per-`caseTypeId` lock; secondary `register()` failures logged at ERROR.
- `ProcessDefinitionKeyCache`: hydrate on `ApplicationReadyEvent` with `putIfAbsent` (replaces `@PostConstruct` with no-op `@Transactional`).
- ArchUnit rule for `engine.delegate` imports tightened from `..engine..` to specific class-name suffixes + `engine/listeners/`.
- Migration adds `CHECK (case_type_version >= 1)` and a `process_definition_key` index.
- `CaseFlowIT` enforces AC1 `< 500 ms` latency.

## Test plan

- [x] `mvn test` — 219 surefire tests pass (incl. 6 new tests added by review)
- [x] `mvn test -Dtest=ArchitectureTest` — 17 ArchUnit rules pass
- [x] `mvn verify` failsafe via pre-push hook — local CI mirror green (CaseFlowIT, CaseAuthIT, CibSevenWorkflowEngineIT, ProcessDefinitionKeyPersistenceIT, etc.)
- [x] Frontend lint + typecheck + test + build — pre-push hook green
- [x] Spotless — applied
- [ ] CI on this PR — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)