### PR TITLE
Story 2.7 — Case creation flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,7 +446,61 @@ Case types are declared as YAML files in a directory mounted into the container.
   to a single "N filters" pill that opens the chip list in a Radix Popover; empty narrowed
   state shows a single "Add filter" ghost button. Full-width variant unchanged from 2.5.
 
+### Forms (RHF + Zod + FormField) — Story 2.7
+
+- **Stack**: `react-hook-form@^7` + `zod@^3` + `@hookform/resolvers/zod`. RHF mode
+  `onBlur` + `reValidateMode: onChange` + `shouldFocusError: true` is the canonical
+  config — first error focuses on submit, then per-field rechecks are immediate.
+- **`<FormField>`** (`components/ui/FormField.tsx`): render-prop wrapper. Wires
+  `id` / `htmlFor` / `aria-invalid` / `aria-describedby` / `aria-required` from RHF
+  context automatically. Consumer renders the input via `children(fieldProps)` —
+  full control over input element + attrs, no kitchen-sink wrapper.
+- **`buildZodFromFieldDefs(fields, mode)`** (`lib/buildZodFromFieldDefs.ts`): pure
+  function. Reads case-type `FieldDefinition[]` (post-filter to `requiredOnCreate`
+  for `'create'` mode) and returns a `z.ZodObject` with per-type validation slots
+  mirrored (text → `.min(1).max(maxLength)`, number → `z.coerce.number().min().max()`,
+  date → `.regex(YYYY-MM-DD).refine(dateRange)`, select → `z.enum(options[].value)`,
+  checkbox → required-on-create boolean, file → `z.unknown().optional()` until
+  Story 3.1). Specific error message per slot from `i18n/en.json` (`cases.create.errors.*`).
+- **`<MutationButton>`** (`components/ui/MutationButton.tsx`): 4-state slice of
+  `TaskLifecycleButton` (`idle | confirming | confirmed | failed`). Presentational
+  only — parent drives transitions via `state` prop. Story 2.8 extends with
+  `processing` (5th state, 2s-without-confirmation timer) for task-completion
+  surfaces; the TS literal-union is forward-compatible.
+- **`LoginPage` is the reference pattern**. Read `pages/LoginPage.tsx` for the
+  canonical wiring of `FormProvider` + `useForm({resolver: zodResolver(schema)})` +
+  `<FormField>` + `<MutationButton>`. The case-creation dialog inherits the same
+  shape.
+- **Server errors via `setError`**. On 422 with `errors[].field` (`WKS-API-001`),
+  map onto RHF via `form.setError(fieldName, {type: 'server', message})` —
+  `pointerToField` on the backend guarantees `field` is the YAML-declared id, not
+  a JSON-Pointer fragment. Envelope-level errors (no field) render in a banner
+  above the form following the confidence-not-safety pattern: "Couldn't create
+  case. Your input is preserved. Try again or correct the highlighted fields."
+
 ## Change Log
+
+- 2026-04-27 — Story 2.7: Case Creation Flow — backend YAML grammar gains
+  `requiredOnCreate: bool` (default-on-omit = `required`), `WKS-CFG-013` reserved
+  for file-on-create warning (validator emits at `ValidationResult.warnings`,
+  startup loader logs at WARN level). Wire shape: `CaseTypeViewDto.fields[]`
+  widens from domain-record echo to flattened `FieldView` carrying every per-type
+  validation slot; `CaseTypeSummaryDto` gains `permissions: string[]` (caller's
+  verbs). New `CaseTypePermissionEvaluator.verbsOf` cheap look-up. Frontend:
+  `react-hook-form` + `zod` + `@hookform/resolvers` + `@radix-ui/react-select` +
+  `@radix-ui/react-checkbox` deps. Owned-source primitives `Dialog`, `Select`,
+  `Checkbox`, `Textarea` join `Tabs`/`Tooltip`/`Popover` shelf.
+  `components/ui/FormField.tsx` + `components/ui/MutationButton.tsx` (4-state
+  slice). `lib/buildZodFromFieldDefs.ts` (runtime Zod builder). `useCreateCase`
+  TanStack mutation primes detail cache + invalidates list, no auto-retry on 5xx.
+  `useUiStore.recentlyCreatedCaseIds` (6s TTL, SSR-safe). `NewCaseButton` +
+  `NewCaseDialog` mounted in workspace header — 0/1/≥2 case-type selector
+  behavior. `LoginPage` retrofitted to RHF + Zod as the reference pattern. 35
+  new i18n keys (`cases.create.*`, `common.lifecycle.*`, `login.errors.*`).
+  Closes 1.3 deferred-work entries (LoginPage RHF retrofit + FormField
+  aria-describedby) + 2.5 re-pinned `pointerToField` nested handling.
+  `CaseDataValidatorAdapter.pointerToField` package-private + `CaseTypeConfig`-
+  aware. ApiError carries `envelopeErrors[]` for multi-field 422 mapping.
 
 - 2026-04-26 — Story 2.6: Split-pane workspace and case detail — `CaseWorkspace` (two CSS
   states, URL-driven selection, J/K/Esc keyboard nav, focus management, responsive

--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseTypeController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseTypeController.java
@@ -60,7 +60,8 @@ public class CaseTypeController {
                         ct.displayName(),
                         ct.version(),
                         ct.statuses().size(),
-                        ct.fields().size()))
+                        ct.fields().size(),
+                        List.copyOf(evaluator.verbsOf(actor.authenticated(), ct.id()))))
             .toList();
     return ApiResponse.success(data);
   }

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeSummaryDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeSummaryDto.java
@@ -1,11 +1,27 @@
 package com.wkspower.platform.api.dto.response;
 
+import java.util.List;
+
 /**
  * Summary projection of a case type for {@code GET /api/case-types}. The case-type filter dropdown
  * (frontend Story 2.5) only needs {@code id} + {@code displayName}, but {@code statusCount} and
  * {@code fieldCount} are essentially free to compute and surface useful chrome for a future
  * case-type selector. Heavy fields ({@code fields[]}, {@code statuses[]}, {@code listColumns}) live
  * on {@link CaseTypeViewDto} for {@code GET /api/case-types/{id}}.
+ *
+ * <p>Story 2.7 adds {@link #permissions()} — the verbs the caller holds on this case-type. The
+ * frontend uses this to filter the Create-Case selector dropdown to only case-types where the user
+ * holds {@code create}, without an extra round-trip per case-type.
  */
 public record CaseTypeSummaryDto(
-    String id, String displayName, int version, int statusCount, int fieldCount) {}
+    String id,
+    String displayName,
+    int version,
+    int statusCount,
+    int fieldCount,
+    List<String> permissions) {
+
+  public CaseTypeSummaryDto {
+    permissions = permissions == null ? List.of() : List.copyOf(permissions);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
@@ -1,6 +1,6 @@
 package com.wkspower.platform.api.dto.response;
 
-import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
 import java.util.List;
 
@@ -11,11 +11,45 @@ import java.util.List;
  * <p>Roles and the workflow {@code bpmn} reference are intentionally NOT echoed — leaking the
  * role/permission matrix to the client would expose authorization metadata; the BPMN file path is
  * an internal concern.
+ *
+ * <p>Story 2.7 widens {@code fields[]} from {@code FieldDefinition} to {@link FieldView}: the
+ * frontend's runtime Zod builder ({@code lib/buildZodFromFieldDefs.ts}) needs every per-type
+ * validation slot ({@code minLength}, {@code maxLength}, {@code min}, {@code max}, {@code step},
+ * {@code options[]}, {@code requiredOnCreate}, etc.). The wire field names match the YAML grammar
+ * tokens exactly so the validation contract is one shape end-to-end.
  */
 public record CaseTypeViewDto(
     String id,
     String displayName,
     int version,
-    List<FieldDefinition> fields,
+    List<FieldView> fields,
     List<StatusDefinition> statuses,
-    List<String> listColumns) {}
+    List<String> listColumns) {
+
+  /**
+   * Wire-shape projection of {@code FieldDefinition} for the case-type detail endpoint. Every
+   * type-specific slot is nullable on the wire — only the slots relevant to {@link #type()} are
+   * populated. The frontend renderer dispatches on {@code type} and reads only the matching slots.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record FieldView(
+      String id,
+      String displayName,
+      String type,
+      boolean required,
+      boolean requiredOnCreate,
+      int order,
+      List<OptionView> options,
+      Integer minLength,
+      Integer maxLength,
+      Number min,
+      Number max,
+      Number step,
+      String dateMin,
+      String dateMax,
+      Long maxBytes,
+      List<String> allowedMimeTypes) {}
+
+  /** Wire-shape for a single {@code select}-field option. */
+  public record OptionView(String label, String value) {}
+}

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -3,9 +3,13 @@ package com.wkspower.platform.api.mapper;
 import com.wkspower.platform.api.dto.response.CaseDto;
 import com.wkspower.platform.api.dto.response.CaseSummaryDto;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto;
+import com.wkspower.platform.api.dto.response.CaseTypeViewDto.FieldView;
+import com.wkspower.platform.api.dto.response.CaseTypeViewDto.OptionView;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
 import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.model.CaseSummary;
+import java.util.List;
 
 /**
  * Domain-model → wire-DTO mapping for the case CRUD endpoints. Manual mapping (no MapStruct) per
@@ -50,8 +54,31 @@ public final class CaseDtoMapper {
         caseType.id(),
         caseType.displayName(),
         caseType.version(),
-        caseType.fields(),
+        caseType.fields().stream().map(CaseDtoMapper::toFieldView).toList(),
         caseType.statuses(),
         caseType.listColumns());
+  }
+
+  static FieldView toFieldView(FieldDefinition f) {
+    FieldDefinition.TypeSlots s = f.slots();
+    List<OptionView> options =
+        f.options().stream().map(o -> new OptionView(o.label(), o.value())).toList();
+    return new FieldView(
+        f.id(),
+        f.displayName(),
+        f.type().wire(),
+        f.required(),
+        f.requiredOnCreate(),
+        f.order(),
+        options,
+        s == null ? null : s.minLength(),
+        s == null ? null : s.maxLength(),
+        s == null ? null : s.min(),
+        s == null ? null : s.max(),
+        s == null ? null : s.step(),
+        s == null ? null : s.dateMin(),
+        s == null ? null : s.dateMax(),
+        s == null ? null : s.maxBytes(),
+        s == null || s.allowedMimeTypes() == null ? List.of() : s.allowedMimeTypes());
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/ValidationResult.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/ValidationResult.java
@@ -9,11 +9,18 @@ import java.util.Optional;
  * Outcome of running a case-type YAML through the loader + validator pipeline. An invariant holds:
  * exactly one of {@code errors.isEmpty()} and {@code config.isPresent()} is true — enforced at
  * construction so a caller can never encounter "no errors, no config".
+ *
+ * <p>Story 2.7 introduces {@link #warnings()} — non-blocking findings that the loader logs at WARN
+ * level but do not prevent the case-type from loading. Today only {@code WKS-CFG-013} (file field
+ * marked {@code requiredOnCreate}) populates this list. Existing callers that read {@link
+ * #errors()} see no behavior change.
  */
-public record ValidationResult(List<ErrorDetail> errors, Optional<CaseTypeConfig> config) {
+public record ValidationResult(
+    List<ErrorDetail> errors, List<ErrorDetail> warnings, Optional<CaseTypeConfig> config) {
 
   public ValidationResult {
     errors = List.copyOf(errors);
+    warnings = warnings == null ? List.of() : List.copyOf(warnings);
     if (errors.isEmpty() == config.isEmpty()) {
       throw new IllegalStateException(
           "ValidationResult invariant: exactly one of errors-empty and config-present must hold "
@@ -26,14 +33,22 @@ public record ValidationResult(List<ErrorDetail> errors, Optional<CaseTypeConfig
   }
 
   public static ValidationResult ok(CaseTypeConfig config) {
-    return new ValidationResult(List.of(), Optional.of(config));
+    return new ValidationResult(List.of(), List.of(), Optional.of(config));
+  }
+
+  public static ValidationResult ok(CaseTypeConfig config, List<ErrorDetail> warnings) {
+    return new ValidationResult(List.of(), warnings, Optional.of(config));
   }
 
   public static ValidationResult invalid(List<ErrorDetail> errors) {
-    return new ValidationResult(errors, Optional.empty());
+    return new ValidationResult(errors, List.of(), Optional.empty());
   }
 
   public boolean isInvalid() {
     return !errors.isEmpty();
+  }
+
+  public boolean hasWarnings() {
+    return !warnings.isEmpty();
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/FieldDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/FieldDefinition.java
@@ -7,18 +7,41 @@ import java.util.Optional;
  * One field on a case of this type. Immutable. Type-specific slots live in {@link TypeSlots} to
  * keep this record flat without exploding into seven subtypes — validation has already ensured only
  * the slots relevant to {@link #type} are populated by the time this record is built.
+ *
+ * <p>Story 2.7 introduces {@link #requiredOnCreate()} — controls whether the create-form dialog
+ * (driven by the case-type YAML) asks for this field at case creation time. Defaults to {@link
+ * #required()} when the YAML omits the slot, preserving backwards-compatible behavior for seed
+ * YAMLs that pre-date the grammar extension.
  */
 public record FieldDefinition(
     String id,
     String displayName,
     FieldType type,
     boolean required,
+    boolean requiredOnCreate,
     int order,
     List<FieldOption> options,
     TypeSlots slots) {
 
   public FieldDefinition {
     options = options == null ? List.of() : List.copyOf(options);
+  }
+
+  /**
+   * Backwards-compatible secondary constructor for callers (mostly tests + Story 2.1/2.2/2.3
+   * fixtures) that pre-date the {@code requiredOnCreate} grammar extension. Defaults {@code
+   * requiredOnCreate} to {@code required}, mirroring the YAML default-on-omit behavior in {@link
+   * com.wkspower.platform.infrastructure.config.ConfigValidator}.
+   */
+  public FieldDefinition(
+      String id,
+      String displayName,
+      FieldType type,
+      boolean required,
+      int order,
+      List<FieldOption> options,
+      TypeSlots slots) {
+    this(id, displayName, type, required, required, order, options, slots);
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -81,6 +81,13 @@ public enum ErrorCode {
    */
   WKS_CFG_012("WKS-CFG-012"),
   /**
+   * Case-type YAML marks a {@code file}-typed field as {@code requiredOnCreate: true} but file
+   * upload is not yet supported on the create form (closes in Story 3.1 — Document Upload). The
+   * case-type still loads; the validator emits this as a WARN-level finding so operators get a
+   * heads-up. Story 2.7 introduces this code.
+   */
+  WKS_CFG_013("WKS-CFG-013"),
+  /**
    * BPMN user task is missing the required {@code archetype} declaration in {@code
    * camunda:properties}. One per offending user task (Story 2.2).
    */

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseDataValidatorAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseDataValidatorAdapter.java
@@ -7,11 +7,13 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
 import com.wkspower.platform.domain.event.ConfigDeployed;
 import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.ErrorDetail;
 import com.wkspower.platform.domain.port.CaseDataValidator;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,7 +78,7 @@ class CaseDataValidatorAdapter implements CaseDataValidator {
 
     List<ErrorDetail> errors = new ArrayList<>();
     for (ValidationMessage m : messages) {
-      String field = pointerToField(m.getInstanceLocation().toString());
+      String field = pointerToField(m.getInstanceLocation().toString(), caseType);
       errors.add(ErrorDetail.ofField(ErrorCode.WKS_API_001.wire(), m.getMessage(), field));
     }
     return List.copyOf(errors);
@@ -99,17 +101,77 @@ class CaseDataValidatorAdapter implements CaseDataValidator {
 
   private record CacheKey(String caseTypeId, int version) {}
 
-  private static String pointerToField(String pointer) {
-    if (pointer == null || pointer.isEmpty() || "$".equals(pointer)) {
-      return null;
+  /**
+   * Resolves a networknt validator instance-location string (either JsonPath-style {@code $.foo} or
+   * JSON-Pointer-style {@code /data/foo} / {@code /foo/bar}) to the YAML-declared field id the
+   * frontend RHF form references. Phase 0 grammar is flat — there is no nested object schema — but
+   * the resolver is defensive against future schema evolution per Story 2.7 AC10.
+   *
+   * <p>Resolution rules (Story 2.7 AC10):
+   *
+   * <ol>
+   *   <li>Empty / root pointer → wire literal {@code "data"} (form-level violation).
+   *   <li>Strip the leading {@code $.} or {@code /} (and a literal {@code data/} or {@code data.}
+   *       segment — networknt uses both styles depending on schema-draft and version).
+   *   <li>If the remainder matches a top-level field id from the case-type, return it verbatim.
+   *   <li>Otherwise return the leaf path token (last {@code /}- or {@code .}-delimited segment) —
+   *       belt-and-braces fallback for nested validators that may surface in future drafts. Never
+   *       converts {@code /} to {@code .} since YAML field ids may contain {@code _}/{@code -} but
+   *       never {@code .}.
+   * </ol>
+   *
+   * <p>Package-private to keep the unit-test surface tight; previously {@code private static}.
+   */
+  static String pointerToField(String pointer, CaseTypeConfig caseType) {
+    if (pointer == null || pointer.isEmpty() || "$".equals(pointer) || "/".equals(pointer)) {
+      return "data";
     }
-    // networknt 1.5 uses JsonPath-style locations like "$.applicant_name". Strip the prefix.
-    if (pointer.startsWith("$.")) {
-      return pointer.substring(2);
+    String stripped = pointer;
+    if (stripped.startsWith("$.")) {
+      stripped = stripped.substring(2);
+    } else if (stripped.startsWith("$")) {
+      stripped = stripped.substring(1);
     }
-    if (pointer.startsWith("/")) {
-      return pointer.substring(1);
+    if (stripped.startsWith("/")) {
+      stripped = stripped.substring(1);
     }
-    return pointer;
+    // Strip a leading "data/" or "data." segment when the schema wraps payloads under /data.
+    if (stripped.startsWith("data/")) {
+      stripped = stripped.substring("data/".length());
+    } else if (stripped.startsWith("data.")) {
+      stripped = stripped.substring("data.".length());
+    } else if ("data".equals(stripped)) {
+      return "data";
+    }
+    if (stripped.isEmpty()) {
+      return "data";
+    }
+    Set<String> declared = declaredFieldIds(caseType);
+    if (declared.contains(stripped)) {
+      return stripped;
+    }
+    // Nested or unknown path: take the leaf segment as a best-effort. Only return it when it
+    // matches a YAML-declared field id — otherwise fall back to "data" so the frontend renders a
+    // form-level banner instead of setError on a non-existent RHF field (which RHF accepts
+    // silently, making the error vanish).
+    int slash = stripped.lastIndexOf('/');
+    int dot = stripped.lastIndexOf('.');
+    int cut = Math.max(slash, dot);
+    String leaf = cut >= 0 ? stripped.substring(cut + 1) : stripped;
+    if (leaf.isEmpty()) {
+      return "data";
+    }
+    return declared.contains(leaf) ? leaf : "data";
+  }
+
+  private static Set<String> declaredFieldIds(CaseTypeConfig caseType) {
+    if (caseType == null || caseType.fields() == null) {
+      return Set.of();
+    }
+    Set<String> ids = new LinkedHashSet<>();
+    for (FieldDefinition f : caseType.fields()) {
+      ids.add(f.id());
+    }
+    return ids;
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoader.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoader.java
@@ -230,6 +230,9 @@ public class CaseTypeStartupLoader {
       logErrors(yamlResult.errors(), file);
       return FileOutcome.yamlRejected();
     }
+    if (yamlResult.hasWarnings()) {
+      logWarnings(yamlResult.warnings(), file);
+    }
     CaseTypeConfig caseType = yamlResult.config().orElseThrow();
 
     DeployResult bpmnResult;
@@ -260,6 +263,18 @@ public class CaseTypeStartupLoader {
           .addKeyValue("errorField", e.field())
           .addKeyValue("line", e.line())
           .log("case-type validation error: {}", e.message());
+    }
+  }
+
+  /** Story 2.7 — log validator warnings (non-blocking findings, e.g. WKS-CFG-013) at WARN. */
+  private static void logWarnings(List<ErrorDetail> warnings, Path file) {
+    for (ErrorDetail w : warnings) {
+      log.atWarn()
+          .addKeyValue("wksErrorCode", w.code())
+          .addKeyValue("file", file.getFileName().toString())
+          .addKeyValue("warningField", w.field())
+          .addKeyValue("line", w.line())
+          .log("case-type validation warning: {}", w.message());
     }
   }
 

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -72,7 +72,8 @@ public class ConfigValidator {
           eb.error(ErrorCode.WKS_CFG_007, "description must be ≤ 400 characters", "description"));
     }
 
-    List<FieldDefinition> fields = checkFields(raw.fields(), eb, errors);
+    List<ErrorDetail> warnings = new ArrayList<>();
+    List<FieldDefinition> fields = checkFields(raw.fields(), eb, errors, warnings);
     List<StatusDefinition> statuses = checkStatuses(raw.statuses(), eb, errors);
     List<RoleDefinition> roles = checkRoles(raw.roles(), eb, errors);
     List<String> listColumns =
@@ -93,7 +94,7 @@ public class ConfigValidator {
             statuses,
             listColumns,
             roles);
-    return ValidationResult.ok(config);
+    return ValidationResult.ok(config, warnings);
   }
 
   // ---- per-section checks -------------------------------------------------
@@ -129,7 +130,10 @@ public class ConfigValidator {
   }
 
   private List<FieldDefinition> checkFields(
-      List<RawCaseTypeConfig.RawField> raws, ErrorBuilder eb, List<ErrorDetail> errors) {
+      List<RawCaseTypeConfig.RawField> raws,
+      ErrorBuilder eb,
+      List<ErrorDetail> errors,
+      List<ErrorDetail> warnings) {
     if (raws == null || raws.isEmpty()) {
       errors.add(eb.error(ErrorCode.WKS_CFG_001, "Required key missing: fields", "fields"));
       return List.of();
@@ -195,12 +199,27 @@ public class ConfigValidator {
       List<FieldOption> opts = checkFieldOptions(f, ft, base, eb, errors);
 
       if (idOk && hasDn && ft != null) {
+        boolean required = Boolean.TRUE.equals(f.required());
+        // Default requiredOnCreate to required when YAML omits the slot — preserves seed behavior.
+        boolean requiredOnCreate = f.requiredOnCreate() == null ? required : f.requiredOnCreate();
+        if (requiredOnCreate && ft == FieldType.FILE) {
+          warnings.add(
+              eb.error(
+                  ErrorCode.WKS_CFG_013,
+                  "Field '"
+                      + f.id()
+                      + "' is type 'file' with requiredOnCreate: true, but file upload is not"
+                      + " supported on the create form (Story 3.1 will close this). The create"
+                      + " form will treat this field as optional until 3.1 ships.",
+                  base + ".requiredOnCreate"));
+        }
         out.add(
             new FieldDefinition(
                 f.id(),
                 f.displayName(),
                 ft,
-                Boolean.TRUE.equals(f.required()),
+                required,
+                requiredOnCreate,
                 f.order() == null ? Integer.MAX_VALUE : f.order(),
                 opts,
                 new FieldDefinition.TypeSlots(

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -34,6 +34,7 @@ public record RawCaseTypeConfig(
       String displayName,
       String type,
       Boolean required,
+      Boolean requiredOnCreate,
       Integer order,
       List<RawOption> options,
       Integer minLength,

--- a/backend/src/main/java/com/wkspower/platform/security/CaseTypePermissionEvaluator.java
+++ b/backend/src/main/java/com/wkspower/platform/security/CaseTypePermissionEvaluator.java
@@ -3,7 +3,9 @@ package com.wkspower.platform.security;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.config.model.Permission;
 import com.wkspower.platform.domain.port.CaseTypeReader;
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -45,5 +47,30 @@ public class CaseTypePermissionEvaluator {
         .flatMap(r -> r.permissions().stream())
         .map(Permission::wire)
         .anyMatch(verb::equals);
+  }
+
+  /**
+   * Returns the verb subset (as wire strings) that the caller holds on the given case-type. Used by
+   * {@code GET /api/case-types} to populate {@code CaseTypeSummaryDto.permissions[]} so the
+   * frontend can filter the Create-Case dropdown to entries the user can actually act on without
+   * round-tripping per case-type. Story 2.7 introduces this method.
+   *
+   * @return immutable set of verb wire strings; empty set for null inputs or unknown case-types.
+   */
+  public Set<String> verbsOf(AuthenticatedUser user, String caseTypeId) {
+    if (user == null || caseTypeId == null) {
+      return Set.of();
+    }
+    Optional<CaseTypeConfig> config = caseTypeReader.find(caseTypeId);
+    if (config.isEmpty()) {
+      return Set.of();
+    }
+    Set<String> verbs = new LinkedHashSet<>();
+    config.get().roles().stream()
+        .filter(r -> user.roles().contains(r.name()))
+        .flatMap(r -> r.permissions().stream())
+        .map(Permission::wire)
+        .forEach(verbs::add);
+    return Set.copyOf(verbs);
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseDataValidatorAdapterTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseDataValidatorAdapterTest.java
@@ -97,6 +97,33 @@ class CaseDataValidatorAdapterTest {
   }
 
   @Test
+  void pointerToFieldStripsDataPrefixForKnownTopLevel() {
+    CaseTypeConfig ct = caseType("loan-application", 1);
+    assertThat(CaseDataValidatorAdapter.pointerToField("/data/name", ct)).isEqualTo("name");
+    assertThat(CaseDataValidatorAdapter.pointerToField("$.name", ct)).isEqualTo("name");
+    assertThat(CaseDataValidatorAdapter.pointerToField("name", ct)).isEqualTo("name");
+  }
+
+  @Test
+  void pointerToFieldEmptyOrRootMapsToData() {
+    CaseTypeConfig ct = caseType("loan-application", 1);
+    assertThat(CaseDataValidatorAdapter.pointerToField("", ct)).isEqualTo("data");
+    assertThat(CaseDataValidatorAdapter.pointerToField("/", ct)).isEqualTo("data");
+    assertThat(CaseDataValidatorAdapter.pointerToField("$", ct)).isEqualTo("data");
+    assertThat(CaseDataValidatorAdapter.pointerToField("/data/", ct)).isEqualTo("data");
+    assertThat(CaseDataValidatorAdapter.pointerToField(null, ct)).isEqualTo("data");
+  }
+
+  @Test
+  void pointerToFieldNestedReturnsLeafSegment() {
+    CaseTypeConfig ct = caseType("loan-application", 1);
+    // Nested is defensive — Phase 0 grammar is flat. Leaf wins; no slash-to-dot conversion.
+    assertThat(CaseDataValidatorAdapter.pointerToField("/data/applicant/name", ct))
+        .isEqualTo("name");
+    assertThat(CaseDataValidatorAdapter.pointerToField("$.applicant.name", ct)).isEqualTo("name");
+  }
+
+  @Test
   void invalidationForUnrelatedCaseTypeIsNoop() {
     CaseTypeConfig loan = caseType("loan-application", 1);
     adapter.validate(loan, Map.of("name", "Asha"));

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
@@ -498,6 +498,56 @@ class ConfigValidatorTest {
     return validator.validate(r.raw(), r.lines());
   }
 
+  // ---- Story 2.7 — requiredOnCreate grammar extension + WKS-CFG-013 ----
+
+  @Test
+  void requiredOnCreateDefaultsToRequiredWhenOmitted() {
+    var result = validate(GREEN_YAML);
+    assertThat(result.isInvalid()).isFalse();
+    var fields = result.config().get().fields();
+    var applicantName =
+        fields.stream().filter(f -> f.id().equals("applicant_name")).findFirst().get();
+    var loanAmount = fields.stream().filter(f -> f.id().equals("loan_amount")).findFirst().get();
+    assertThat(applicantName.required()).isTrue();
+    assertThat(applicantName.requiredOnCreate())
+        .as("applicant_name has required:true and no requiredOnCreate slot — defaults to required")
+        .isTrue();
+    assertThat(loanAmount.required()).isFalse();
+    assertThat(loanAmount.requiredOnCreate()).isFalse();
+  }
+
+  @Test
+  void requiredOnCreateExplicitFalseOnRequiredFieldIsHonored() {
+    var yaml =
+        GREEN_YAML.replace(
+            "    type: text\n    required: true",
+            "    type: text\n    required: true\n    requiredOnCreate: false");
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).isFalse();
+    var f =
+        result.config().get().fields().stream()
+            .filter(x -> x.id().equals("applicant_name"))
+            .findFirst()
+            .get();
+    assertThat(f.required()).isTrue();
+    assertThat(f.requiredOnCreate()).isFalse();
+  }
+
+  @Test
+  void wksCfg013_fileFieldRequiredOnCreateEmitsWarning() {
+    var yaml =
+        GREEN_YAML.replace(
+            "  - id: loan_amount\n    displayName: Loan amount\n    type: number",
+            "  - id: id_proof\n    displayName: ID proof\n    type: file\n"
+                + "    requiredOnCreate: true");
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).as("WKS-CFG-013 is a warning, not a blocking error").isFalse();
+    assertThat(result.warnings()).hasSize(1);
+    assertThat(result.warnings().get(0).code()).isEqualTo("WKS-CFG-013");
+    assertThat(result.warnings().get(0).field()).contains("requiredOnCreate");
+    assertThat(result.config()).isPresent();
+  }
+
   private ErrorDetail assertErrorOn(List<ErrorDetail> errors, String code, String field) {
     var match =
         errors.stream().filter(e -> code.equals(e.code()) && field.equals(e.field())).findFirst();

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
@@ -172,6 +172,44 @@ class CaseFlowIT {
     assertThat(conflict.getBody()).contains("WKS-RTM-409");
   }
 
+  @Test
+  void createReturns422WithFieldId() throws Exception {
+    // P28 / AC10 / Story 2.7 — POST /api/cases with a payload that omits a required field returns
+    // 422 with errors[].field set to the YAML-declared field id ("name"), NOT a JSON-Pointer path
+    // like "/data/name". The frontend RHF setError(field, ...) path depends on this exact shape;
+    // any drift makes inline validation messages vanish silently.
+    String cookie = login();
+
+    // Send `name: 123` (a number where the schema declares string) — networknt assigns this
+    // violation to the property location `/name`, exercising the pointerToField field-id roundtrip
+    // that the frontend setError() path depends on. (A `data: {}` payload would attribute the
+    // missing-required violation to the parent location instead, returning "data".)
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"name\":123}}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    JsonNode body = json.readTree(resp.getBody());
+    JsonNode errors = body.path("error").path("errors");
+    assertThat(errors.isArray()).isTrue();
+    assertThat(errors.size()).isGreaterThan(0);
+    boolean hasNameFieldError = false;
+    for (JsonNode err : errors) {
+      String field = err.path("field").asText();
+      // P11 — must be the YAML id, not "/data/name", "data.name" or "data".
+      if ("name".equals(field)) {
+        hasNameFieldError = true;
+        break;
+      }
+    }
+    assertThat(hasNameFieldError)
+        .as("at least one error must carry the YAML-declared field id 'name'")
+        .isTrue();
+  }
+
   private String login() {
     ResponseEntity<String> resp =
         rest.postForEntity("/api/auth/login", new LoginRequest(EMAIL, PASSWORD), String.class);

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseTypeControllerIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseTypeControllerIT.java
@@ -120,6 +120,23 @@ class CaseTypeControllerIT {
   }
 
   @Test
+  void summaryIncludesPermissionsForCaller() {
+    // P28 / AC9 — the case-types list response must include the caller's verbs per case-type so
+    // the frontend dropdown can filter to creatable types client-side without a second round-trip.
+    String cookie = login(EMAIL);
+
+    ResponseEntity<String> resp = exchange("/api/case-types", HttpMethod.GET, cookie);
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    String body = resp.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body)
+        .contains("\"id\":\"loan-application\"")
+        .contains("\"permissions\":[\"view\"]")
+        .doesNotContain("\"hr-onboarding\"");
+  }
+
+  @Test
   void unknownCaseTypeReturns404() {
     String cookie = login(EMAIL);
 

--- a/backend/src/test/java/com/wkspower/platform/security/CaseTypePermissionEvaluatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/security/CaseTypePermissionEvaluatorTest.java
@@ -58,6 +58,24 @@ class CaseTypePermissionEvaluatorTest {
   }
 
   @Test
+  void verbsOfReturnsCallerVerbSubset() {
+    CaseTypePermissionEvaluator eval = new CaseTypePermissionEvaluator(reader(loanType()));
+
+    assertThat(eval.verbsOf(OFFICER, "loan-application"))
+        .containsExactlyInAnyOrder("view", "create");
+    assertThat(eval.verbsOf(CUSTOMER, "loan-application")).containsExactly("view");
+  }
+
+  @Test
+  void verbsOfReturnsEmptyForUnknownCaseTypeOrNullInputs() {
+    CaseTypePermissionEvaluator eval = new CaseTypePermissionEvaluator(reader(loanType()));
+
+    assertThat(eval.verbsOf(OFFICER, "no-such-type")).isEmpty();
+    assertThat(eval.verbsOf(null, "loan-application")).isEmpty();
+    assertThat(eval.verbsOf(OFFICER, null)).isEmpty();
+  }
+
+  @Test
   void nullInputsReturnFalse() {
     CaseTypePermissionEvaluator eval = new CaseTypePermissionEvaluator(reader(loanType()));
 

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -95,6 +95,12 @@ return PageMetaBuilder.paged(page, MyMapper::toDto);
 Codes are defined once in `domain/exception/ErrorCode.java`. Wire strings are part of the public
 contract — never renumber or reuse a code once shipped.
 
+### Story 2.7 — additions
+
+- `WKS-CFG-013` — case-type YAML marks a `file`-typed field as `requiredOnCreate: true` but file
+  upload is not yet supported on the create form. WARN-level finding (case-type still loads); the
+  create-form treats the field as optional until Story 3.1 ships document upload.
+
 ### Config validation codes (WKS-CFG-001..099)
 
 Case-type YAML validation (Story 2.1). Every entry carries `field` (dotted JSON-Pointer-flavour
@@ -221,7 +227,7 @@ Returns the case types the caller has the `view` verb on, sorted by `displayName
 {
   "data": [
     { "id": "loan-application", "displayName": "Loan Application", "version": 1,
-      "statusCount": 5, "fieldCount": 8 }
+      "statusCount": 5, "fieldCount": 8, "permissions": ["view", "create"] }
   ],
   "meta": {}
 }
@@ -229,6 +235,13 @@ Returns the case types the caller has the `view` verb on, sorted by `displayName
 
 `statusCount` and `fieldCount` are convenience counts for a future case-type selector — the heavy
 fields (`fields[]`, `statuses[]`, `listColumns`) live on the detail endpoint below.
+
+`permissions[]` (Story 2.7) is the verb subset the **caller** holds on the case-type — a subset
+of the declared `view`, `create`, `edit`, `transition`, `assign`, `upload-document` verbs.
+The frontend uses this to filter the Create-Case dropdown to entries the user can actually act
+on, without an extra round-trip per case-type. The list endpoint still gates entries by the
+`view` verb; `permissions[]` only surfaces info the caller is otherwise entitled to derive from
+their own roles + the YAML.
 
 `GET /api/case-types/{id}`
 
@@ -238,14 +251,30 @@ fields (`fields[]`, `statuses[]`, `listColumns`) live on the detail endpoint bel
     "id": "loan-application",
     "displayName": "Loan Application",
     "version": 1,
-    "fields": [ { "id": "name", "displayName": "Name", "type": "text", "required": true, "order": 0,
-                  "options": [], "slots": null } ],
+    "fields": [ { "id": "applicant_name", "displayName": "Applicant name", "type": "text",
+                  "required": true, "requiredOnCreate": true, "order": 0, "options": [],
+                  "maxLength": 80 } ],
     "statuses": [ { "id": "open", "displayName": "Open", "color": "zinc" } ],
-    "listColumns": [ "name" ]
+    "listColumns": [ "applicant_name" ]
   },
   "meta": {}
 }
 ```
+
+`fields[]` (Story 2.7 widening): every entry is a flattened `FieldView` carrying the per-type
+validation slots the frontend Zod builder reads — `minLength`/`maxLength` for `text`/`textarea`,
+`min`/`max`/`step` for `number`, `dateMin`/`dateMax` for `date`, `options[]` for `select`,
+`maxBytes`/`allowedMimeTypes` for `file`. Slots are nullable; only the slots relevant to `type`
+are populated. `requiredOnCreate` (default = `required`) controls whether the create-form dialog
+asks for this field at case-creation time. The wire field names mirror the YAML grammar tokens
+exactly (camelCase) so the validation contract is one shape end-to-end.
+
+`POST /api/cases` 422 (Story 2.7 AC10): every `errors[].field` is the YAML-declared field id
+verbatim (e.g., `applicant_name`), **not** a JSON-Pointer fragment (`/data/applicant_name`).
+The backend `CaseDataValidatorAdapter.pointerToField` resolver strips the `$.` / `/data/`
+prefix and (for nested paths, defensively — Phase 0 grammar is flat) returns the leaf segment.
+Empty / root pointer maps to the wire literal `data` so the frontend banner code can render it
+as a form-level violation. The frontend RHF `setError` mapping depends on this contract.
 
 - `404 WKS-API-404` — unknown id.
 - `403 WKS-API-403` — caller lacks `view` on this case type.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,12 @@
       "name": "wks-platform-frontend",
       "version": "2.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.10.0",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.1.1",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.1.6",
@@ -21,8 +24,10 @@
         "lucide-react": "^0.468.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.74.0",
         "react-router-dom": "^7.1.0",
         "tailwind-merge": "^3.0.0",
+        "zod": "^3.25.76",
         "zustand": "^5.0.2"
       },
       "devDependencies": {
@@ -1227,6 +1232,15 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1489,6 +1503,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1502,6 +1522,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2040,6 +2090,67 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -2214,6 +2325,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -7884,6 +8010,22 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.74.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
+      "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -10662,6 +10804,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,9 +12,12 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.10.0",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.1.6",
@@ -25,8 +28,10 @@
     "lucide-react": "^0.468.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.74.0",
     "react-router-dom": "^7.1.0",
     "tailwind-merge": "^3.0.0",
+    "zod": "^3.25.76",
     "zustand": "^5.0.2"
   },
   "engines": {

--- a/frontend/src/api/cases.ts
+++ b/frontend/src/api/cases.ts
@@ -26,3 +26,20 @@ export async function listCases(query: CaseListQuery): Promise<CaseSummary[]> {
   const result = await apiFetch<CaseSummary[]>(`/api/cases?${params.toString()}`);
   return result.data;
 }
+
+/** Story 2.7 — request body for `POST /api/cases`. */
+export interface CreateCaseRequest {
+  caseTypeId: string;
+  data: Record<string, unknown>;
+  assignee?: string | null;
+}
+
+/** Story 2.7 — `POST /api/cases` (Story 2.3 endpoint, first consumed from a UI surface here). */
+export async function createCase(req: CreateCaseRequest): Promise<CaseDto> {
+  const result = await apiFetch<CaseDto>('/api/cases', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  });
+  return result.data;
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,11 +4,24 @@ import { sessionBus } from './sessionBus';
 
 const LOGIN_PATH = '/api/auth/login';
 
+export interface ApiEnvelopeError {
+  code: string;
+  message: string;
+  field?: string | null;
+}
+
 export class ApiError extends Error {
   readonly status: number;
   readonly code: string;
   readonly field: string | null;
   readonly correlationId: string | null;
+  /**
+   * Story 2.7 — multi-error aggregate from {@code error.errors[]} (Story 2.3 envelope, populated
+   * for {@code WKS-API-001} 422s and {@code WKS-CFG-000} aggregates). The single-field {@code
+   * field} property reflects the envelope's top-level field; {@code envelopeErrors} surfaces
+   * every individual validation error the backend produced. Null when the envelope had no array.
+   */
+  readonly envelopeErrors: ApiEnvelopeError[] | null;
 
   constructor(init: {
     status: number;
@@ -16,6 +29,7 @@ export class ApiError extends Error {
     message: string;
     field?: string | null;
     correlationId?: string | null;
+    envelopeErrors?: ApiEnvelopeError[] | null;
   }) {
     super(init.message);
     this.name = 'ApiError';
@@ -23,6 +37,7 @@ export class ApiError extends Error {
     this.code = init.code;
     this.field = init.field ?? null;
     this.correlationId = init.correlationId ?? null;
+    this.envelopeErrors = init.envelopeErrors ?? null;
   }
 }
 
@@ -74,11 +89,13 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
     errorBody = null;
   }
 
+  const errors = (errorBody?.error as { errors?: ApiEnvelopeError[] } | undefined)?.errors;
   throw new ApiError({
     status: response.status,
     code: errorBody?.error.code ?? `WKS-API-${response.status}`,
     message: errorBody?.error.message ?? response.statusText,
     field: errorBody?.error.field ?? null,
     correlationId,
+    envelopeErrors: Array.isArray(errors) ? errors : null,
   });
 }

--- a/frontend/src/components/ui/Checkbox.test.tsx
+++ b/frontend/src/components/ui/Checkbox.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Checkbox } from './Checkbox';
+
+function Harness({ initial = false }: { initial?: boolean }) {
+  const [checked, setChecked] = useState<boolean>(initial);
+  return (
+    <Checkbox
+      aria-label="Agree"
+      checked={checked}
+      onCheckedChange={(v) => setChecked(Boolean(v))}
+    />
+  );
+}
+
+describe('Checkbox', () => {
+  it('toggles checked state on click', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const cb = screen.getByRole('checkbox', { name: 'Agree' });
+    expect(cb).toHaveAttribute('data-state', 'unchecked');
+    await user.click(cb);
+    expect(cb).toHaveAttribute('data-state', 'checked');
+  });
+
+  it('hasError prop sets aria-invalid', () => {
+    render(<Checkbox aria-label="x" hasError />);
+    expect(screen.getByRole('checkbox', { name: 'x' })).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('respects keyboard activation (Space)', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const cb = screen.getByRole('checkbox', { name: 'Agree' });
+    cb.focus();
+    await user.keyboard(' ');
+    expect(cb).toHaveAttribute('data-state', 'checked');
+  });
+});

--- a/frontend/src/components/ui/Checkbox.tsx
+++ b/frontend/src/components/ui/Checkbox.tsx
@@ -1,0 +1,27 @@
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { Check } from 'lucide-react';
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export const Checkbox = forwardRef<
+  ElementRef<typeof CheckboxPrimitive.Root>,
+  ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> & { hasError?: boolean }
+>(function Checkbox({ className, hasError, ...props }, ref) {
+  return (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      aria-invalid={hasError ? true : undefined}
+      className={cn(
+        'peer size-4 shrink-0 rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--card)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[var(--primary)] data-[state=checked]:text-[var(--primary-foreground)]',
+        hasError && 'border-[var(--destructive)] focus-visible:ring-[var(--destructive)]',
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+        <Check className="size-3.5" aria-hidden />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+});

--- a/frontend/src/components/ui/Dialog.test.tsx
+++ b/frontend/src/components/ui/Dialog.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from './Dialog';
+
+function Harness({ defaultOpen = false }: { defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger>Open</DialogTrigger>
+      <DialogContent>
+        <DialogTitle>Hello</DialogTitle>
+        <DialogDescription>World</DialogDescription>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+describe('Dialog', () => {
+  it('renders title + description with the right ARIA wiring', () => {
+    render(<Harness defaultOpen />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('World')).toBeInTheDocument();
+  });
+
+  it('close button has an accessible name (P7 — fixes empty sr-only span)', () => {
+    render(<Harness defaultOpen />);
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+
+  it('opens via trigger and closes via the X button', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -1,0 +1,91 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+
+import { t } from '@/i18n';
+import { cn } from '@/lib/cn';
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogClose = DialogPrimitive.Close;
+export const DialogPortal = DialogPrimitive.Portal;
+
+export const DialogOverlay = forwardRef<
+  ElementRef<typeof DialogPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(function DialogOverlay({ className, ...props }, ref) {
+  return (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className={cn(
+        'fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+export const DialogContent = forwardRef<
+  ElementRef<typeof DialogPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { showClose?: boolean }
+>(function DialogContent({ className, children, showClose = true, ...props }, ref) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-[var(--border)] bg-[var(--card)] p-6 shadow-lg rounded-[var(--radius-lg)] focus:outline-none',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showClose && (
+          <DialogPrimitive.Close
+            aria-label={t('common.close')}
+            className="absolute right-4 top-4 rounded-[var(--radius-sm)] opacity-70 hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2"
+          >
+            <X className="size-4" aria-hidden />
+            <span className="sr-only">{t('common.close')}</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+});
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col gap-1.5 text-left', className)} {...props} />
+);
+
+export const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-row justify-end gap-2', className)} {...props} />
+);
+
+export const DialogTitle = forwardRef<
+  ElementRef<typeof DialogPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(function DialogTitle({ className, ...props }, ref) {
+  return (
+    <DialogPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold text-[var(--foreground)]', className)}
+      {...props}
+    />
+  );
+});
+
+export const DialogDescription = forwardRef<
+  ElementRef<typeof DialogPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(function DialogDescription({ className, ...props }, ref) {
+  return (
+    <DialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-[var(--muted-foreground)]', className)}
+      {...props}
+    />
+  );
+});

--- a/frontend/src/components/ui/DropdownMenu.tsx
+++ b/frontend/src/components/ui/DropdownMenu.tsx
@@ -32,6 +32,22 @@ export const DropdownMenuContent = forwardRef<
   );
 });
 
+export const DropdownMenuItem = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(function DropdownMenuItem({ className, ...props }, ref) {
+  return (
+    <DropdownMenuPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-[var(--radius-sm)] px-2 py-1.5 text-sm outline-none focus:bg-[var(--muted)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
 export const DropdownMenuLabel = forwardRef<
   ElementRef<typeof DropdownMenuPrimitive.Label>,
   ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label>

--- a/frontend/src/components/ui/FormField.test.tsx
+++ b/frontend/src/components/ui/FormField.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FormProvider, useForm } from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+
+import { FormField } from './FormField';
+import { Input } from './Input';
+
+function Harness({
+  defaultValues,
+  required,
+  description,
+  errorMessage,
+}: {
+  defaultValues?: Record<string, unknown>;
+  required?: boolean;
+  description?: string;
+  errorMessage?: string;
+}) {
+  const form = useForm({ defaultValues: defaultValues ?? { name: '' } });
+  // Inject an error post-mount when requested.
+  if (errorMessage && !form.formState.errors.name) {
+    form.setError('name', { message: errorMessage });
+  }
+  return (
+    <FormProvider {...form}>
+      <FormField name="name" label="Name" required={required} description={description}>
+        {(field) => <Input type="text" {...field} value={String(field.value ?? '')} />}
+      </FormField>
+    </FormProvider>
+  );
+}
+
+describe('FormField', () => {
+  it('renders the label and wires htmlFor → input id', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText('Name');
+    expect(input).toBeInTheDocument();
+    expect(input.id).toMatch(/-name$/);
+  });
+
+  it('marks required visually + with aria-required', () => {
+    render(<Harness required />);
+    const input = screen.getByLabelText(/Name/);
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('wires aria-describedby to description when present', () => {
+    render(<Harness description="Your full name" />);
+    const input = screen.getByLabelText('Name');
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)).toHaveTextContent('Your full name');
+  });
+
+  it('renders error message + sets aria-invalid + extends aria-describedby with errorId', () => {
+    render(<Harness errorMessage="Required" />);
+    const input = screen.getByLabelText('Name');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(screen.getByRole('alert')).toHaveTextContent('Required');
+  });
+
+  it('integrates with RHF — typing updates form state', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    const input = screen.getByLabelText('Name');
+    await user.type(input, 'Alice');
+    expect(input).toHaveValue('Alice');
+  });
+});

--- a/frontend/src/components/ui/FormField.tsx
+++ b/frontend/src/components/ui/FormField.tsx
@@ -1,0 +1,110 @@
+import { useId, type ReactNode } from 'react';
+import {
+  useController,
+  useFormContext,
+  type ControllerRenderProps,
+  type FieldPath,
+  type FieldValues,
+} from 'react-hook-form';
+
+import { cn } from '@/lib/cn';
+
+export type FormFieldRenderProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = ControllerRenderProps<TFieldValues, TName> & {
+  id: string;
+  'aria-invalid': boolean | undefined;
+  'aria-describedby': string | undefined;
+  'aria-required': boolean | undefined;
+  disabled?: boolean;
+};
+
+export type FormFieldProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+  label: string;
+  description?: string;
+  required?: boolean;
+  /** When true, forwards `disabled` to the rendered input via the render-prop's `disabled`. */
+  disabled?: boolean;
+  className?: string;
+  children: (field: FormFieldRenderProps<TFieldValues, TName>) => ReactNode;
+};
+
+/**
+ * Story 2.7 — RHF + Zod field wrapper. Composes a Label + the consumer's input element + an
+ * ErrorMessage. Wires `id` / `htmlFor` / `aria-invalid` / `aria-describedby` / `aria-required`
+ * automatically from RHF state so individual input components don't need per-field plumbing.
+ *
+ * Closes 1.3 chunk-3 deferred-work entry: "Input lacks aria-describedby wiring to external error
+ * messages — formalize in the FormField wrapper that ships with RHF + Zod in 2.7."
+ *
+ * Uses {@code useController} (per AC12) so controlled Radix primitives (Select, Checkbox) slot in
+ * via the same wrapper as plain Input/Textarea — `field.value` + `field.onChange` work uniformly.
+ * Also exposes `field.ref` so RHF's `shouldFocusError` can focus controlled controls.
+ */
+export function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  name,
+  label,
+  description,
+  required,
+  disabled,
+  className,
+  children,
+}: FormFieldProps<TFieldValues, TName>) {
+  // Touch the form context so we throw a clear error when used outside <FormProvider> rather
+  // than the cryptic useController error.
+  useFormContext<TFieldValues>();
+  const { field, fieldState } = useController<TFieldValues, TName>({ name });
+  const reactId = useId();
+  const fieldId = `${reactId}-${String(name)}`;
+  const errorId = `${fieldId}-error`;
+  const descId = description ? `${fieldId}-desc` : undefined;
+
+  const errorMessage =
+    typeof fieldState.error?.message === 'string' ? fieldState.error.message : undefined;
+
+  const describedBy =
+    [errorMessage ? errorId : null, descId].filter(Boolean).join(' ') || undefined;
+
+  const renderProps: FormFieldRenderProps<TFieldValues, TName> = {
+    ...field,
+    // Default value to '' so plain Inputs are always controlled (RHF can hand back undefined).
+    value: (field.value ?? '') as ControllerRenderProps<TFieldValues, TName>['value'],
+    id: fieldId,
+    'aria-invalid': errorMessage ? true : undefined,
+    'aria-describedby': describedBy,
+    'aria-required': required ? true : undefined,
+    disabled,
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      <label htmlFor={fieldId} className="text-sm font-medium text-[var(--foreground)]">
+        {label}
+        {required && (
+          <span className="ml-0.5 text-[var(--destructive)]" aria-hidden>
+            {'*'}
+          </span>
+        )}
+      </label>
+      {children(renderProps)}
+      {description && (
+        <p id={descId} className="text-sm text-[var(--muted-foreground)]">
+          {description}
+        </p>
+      )}
+      {errorMessage && (
+        <p id={errorId} role="alert" className="text-sm text-[var(--destructive)]">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/MutationButton.test.tsx
+++ b/frontend/src/components/ui/MutationButton.test.tsx
@@ -1,0 +1,84 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MutationButton } from './MutationButton';
+
+describe('MutationButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('idle state shows the children, button enabled', () => {
+    render(<MutationButton state="idle">Save</MutationButton>);
+    const btn = screen.getByRole('button');
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent('Save');
+    expect(btn).toHaveAttribute('data-state', 'idle');
+  });
+
+  it('confirming state disables the button and exposes aria-busy', () => {
+    render(
+      <MutationButton state="confirming" confirmingLabel="Saving…">
+        Save
+      </MutationButton>,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(btn).toHaveTextContent('Saving…');
+  });
+
+  it('confirmed state holds 2s then fades to idle (re-enables button + restores children)', () => {
+    const { rerender } = render(
+      <MutationButton state="idle" confirmedLabel="Saved">
+        Save
+      </MutationButton>,
+    );
+    rerender(
+      <MutationButton state="confirmed" confirmedLabel="Saved">
+        Save
+      </MutationButton>,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent('Saved');
+    act(() => {
+      vi.advanceTimersByTime(2_001);
+    });
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent('Save');
+    expect(btn).toHaveAttribute('data-state', 'idle');
+  });
+
+  it('failed state renders retryAction next to the button', () => {
+    render(
+      <MutationButton
+        state="failed"
+        failedLabel="Failed — boom"
+        retryAction={<button type="button">Retry</button>}
+      >
+        Save
+      </MutationButton>,
+    );
+    // The button label appears twice (visible text + sr-only live region announcement) — both
+    // good. Just confirm the button has the failed copy and the retry button is rendered.
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[0]).toHaveTextContent('Failed — boom');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('always-polite live region (never assertive)', () => {
+    render(
+      <MutationButton state="failed" failedLabel="Failed">
+        Save
+      </MutationButton>,
+    );
+    // The sr-only span carries aria-live="polite" regardless of state to keep AT region tracking.
+    const polite = document.querySelector('[aria-live="polite"]');
+    expect(polite).toBeInTheDocument();
+    expect(document.querySelector('[aria-live="assertive"]')).toBeNull();
+  });
+});

--- a/frontend/src/components/ui/MutationButton.tsx
+++ b/frontend/src/components/ui/MutationButton.tsx
@@ -1,0 +1,130 @@
+import { Check, Loader2, X } from 'lucide-react';
+import {
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from 'react';
+
+import { cn } from '@/lib/cn';
+
+import { Button } from './Button';
+
+/**
+ * Story 2.7 — 4-state slice of the TaskLifecycleButton state machine (UX spec §TaskLifecycleButton
+ * lines 716-744). The 5-state owner with the {@code processing} state ships in Story 2.8 — at that
+ * point this component is either renamed or wrapped. The TS literal-union here is forward-
+ * compatible: 2.8 widens the union to add {@code 'processing'}.
+ *
+ * Presentational: parents drive transitions via the {@code state} prop (typically derived from
+ * RHF's {@code formState.isSubmitting} + a TanStack Query mutation's {@code isPending} /
+ * {@code isSuccess} / {@code isError}). The component itself owns no state machine.
+ */
+export type MutationButtonState = 'idle' | 'confirming' | 'confirmed' | 'failed';
+
+const CONFIRMED_FADE_MS = 2_000;
+
+export interface MutationButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children'
+> {
+  state: MutationButtonState;
+  /** Idle-state children. */
+  children: ReactNode;
+  /** Label for confirming state — parent supplies localised string. */
+  confirmingLabel?: string;
+  /** Label for confirmed state — parent supplies localised string. */
+  confirmedLabel?: string;
+  /** Reason-bearing label for failed state — parent supplies localised string. */
+  failedLabel?: string;
+  /** Optional retry slot; renders only on `failed`. */
+  retryAction?: ReactNode;
+}
+
+export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>(
+  function MutationButton(
+    {
+      state,
+      children,
+      confirmingLabel = 'Confirming…',
+      confirmedLabel = 'Confirmed',
+      failedLabel = 'Failed',
+      retryAction,
+      className,
+      disabled,
+      ...rest
+    },
+    ref,
+  ) {
+    // P6 — AC6 says "Holds visible 2s then fades to subtle". After 2s in `confirmed`, drop the
+    // green chip and re-enable the button so the parent can either stay (e.g. "Save and view") or
+    // trigger the next action. Reset on any state change away from confirmed.
+    const [confirmedFaded, setConfirmedFaded] = useState(false);
+    const announceKey = useRef(0);
+    useEffect(() => {
+      setConfirmedFaded(false);
+      if (state !== 'confirmed') return;
+      const handle = window.setTimeout(() => setConfirmedFaded(true), CONFIRMED_FADE_MS);
+      return () => clearTimeout(handle);
+    }, [state]);
+    // Bump the announce key on every state transition so the sr-only span re-renders even when
+    // the visible text is unchanged — some AT engines coalesce identical adjacent updates.
+    useEffect(() => {
+      announceKey.current += 1;
+    }, [state]);
+
+    // P24 — hold `polite` for the lifetime of the live region; switching politeness mid-flight
+    // makes some AT engines drop region tracking. Failed state is still loud because the text
+    // changes, the region just doesn't switch to assertive.
+    const announce =
+      state === 'confirming'
+        ? confirmingLabel
+        : state === 'confirmed'
+          ? confirmedLabel
+          : state === 'failed'
+            ? failedLabel
+            : '';
+
+    const stateClass =
+      state === 'confirming'
+        ? 'bg-[var(--ring)] text-white animate-pulse'
+        : state === 'confirmed'
+          ? confirmedFaded
+            ? ''
+            : 'bg-emerald-600 text-white hover:bg-emerald-600'
+          : state === 'failed'
+            ? 'bg-[var(--destructive)] text-white hover:bg-[var(--destructive)]'
+            : '';
+
+    const isVisuallyConfirmed = state === 'confirmed' && !confirmedFaded;
+    const buttonDisabled = disabled || state === 'confirming' || isVisuallyConfirmed;
+
+    return (
+      <div className={cn('inline-flex items-center gap-2')}>
+        <Button
+          ref={ref}
+          type={rest.type ?? 'submit'}
+          aria-busy={state === 'confirming' ? true : undefined}
+          disabled={buttonDisabled}
+          data-state={confirmedFaded && state === 'confirmed' ? 'idle' : state}
+          className={cn(stateClass, className)}
+          {...rest}
+        >
+          {state === 'confirming' && <Loader2 className="size-4 animate-spin" aria-hidden />}
+          {isVisuallyConfirmed && <Check className="size-4" aria-hidden />}
+          {state === 'failed' && <X className="size-4" aria-hidden />}
+          {(state === 'idle' || (state === 'confirmed' && confirmedFaded)) && children}
+          {state === 'confirming' && confirmingLabel}
+          {isVisuallyConfirmed && confirmedLabel}
+          {state === 'failed' && failedLabel}
+          <span key={announceKey.current} className="sr-only" aria-live="polite">
+            {announce}
+          </span>
+        </Button>
+        {state === 'failed' && retryAction}
+      </div>
+    );
+  },
+);

--- a/frontend/src/components/ui/Select.test.tsx
+++ b/frontend/src/components/ui/Select.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './Select';
+
+function Harness({ initial = undefined as string | undefined }) {
+  const [value, setValue] = useState<string | undefined>(initial);
+  return (
+    <Select value={value} onValueChange={setValue}>
+      <SelectTrigger aria-label="Color">
+        <SelectValue placeholder="Pick…" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="red">Red</SelectItem>
+        <SelectItem value="blue">Blue</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+describe('Select', () => {
+  it('renders the placeholder when value is undefined', () => {
+    render(<Harness />);
+    expect(screen.getByText('Pick…')).toBeInTheDocument();
+  });
+
+  it('shows the selected option label after pick', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('combobox', { name: 'Color' }));
+    await user.click(screen.getByRole('option', { name: 'Blue' }));
+    expect(screen.getByRole('combobox', { name: 'Color' })).toHaveTextContent('Blue');
+  });
+
+  it('hasError prop sets aria-invalid on the trigger', () => {
+    render(
+      <Select>
+        <SelectTrigger aria-label="X" hasError>
+          <SelectValue placeholder="Pick…" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="x">X</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    expect(screen.getByRole('combobox', { name: 'X' })).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -1,0 +1,77 @@
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown } from 'lucide-react';
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export const Select = SelectPrimitive.Root;
+export const SelectGroup = SelectPrimitive.Group;
+export const SelectValue = SelectPrimitive.Value;
+
+export const SelectTrigger = forwardRef<
+  ElementRef<typeof SelectPrimitive.Trigger>,
+  ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & { hasError?: boolean }
+>(function SelectTrigger({ className, hasError, children, ...props }, ref) {
+  return (
+    <SelectPrimitive.Trigger
+      ref={ref}
+      aria-invalid={hasError ? true : undefined}
+      className={cn(
+        'flex h-10 w-full items-center justify-between rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        hasError && 'border-[var(--destructive)] focus-visible:ring-[var(--destructive)]',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="size-4 opacity-50" aria-hidden />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+});
+
+export const SelectContent = forwardRef<
+  ElementRef<typeof SelectPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(function SelectContent({ className, children, position = 'popper', ...props }, ref) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
+        position={position}
+        className={cn(
+          'relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem] overflow-hidden rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--card)] text-[var(--foreground)] shadow-md',
+          position === 'popper' && 'w-[var(--radix-select-trigger-width)]',
+          className,
+        )}
+        {...props}
+      >
+        <SelectPrimitive.Viewport className="p-1">{children}</SelectPrimitive.Viewport>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+});
+
+export const SelectItem = forwardRef<
+  ElementRef<typeof SelectPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(function SelectItem({ className, children, ...props }, ref) {
+  return (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex w-full cursor-default select-none items-center rounded-[var(--radius-sm)] py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-[var(--muted)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="size-4" aria-hidden />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+});

--- a/frontend/src/components/ui/Textarea.test.tsx
+++ b/frontend/src/components/ui/Textarea.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { Textarea } from './Textarea';
+
+describe('Textarea', () => {
+  it('renders a textarea with the given placeholder + default 4 rows', () => {
+    render(<Textarea placeholder="Notes" />);
+    const ta = screen.getByPlaceholderText('Notes') as HTMLTextAreaElement;
+    expect(ta.tagName).toBe('TEXTAREA');
+    expect(ta.rows).toBe(4);
+  });
+
+  it('forwards maxLength', async () => {
+    const user = userEvent.setup();
+    render(<Textarea placeholder="x" maxLength={5} />);
+    const ta = screen.getByPlaceholderText('x') as HTMLTextAreaElement;
+    await user.type(ta, 'abcdefg');
+    expect(ta.value).toBe('abcde');
+  });
+
+  it('hasError sets aria-invalid', () => {
+    render(<Textarea aria-label="x" hasError />);
+    expect(screen.getByRole('textbox', { name: 'x' })).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -1,0 +1,26 @@
+import { forwardRef, type TextareaHTMLAttributes } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  hasError?: boolean;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { className, hasError, rows = 4, ...props },
+  ref,
+) {
+  return (
+    <textarea
+      ref={ref}
+      rows={rows}
+      aria-invalid={hasError ? true : undefined}
+      className={cn(
+        'flex w-full rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--muted-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        hasError && 'border-[var(--destructive)] focus-visible:ring-[var(--destructive)]',
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/frontend/src/components/workspace/CaseDataTable.recentlyCreated.test.tsx
+++ b/frontend/src/components/workspace/CaseDataTable.recentlyCreated.test.tsx
@@ -1,0 +1,68 @@
+import { act, render as rtlRender, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import { buildCaseColumns } from '@/lib/buildCaseColumns';
+import { useUiStore } from '@/stores/uiStore';
+import {
+  buildCaseListFixture,
+  loanApplicationCaseTypeView,
+} from '@/test/fixtures/buildCaseListFixture';
+import { toCaseRow } from '@/types/case';
+
+import { CaseDataTable } from './CaseDataTable';
+
+function render(ui: ReactElement) {
+  return rtlRender(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
+}
+
+describe('CaseDataTable — recentlyCreatedCaseIds wiring (P5 / AC8)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useUiStore.setState({ recentlyCreatedCaseIds: new Set() });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const caseType = loanApplicationCaseTypeView();
+  const columns = buildCaseColumns(caseType);
+  const rows = buildCaseListFixture(3).map(toCaseRow);
+
+  it('applies the border-l-3 highlight to rows whose id is in recentlyCreatedCaseIds', () => {
+    const targetId = rows[1]!.id;
+    render(<CaseDataTable columns={columns} data={rows} emptyState="no-data" ariaLabel="Cases" />);
+    act(() => {
+      useUiStore.getState().pushRecentlyCreated(targetId);
+    });
+    const tr = document.querySelector(`tr[data-row-id="${targetId}"]`);
+    expect(tr).toBeTruthy();
+    expect(tr?.className).toMatch(/border-l-\[3px\]/);
+  });
+
+  it('announces the freshly-created case once via aria-live=polite', () => {
+    const targetId = rows[0]!.id;
+    render(<CaseDataTable columns={columns} data={rows} emptyState="no-data" ariaLabel="Cases" />);
+    expect(screen.getByRole('status')).toHaveTextContent('');
+    act(() => {
+      useUiStore.getState().pushRecentlyCreated(targetId);
+    });
+    expect(screen.getByRole('status')).toHaveTextContent(/created/i);
+  });
+
+  it('drops the highlight after the 6s TTL expires', () => {
+    const targetId = rows[2]!.id;
+    render(<CaseDataTable columns={columns} data={rows} emptyState="no-data" ariaLabel="Cases" />);
+    act(() => {
+      useUiStore.getState().pushRecentlyCreated(targetId);
+    });
+    let tr = document.querySelector(`tr[data-row-id="${targetId}"]`);
+    expect(tr?.className).toMatch(/border-l-\[3px\]/);
+    act(() => {
+      vi.advanceTimersByTime(6_001);
+    });
+    tr = document.querySelector(`tr[data-row-id="${targetId}"]`);
+    expect(tr?.className).not.toMatch(/border-l-\[3px\] border-\[var\(--primary\)\]/);
+  });
+});

--- a/frontend/src/components/workspace/CaseDataTable.tsx
+++ b/frontend/src/components/workspace/CaseDataTable.tsx
@@ -11,13 +11,14 @@ import {
   type VisibilityState,
 } from '@tanstack/react-table';
 import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
-import { useEffect, useMemo, useState, type KeyboardEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 
 import { Button } from '@/components/ui/Button';
 import { Table, TBody, THead, Th, Td, Tr } from '@/components/ui/Table';
 import { t } from '@/i18n';
 import { urgencyDefaultSort } from '@/lib/buildCaseColumns';
 import { cn } from '@/lib/cn';
+import { useUiStore } from '@/stores/uiStore';
 import type { CaseRow } from '@/types/case';
 
 export type EmptyState = 'no-data' | 'filtered';
@@ -89,6 +90,12 @@ export function CaseDataTable<TRow extends CaseRow = CaseRow>({
 }: CaseDataTableProps<TRow>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  // P5 — AC8: highlighted-row affordance + announcement for the freshly-created case. The set
+  // self-clears 6s after each push (uiStore TTL); subscribing here means a row repaints once the
+  // dialog pushes its id, and again when the timer trims it.
+  const recentlyCreated = useUiStore((s) => s.recentlyCreatedCaseIds);
+  const announcedRef = useRef<Set<string>>(new Set());
+  const [announceMessage, setAnnounceMessage] = useState<string>('');
   // AC7 #4 — roving tabindex. Only the active row carries `tabIndex={0}` so Tab leaves the
   // table after a single stop instead of walking every row. Initial entry point is row 0; on
   // `onFocus` the active index follows the user's last-focused row, so Tab back into the table
@@ -164,6 +171,21 @@ export function CaseDataTable<TRow extends CaseRow = CaseRow>({
     if (!onSortedRowsChange) return;
     onSortedRowsChange(navRows.map((r) => r.original));
   }, [navRows, onSortedRowsChange]);
+
+  // P5 — AC8: announce the freshly-created case once per id. Walks the recently-created set;
+  // any id that appears in `data` AND has not yet been announced gets a one-shot polite live-
+  // region update. The id is recorded in `announcedRef` so re-renders don't re-announce.
+  useEffect(() => {
+    if (recentlyCreated.size === 0) return;
+    for (const id of recentlyCreated) {
+      if (announcedRef.current.has(id)) continue;
+      const matched = data.find((row) => row.id === id);
+      if (!matched) continue;
+      announcedRef.current.add(id);
+      const idShort = id.length > 8 ? `${id.slice(0, 8)}…` : id;
+      setAnnounceMessage(t('cases.created.announcement', { idShort }));
+    }
+  }, [recentlyCreated, data]);
 
   // AC5 — when the search input is non-empty OR the parent declared a filtered context, render the
   // 'filtered' empty copy. Earlier ternary form was parsed as `showEmpty && (cond1 ? true : cond2)`
@@ -269,7 +291,10 @@ export function CaseDataTable<TRow extends CaseRow = CaseRow>({
                 onKeyDown={(e) => handleRowKeyDown(e, row, idx)}
                 onClick={() => onRowSelect?.(row.original)}
                 className={cn(
-                  row.original.hasUnreadActivity && 'border-l-[3px] border-[var(--primary)]',
+                  // P5 — recentlyCreated reuses the same border-l affordance as unread activity
+                  // (AC8 explicitly says "the same affordance 2.5 §AC11 added for hasUnreadActivity").
+                  (row.original.hasUnreadActivity || recentlyCreated.has(row.original.id)) &&
+                    'border-l-[3px] border-[var(--primary)]',
                   'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]',
                 )}
               >
@@ -286,6 +311,9 @@ export function CaseDataTable<TRow extends CaseRow = CaseRow>({
           )}
         </TBody>
       </Table>
+      <div role="status" aria-live="polite" className="sr-only">
+        {announceMessage}
+      </div>
       {!isLoading && filteredCount > PAGE_SIZE ? (
         <div className="flex items-center justify-end gap-2 px-2 py-2 text-sm">
           <Button

--- a/frontend/src/components/workspace/CaseDetailPanel.test.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.test.tsx
@@ -39,7 +39,6 @@ const dto: CaseDto = {
         required: true,
         order: 0,
         options: [],
-        slots: null,
       },
     ],
     statuses: [],

--- a/frontend/src/components/workspace/NewCaseButton.permissions.test.tsx
+++ b/frontend/src/components/workspace/NewCaseButton.permissions.test.tsx
@@ -1,0 +1,77 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import { caseTypeSummaryFixture } from '@/test/fixtures/buildCaseListFixture';
+import { server } from '@/test/server';
+
+import { NewCaseButton } from './NewCaseButton';
+
+function renderWithProviders(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('NewCaseButton — permission filter (AC9)', () => {
+  it('only shows case types in the dropdown where the caller holds the `create` verb', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get('/api/case-types', () =>
+        HttpResponse.json({
+          data: [
+            caseTypeSummaryFixture({
+              id: 'a',
+              displayName: 'Alpha',
+              permissions: ['view', 'create'],
+            }),
+            caseTypeSummaryFixture({ id: 'b', displayName: 'Bravo', permissions: ['view'] }),
+            caseTypeSummaryFixture({
+              id: 'c',
+              displayName: 'Charlie',
+              permissions: ['view', 'create'],
+            }),
+          ],
+          meta: {},
+        }),
+      ),
+    );
+    renderWithProviders(<NewCaseButton />);
+    await user.click(await screen.findByRole('button', { name: /new case/i }));
+
+    // Bravo (no create) must not appear in the dropdown.
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'Alpha' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Charlie' })).toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'Bravo' })).toBeNull();
+    });
+  });
+
+  it('treats missing permissions array as no create access (defensive)', async () => {
+    server.use(
+      http.get('/api/case-types', () =>
+        HttpResponse.json({
+          data: [{ ...caseTypeSummaryFixture(), permissions: undefined }],
+          meta: {},
+        }),
+      ),
+    );
+    renderWithProviders(<NewCaseButton />);
+    await waitFor(() => {
+      const btn = screen.getByRole('button');
+      expect(btn).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/components/workspace/NewCaseButton.test.tsx
+++ b/frontend/src/components/workspace/NewCaseButton.test.tsx
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import {
+  caseTypeSummaryFixture,
+  loanApplicationCaseTypeView,
+} from '@/test/fixtures/buildCaseListFixture';
+import { server } from '@/test/server';
+
+import { NewCaseButton } from './NewCaseButton';
+
+function renderWithProviders(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('NewCaseButton — render states (AC1)', () => {
+  it('renders a skeleton placeholder while case-types are loading (P23)', () => {
+    server.use(
+      http.get('/api/case-types', () => new Promise(() => {})), // never resolves
+    );
+    renderWithProviders(<NewCaseButton />);
+    // Skeleton renders as an aria-hidden span (no role=button) — the placeholder, not a real
+    // disabled button.
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(document.querySelector('[aria-hidden].animate-pulse')).toBeInTheDocument();
+  });
+
+  it('renders a disabled button + tooltip when the user has create on zero case types', async () => {
+    server.use(
+      http.get('/api/case-types', () =>
+        HttpResponse.json({
+          data: [caseTypeSummaryFixture({ permissions: ['view'] })],
+          meta: {},
+        }),
+      ),
+    );
+    renderWithProviders(<NewCaseButton />);
+    await waitFor(() => {
+      const btn = screen.getByRole('button');
+      expect(btn).toBeDisabled();
+      expect(btn).toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  it('opens the dialog directly when there is exactly one creatable case type', async () => {
+    const user = userEvent.setup();
+    const view = loanApplicationCaseTypeView();
+    server.use(
+      http.get('/api/case-types', () =>
+        HttpResponse.json({ data: [caseTypeSummaryFixture()], meta: {} }),
+      ),
+      http.get(`/api/case-types/${view.id}`, () => HttpResponse.json({ data: view, meta: {} })),
+    );
+    renderWithProviders(<NewCaseButton />);
+    await user.click(await screen.findByRole('button', { name: /new case/i }));
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    expect(screen.getByText(/New Loan Application/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/workspace/NewCaseButton.tsx
+++ b/frontend/src/components/workspace/NewCaseButton.tsx
@@ -1,0 +1,138 @@
+import { Plus } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
+import { useCaseType, useCaseTypes } from '@/hooks/useCaseTypes';
+import { t } from '@/i18n';
+import type { CaseTypeSummary } from '@/types/caseType';
+
+import { NewCaseDialog } from './NewCaseDialog';
+
+/**
+ * Story 2.7 AC1 — primary CTA for creating a new case. Lives in the workspace header. Behavior:
+ *
+ * - 0 case types user can create → button disabled with tooltip explanation.
+ * - 1 case type → click opens the dialog directly (skip the picker).
+ * - ≥ 2 → click opens an inline dropdown listing each accessible case type by displayName.
+ *
+ * The verb filter is applied client-side from the {@code permissions[]} array on each summary
+ * (Story 2.7 AC9 — backend populates the caller's verbs into the list response, so the dropdown
+ * never shows non-actionable options).
+ */
+export function NewCaseButton() {
+  const caseTypesQuery = useCaseTypes();
+  const [openDialogFor, setOpenDialogFor] = useState<string | null>(null);
+
+  const summaries = caseTypesQuery.data ?? [];
+  const creatable = summaries.filter(
+    (s: CaseTypeSummary) => Array.isArray(s.permissions) && s.permissions.includes('create'),
+  );
+
+  if (caseTypesQuery.isLoading) {
+    // P23 — render an inert skeleton placeholder (not a disabled button) so the header layout
+    // doesn't shift but the affordance reads as loading.
+    return (
+      <span
+        aria-hidden
+        className="inline-block h-9 w-28 animate-pulse rounded-[var(--radius-md)] bg-[var(--muted)]"
+      />
+    );
+  }
+
+  if (creatable.length === 0) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span tabIndex={0}>
+            <Button variant="default" disabled aria-disabled="true">
+              <Plus className="size-4" aria-hidden />
+              {t('cases.create.button')}
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{t('cases.create.noTypes')}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  // P1 — close handler must always set openDialogFor to null on close. The previous
+  // `(open) => setOpenDialogFor(open ? <existing-id> : null)` captured the existing id from
+  // render and re-asserted it on Radix's `open=true` callbacks, making the dialog effectively
+  // un-closeable in the multi-type branch.
+  const handleOpenChange = (open: boolean) => {
+    if (!open) setOpenDialogFor(null);
+  };
+
+  // Single case type — click opens the dialog directly.
+  if (creatable.length === 1) {
+    const ct = creatable[0]!;
+    return (
+      <>
+        <Button
+          variant="default"
+          onClick={() => setOpenDialogFor(ct.id)}
+          aria-label={t('cases.create.button')}
+        >
+          <Plus className="size-4" aria-hidden />
+          {t('cases.create.button')}
+        </Button>
+        <NewCaseDialogLoader caseTypeId={openDialogFor} onOpenChange={handleOpenChange} />
+      </>
+    );
+  }
+
+  // ≥ 2 case types — render dropdown picker.
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="default">
+            <Plus className="size-4" aria-hidden />
+            {t('cases.create.button')}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {creatable.map((ct) => (
+            <DropdownMenuItem key={ct.id} onSelect={() => setOpenDialogFor(ct.id)}>
+              {ct.displayName}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <NewCaseDialogLoader caseTypeId={openDialogFor} onOpenChange={handleOpenChange} />
+    </>
+  );
+}
+
+/**
+ * Defers the case-type detail fetch until a user opens the dialog. Until then the picker only
+ * needs the summary list (already loaded). On open we fetch the full {@code CaseTypeView} —
+ * required for the form to know which fields to render and how to validate them.
+ *
+ * P1 — gate the rendered `caseType` on id-match so a fast pick-A-then-pick-B sequence doesn't
+ * flash the previous case-type's fields while TanStack returns previous data during refetch.
+ */
+function NewCaseDialogLoader({
+  caseTypeId,
+  onOpenChange,
+}: {
+  caseTypeId: string | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const detail = useCaseType(caseTypeId ?? undefined);
+  const matched = detail.data && caseTypeId && detail.data.id === caseTypeId ? detail.data : null;
+  return (
+    <NewCaseDialog
+      open={caseTypeId !== null && matched !== null}
+      caseType={matched}
+      onOpenChange={onOpenChange}
+    />
+  );
+}

--- a/frontend/src/components/workspace/NewCaseDialog.test.tsx
+++ b/frontend/src/components/workspace/NewCaseDialog.test.tsx
@@ -1,0 +1,132 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import { loanApplicationCaseTypeView } from '@/test/fixtures/buildCaseListFixture';
+import { server } from '@/test/server';
+
+import { NewCaseDialog } from './NewCaseDialog';
+
+function renderWithProviders(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('NewCaseDialog — render shape (AC2/AC3)', () => {
+  it('renders one FormField per requiredOnCreate field, in order', () => {
+    const view = loanApplicationCaseTypeView();
+    renderWithProviders(<NewCaseDialog open caseType={view} onOpenChange={() => {}} />);
+    // Two requiredOnCreate fields in fixture: applicant_name (text), amount (number)
+    expect(screen.getByLabelText(/Applicant/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Amount/)).toBeInTheDocument();
+  });
+
+  it('shows the empty-state copy when the case type has zero requiredOnCreate fields', () => {
+    const view = loanApplicationCaseTypeView();
+    view.fields = view.fields.map((f) => ({ ...f, requiredOnCreate: false }));
+    renderWithProviders(<NewCaseDialog open caseType={view} onOpenChange={() => {}} />);
+    expect(screen.getByText(/no fields are required/i)).toBeInTheDocument();
+  });
+
+  it('returns null and does not mount when caseType is null', () => {
+    renderWithProviders(<NewCaseDialog open caseType={null} onOpenChange={() => {}} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+describe('NewCaseDialog — submit success path (AC7)', () => {
+  it('on success: closes the dialog and primes the navigation', async () => {
+    const user = userEvent.setup();
+    const view = loanApplicationCaseTypeView();
+    let openState = true;
+    server.use(
+      http.post('/api/cases', () =>
+        HttpResponse.json({
+          data: {
+            id: '11111111-2222-3333-4444-555555555555',
+            caseTypeId: view.id,
+            caseTypeVersion: view.version,
+            status: 'open',
+            assignee: null,
+            data: { applicant_name: 'Asha', amount: 5000 },
+            processInstanceId: null,
+            documentCount: 0,
+            createdAt: '2026-04-01T00:00:00Z',
+            createdBy: null,
+            updatedAt: '2026-04-01T00:00:00Z',
+            version: 1,
+            caseType: view,
+          },
+          meta: {},
+        }),
+      ),
+    );
+    renderWithProviders(
+      <NewCaseDialog
+        open
+        caseType={view}
+        onOpenChange={(next) => {
+          openState = next;
+        }}
+      />,
+    );
+    await user.type(screen.getByLabelText(/Applicant/), 'Asha');
+    await user.type(screen.getByLabelText(/Amount/), '5000');
+    await user.click(screen.getByRole('button', { name: /create case/i }));
+    await waitFor(() => expect(openState).toBe(false));
+  });
+});
+
+describe('NewCaseDialog — submit failure paths (AC5/P2/P4)', () => {
+  it('422 with field error maps the message onto the matching FormField', async () => {
+    const user = userEvent.setup();
+    const view = loanApplicationCaseTypeView();
+    server.use(
+      http.post('/api/cases', () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 'WKS-API-001',
+              message: 'Validation failed',
+              errors: [{ code: 'WKS-API-001', message: 'Amount too high', field: 'amount' }],
+            },
+          },
+          { status: 422 },
+        ),
+      ),
+    );
+    renderWithProviders(<NewCaseDialog open caseType={view} onOpenChange={() => {}} />);
+    await user.type(screen.getByLabelText(/Applicant/), 'Asha');
+    await user.type(screen.getByLabelText(/Amount/), '999999');
+    await user.click(screen.getByRole('button', { name: /create case/i }));
+    await waitFor(() => expect(screen.getByText('Amount too high')).toBeInTheDocument());
+  });
+
+  it('403 surfaces auth-specific banner copy (P4)', async () => {
+    const user = userEvent.setup();
+    const view = loanApplicationCaseTypeView();
+    server.use(
+      http.post('/api/cases', () =>
+        HttpResponse.json({ error: { code: 'WKS-API-403', message: 'denied' } }, { status: 403 }),
+      ),
+    );
+    renderWithProviders(<NewCaseDialog open caseType={view} onOpenChange={() => {}} />);
+    await user.type(screen.getByLabelText(/Applicant/), 'Asha');
+    await user.type(screen.getByLabelText(/Amount/), '500');
+    await user.click(screen.getByRole('button', { name: /create case/i }));
+    await waitFor(() => expect(screen.getByText(/no longer have permission/i)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/workspace/NewCaseDialog.tsx
+++ b/frontend/src/components/workspace/NewCaseDialog.tsx
@@ -1,0 +1,411 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+import { ApiError } from '@/api/client';
+import { Alert } from '@/components/ui/Alert';
+import { Button } from '@/components/ui/Button';
+import { Checkbox } from '@/components/ui/Checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Dialog';
+import { FormField, type FormFieldRenderProps } from '@/components/ui/FormField';
+import { Input } from '@/components/ui/Input';
+import { MutationButton, type MutationButtonState } from '@/components/ui/MutationButton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import { Textarea } from '@/components/ui/Textarea';
+import { useCreateCase } from '@/hooks/useCases';
+import { t } from '@/i18n';
+import { buildZodFromFieldDefs } from '@/lib/buildZodFromFieldDefs';
+import { useUiStore } from '@/stores/uiStore';
+import type { CaseTypeView, FieldDefinition } from '@/types/caseType';
+
+interface ServerErrorBanner {
+  title: string;
+  message: string;
+}
+
+export interface NewCaseDialogProps {
+  open: boolean;
+  caseType: CaseTypeView | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Story 2.7 — Case-creation dialog. Renders one FormField per `requiredOnCreate: true` field in
+ * declared order, validates via runtime-built Zod, and submits via `useCreateCase`. On success
+ * primes the detail-cache, invalidates the list, pushes the id into recentlyCreated, and
+ * navigates to /cases/{id}. On 422 with field-level errors, maps them onto RHF via setError;
+ * envelope errors render a banner with the confidence-not-safety copy.
+ */
+export function NewCaseDialog({ open, caseType, onOpenChange }: NewCaseDialogProps) {
+  const navigate = useNavigate();
+  const createCase = useCreateCase();
+  const pushRecentlyCreated = useUiStore((s) => s.pushRecentlyCreated);
+  const [serverError, setServerError] = useState<ServerErrorBanner | null>(null);
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+
+  const requiredFields = useMemo<FieldDefinition[]>(() => {
+    if (!caseType) return [];
+    return caseType.fields.filter((f) => f.requiredOnCreate).sort((a, b) => a.order - b.order);
+  }, [caseType]);
+
+  const schema = useMemo(
+    () => (caseType ? buildZodFromFieldDefs(requiredFields, 'create') : null),
+    [caseType, requiredFields],
+  );
+
+  // Default values keyed by field id so controlled inputs are always controlled. Checkboxes
+  // default to false, everything else to ''. P20 — derived from the current required-fields list
+  // so a same-id YAML refresh that swaps the schema also re-keys defaults.
+  const defaultValues = useMemo<Record<string, unknown>>(() => {
+    const dv: Record<string, unknown> = {};
+    for (const f of requiredFields) dv[f.id] = f.type === 'checkbox' ? false : '';
+    return dv;
+  }, [requiredFields]);
+
+  const form = useForm<Record<string, unknown>>({
+    resolver: schema ? zodResolver(schema) : undefined,
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+    shouldFocusError: true,
+    defaultValues,
+  });
+
+  // Reset on dialog open OR when the field set changes (case-type switch / YAML refresh). The
+  // dep on `defaultValues` (memoised on requiredFields) handles the same-id-different-schema
+  // case the previous `[open, caseType?.id]` dep missed.
+  useEffect(() => {
+    if (!open) return;
+    form.reset(defaultValues);
+    setServerError(null);
+    createCase.reset();
+    // form/createCase are stable refs from RHF/TanStack — disabling exhaustive-deps to avoid
+    // pinning over-eagerly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, defaultValues]);
+
+  // P22 — focus the form-level error banner when one appears so screen readers announce it
+  // immediately and keyboard users land on the recovery copy.
+  useEffect(() => {
+    if (!serverError) return;
+    bannerRef.current?.focus();
+  }, [serverError]);
+
+  if (!caseType) return null;
+
+  const isPending = createCase.isPending;
+  const state: MutationButtonState = isPending
+    ? 'confirming'
+    : createCase.isSuccess
+      ? 'confirmed'
+      : createCase.isError || serverError
+        ? 'failed'
+        : 'idle';
+
+  async function onSubmit(values: Record<string, unknown>): Promise<void> {
+    setServerError(null);
+    try {
+      // We've already exited the !caseType guard above — narrow safely.
+      const ct = caseType!;
+      const dto = await createCase.mutateAsync({
+        caseTypeId: ct.id,
+        data: values,
+        assignee: null,
+      });
+      pushRecentlyCreated(dto.id);
+      onOpenChange(false);
+      navigate(`/cases/${dto.id}`);
+    } catch (err) {
+      handleSubmitError(err);
+    }
+  }
+
+  function handleSubmitError(err: unknown): void {
+    if (err instanceof ApiError && err.status === 403) {
+      // P4 — 403 means permission was revoked between dropdown render and submit. Surface
+      // auth-specific copy so the user knows retry is futile until they refresh / talk to admin.
+      setServerError({
+        title: t('cases.create.errorBanner.forbiddenTitle'),
+        message: t('cases.create.errorBanner.forbiddenBody'),
+      });
+      return;
+    }
+    if (err instanceof ApiError && err.status === 422 && err.envelopeErrors) {
+      let firstFieldName: string | null = null;
+      const unmapped: string[] = [];
+      const knownIds = new Set(caseType!.fields.map((f) => f.id));
+      for (const e of err.envelopeErrors) {
+        // P2 — route every field error through setError, not just `requiredOnCreate` ones.
+        // Backend may legitimately reject a non-required field (e.g. defaulted by mapper).
+        if (e.field && knownIds.has(e.field)) {
+          form.setError(e.field, { type: 'server', message: e.message });
+          if (firstFieldName === null) firstFieldName = e.field;
+        } else if (e.message) {
+          unmapped.push(e.message);
+        }
+      }
+      if (firstFieldName === null) {
+        setServerError({
+          title: t('cases.create.errorBanner.title'),
+          message: unmapped.length > 0 ? unmapped.join(' · ') : t('cases.create.errorBanner.body'),
+        });
+      } else {
+        form.setFocus(firstFieldName);
+        if (unmapped.length > 0) {
+          // Field errors are surfaced inline; surface any non-field errors in the banner so they
+          // aren't silently dropped.
+          setServerError({
+            title: t('cases.create.errorBanner.title'),
+            message: unmapped.join(' · '),
+          });
+        }
+      }
+      return;
+    }
+    if (err instanceof ApiError) {
+      setServerError({
+        title: t('cases.create.errorBanner.title'),
+        message: t('cases.create.errorBanner.body'),
+      });
+      return;
+    }
+    // Network / unknown — distinguish from server-side rejection per the error-content pattern.
+    setServerError({
+      title: t('cases.create.errorBanner.title'),
+      message: t('cases.create.errorBanner.networkBody'),
+    });
+  }
+
+  // P10 — block ESC / outside-click while the mutation is in flight. Without this the dialog
+  // unmounts mid-request: success fires `pushRecentlyCreated` + navigate from a closed surface,
+  // failure setStates an unmounted component and the error vanishes.
+  const blockCloseWhilePending = (e: Event) => {
+    if (isPending) e.preventDefault();
+  };
+
+  // P8 — wire a Retry slot into the failed-state lifecycle button so the user doesn't have to
+  // close the dialog to clear the error.
+  const retryAction = (
+    <Button
+      type="button"
+      variant="ghost"
+      onClick={() => {
+        setServerError(null);
+        createCase.reset();
+        void form.handleSubmit(onSubmit)();
+      }}
+    >
+      {t('common.retry')}
+    </Button>
+  );
+
+  // P9 — interpolate {reason} into the failed lifecycle label so the SR announcement and
+  // visible chip carry the actual server message (or a generic fallback).
+  const failedReason =
+    serverError?.message ?? (createCase.error instanceof Error ? createCase.error.message : null);
+  const failedLabel = failedReason
+    ? t('common.lifecycle.failed', { reason: failedReason })
+    : t('common.lifecycle.failedNoReason');
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (isPending ? null : onOpenChange(next))}>
+      <DialogContent
+        onEscapeKeyDown={blockCloseWhilePending}
+        onPointerDownOutside={blockCloseWhilePending}
+        onInteractOutside={blockCloseWhilePending}
+        // P22 — opt out of Radix's default focus-restore so the next page (case detail) can
+        // claim focus on its own <h1>.
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {t('cases.create.dialogTitle', { caseTypeName: caseType.displayName })}
+          </DialogTitle>
+        </DialogHeader>
+        <FormProvider {...form}>
+          <form
+            noValidate
+            onSubmit={form.handleSubmit(onSubmit)}
+            aria-busy={isPending ? true : undefined}
+            className="flex flex-col gap-[var(--form-field-gap,1rem)]"
+          >
+            {requiredFields.length === 0 ? (
+              <p className="text-sm text-[var(--muted-foreground)]">
+                {t('cases.create.noRequired', { caseTypeName: caseType.displayName })}
+              </p>
+            ) : (
+              requiredFields.map((f) => renderField(f, isPending, form))
+            )}
+            {serverError ? (
+              <Alert
+                ref={bannerRef}
+                tabIndex={-1}
+                role="alert"
+                variant="destructive"
+                className="py-[var(--space-2)] text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+              >
+                <strong className="block">{serverError.title}</strong>
+                <span>{serverError.message}</span>
+              </Alert>
+            ) : null}
+            <DialogFooter>
+              <Button
+                variant="ghost"
+                type="button"
+                onClick={() => onOpenChange(false)}
+                disabled={isPending}
+              >
+                {t('common.cancel')}
+              </Button>
+              <MutationButton
+                state={state}
+                confirmingLabel={t('common.lifecycle.confirming')}
+                confirmedLabel={t('common.lifecycle.confirmed')}
+                failedLabel={failedLabel}
+                retryAction={retryAction}
+              >
+                {t('cases.create.submit')}
+              </MutationButton>
+            </DialogFooter>
+          </form>
+        </FormProvider>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function renderField(
+  f: FieldDefinition,
+  disabled: boolean,
+  form: UseFormReturn<Record<string, unknown>>,
+) {
+  if (f.type === 'file') {
+    return (
+      <p key={f.id} className="text-sm text-[var(--muted-foreground)]">
+        {t('cases.create.fileNotYet')}
+      </p>
+    );
+  }
+  return (
+    <FormField
+      key={f.id}
+      name={f.id}
+      label={f.displayName}
+      required={f.requiredOnCreate}
+      disabled={disabled}
+    >
+      {(field) => renderInput(f, field, form)}
+    </FormField>
+  );
+}
+
+function renderInput(
+  f: FieldDefinition,
+  field: FormFieldRenderProps<Record<string, unknown>, string>,
+  form: UseFormReturn<Record<string, unknown>>,
+) {
+  switch (f.type) {
+    case 'text':
+      return (
+        <Input
+          type="text"
+          maxLength={f.maxLength ?? undefined}
+          {...field}
+          value={String(field.value ?? '')}
+        />
+      );
+    case 'textarea':
+      return (
+        <Textarea
+          maxLength={f.maxLength ?? undefined}
+          {...field}
+          value={String(field.value ?? '')}
+        />
+      );
+    case 'number':
+      return (
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={f.min ?? undefined}
+          max={f.max ?? undefined}
+          step={f.step ?? 1}
+          {...field}
+          value={field.value === undefined || field.value === null ? '' : String(field.value)}
+        />
+      );
+    case 'date':
+      return (
+        <Input
+          type="date"
+          min={f.dateMin ?? undefined}
+          max={f.dateMax ?? undefined}
+          {...field}
+          value={String(field.value ?? '')}
+        />
+      );
+    case 'select': {
+      // P14 — `value=""` is a Radix anti-pattern; pass undefined so SelectValue renders the
+      // placeholder. P25 — go through field.onChange (RHF onBlur mode) so validation timing
+      // matches the rest of the form instead of forcing-validate on every change.
+      const stringValue =
+        typeof field.value === 'string' && field.value !== '' ? field.value : undefined;
+      return (
+        <Select
+          value={stringValue}
+          onValueChange={(v) => {
+            field.onChange(v);
+            // Trigger field-level blur so onBlur validation kicks in once the user picks.
+            void form.trigger(f.id);
+          }}
+          disabled={field.disabled}
+        >
+          <SelectTrigger
+            id={field.id}
+            aria-invalid={field['aria-invalid']}
+            aria-describedby={field['aria-describedby']}
+            ref={field.ref as unknown as React.Ref<HTMLButtonElement>}
+          >
+            <SelectValue placeholder={t('cases.create.selectPlaceholder')} />
+          </SelectTrigger>
+          <SelectContent>
+            {f.options.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }
+    case 'checkbox':
+      return (
+        <Checkbox
+          id={field.id}
+          checked={Boolean(field.value)}
+          onCheckedChange={(v) => {
+            field.onChange(Boolean(v));
+            void form.trigger(f.id);
+          }}
+          disabled={field.disabled}
+          aria-invalid={field['aria-invalid']}
+          aria-describedby={field['aria-describedby']}
+          ref={field.ref as unknown as React.Ref<HTMLButtonElement>}
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/frontend/src/components/workspace/PropertiesTab.test.tsx
+++ b/frontend/src/components/workspace/PropertiesTab.test.tsx
@@ -20,7 +20,6 @@ function ctView(over: Partial<CaseTypeView> = {}): CaseTypeView {
         required: true,
         order: 0,
         options: [],
-        slots: null,
       },
       {
         id: 'amount',
@@ -29,7 +28,6 @@ function ctView(over: Partial<CaseTypeView> = {}): CaseTypeView {
         required: false,
         order: 1,
         options: [],
-        slots: null,
       },
       {
         id: 'priority',
@@ -41,7 +39,6 @@ function ctView(over: Partial<CaseTypeView> = {}): CaseTypeView {
           { value: 'low', label: 'Low' },
           { value: 'high', label: 'High' },
         ],
-        slots: null,
       },
     ],
     statuses: [],

--- a/frontend/src/hooks/useCases.ts
+++ b/frontend/src/hooks/useCases.ts
@@ -1,6 +1,14 @@
-import { skipToken, useQueries, useQuery, type UseQueryResult } from '@tanstack/react-query';
+import {
+  skipToken,
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
 
-import { getCase, listCases } from '@/api/cases';
+import { createCase, getCase, listCases, type CreateCaseRequest } from '@/api/cases';
 import { caseQueryKeys, type CaseListQuery } from '@/lib/queryKeys';
 import { toCaseRow, type CaseDto, type CaseRow } from '@/types/case';
 
@@ -88,5 +96,28 @@ export function useCase(id: string | null): UseQueryResult<CaseDto, Error> {
     queryFn: id ? () => getCase(id) : skipToken,
     staleTime: STALE_TIME_MS,
     refetchOnWindowFocus: true,
+  });
+}
+
+/**
+ * Story 2.7 — `POST /api/cases` mutation. On success: primes the detail-cache for the new id
+ * (so the navigate to /cases/{id} paints from cache before the network round-trip), and
+ * invalidates the cases-list queries so the next render picks the new row up. The new-case
+ * highlight + announcement (recentlyCreated push) and the navigate are caller responsibility —
+ * the hook stays UI-agnostic so unit tests can wrap it without a router.
+ *
+ * No automatic retry on 5xx — case-create has user-typed payload; silent retry can produce
+ * duplicates if the backend half-succeeded. Idempotency-key headers ship in Phase 1.
+ */
+export function useCreateCase(): UseMutationResult<CaseDto, Error, CreateCaseRequest> {
+  const queryClient = useQueryClient();
+  return useMutation<CaseDto, Error, CreateCaseRequest>({
+    mutationKey: ['cases', 'create'],
+    mutationFn: createCase,
+    onSuccess: (dto) => {
+      queryClient.setQueryData(caseQueryKeys.detail(dto.id), dto);
+      queryClient.invalidateQueries({ queryKey: caseQueryKeys.lists() });
+    },
+    retry: false,
   });
 }

--- a/frontend/src/hooks/useCreateCase.test.tsx
+++ b/frontend/src/hooks/useCreateCase.test.tsx
@@ -1,0 +1,93 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@/test/server';
+import type { CaseDto } from '@/types/case';
+
+import { useCreateCase } from './useCases';
+
+const NEW_ID = '99999999-aaaa-bbbb-cccc-dddddddddddd';
+
+const fixture: CaseDto = {
+  id: NEW_ID,
+  caseTypeId: 'loan_application',
+  caseTypeVersion: 3,
+  status: 'open',
+  assignee: null,
+  data: { applicant_name: 'Asha' },
+  processInstanceId: null,
+  documentCount: 0,
+  createdAt: '2026-04-01T00:00:00Z',
+  createdBy: null,
+  updatedAt: '2026-04-01T00:00:00Z',
+  version: 1,
+  caseType: {
+    id: 'loan_application',
+    displayName: 'Loan Application',
+    version: 3,
+    fields: [],
+    statuses: [],
+    listColumns: [],
+  },
+};
+
+function setupClient() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return client;
+}
+
+function buildWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useCreateCase', () => {
+  it('on success: stores the new case in detail cache and invalidates list queries', async () => {
+    server.use(http.post('/api/cases', () => HttpResponse.json({ data: fixture, meta: {} })));
+    const client = setupClient();
+    const wrapper = buildWrapper(client);
+    const invalidate = client.invalidateQueries.bind(client);
+    let invalidatedListsCount = 0;
+    client.invalidateQueries = ((args: Parameters<typeof invalidate>[0]) => {
+      const key = args?.queryKey?.[0];
+      if (key === 'cases' || key === 'case-list') invalidatedListsCount += 1;
+      return invalidate(args);
+    }) as typeof invalidate;
+
+    const { result } = renderHook(() => useCreateCase(), { wrapper });
+    await result.current.mutateAsync({
+      caseTypeId: 'loan_application',
+      data: { applicant_name: 'Asha' },
+      assignee: null,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.id).toBe(NEW_ID);
+    expect(invalidatedListsCount).toBeGreaterThan(0);
+  });
+
+  it('does NOT auto-retry on 5xx (silent retry would duplicate the case server-side)', async () => {
+    let callCount = 0;
+    server.use(
+      http.post('/api/cases', () => {
+        callCount += 1;
+        return HttpResponse.json({ error: { code: 'WKS-API-500' } }, { status: 500 });
+      }),
+    );
+    const wrapper = buildWrapper(setupClient());
+    const { result } = renderHook(() => useCreateCase(), { wrapper });
+    await expect(
+      result.current.mutateAsync({
+        caseTypeId: 'loan_application',
+        data: {},
+        assignee: null,
+      }),
+    ).rejects.toBeTruthy();
+    expect(callCount).toBe(1);
+  });
+});

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -111,5 +111,47 @@
   "cases.filter.add": "Add filter",
   "cases.idTooltip.label": "Full case id",
 
-  "common.retry": "Retry"
+  "common.retry": "Retry",
+
+  "common.cancel": "Cancel",
+  "common.close": "Close",
+  "common.lifecycle.confirming": "Confirming…",
+  "common.lifecycle.confirmed": "Confirmed",
+  "common.lifecycle.failed": "Failed — {reason}",
+  "common.lifecycle.failedNoReason": "Failed",
+  "common.lifecycle.retry": "Retry",
+
+  "cases.create.button": "New case",
+  "cases.create.dialogTitle": "New {caseTypeName}",
+  "cases.create.dialogClose": "Close create case dialog",
+  "cases.create.submit": "Create case",
+  "cases.create.cancel": "Cancel",
+  "cases.create.noTypes": "No case type available — load a template or ask an admin",
+  "cases.create.noRequired": "No fields are required to create a {caseTypeName}. Click create to start.",
+  "cases.create.fileNotYet": "File upload arrives in Epic 3 — Story 3.1.",
+  "cases.create.errorsCount": "{count} fields need attention",
+  "cases.create.errorBanner.title": "Couldn't create case",
+  "cases.create.errorBanner.body": "Your input is preserved. Try again or correct the highlighted fields.",
+  "cases.create.errorBanner.networkBody": "Couldn't reach the server. Your input is preserved — check your connection and try again.",
+  "cases.create.errorBanner.forbiddenTitle": "You no longer have permission",
+  "cases.create.errorBanner.forbiddenBody": "Your account no longer has permission to create this case type. Refresh and check with your admin.",
+  "cases.create.errorBanner.retry": "Try again",
+  "cases.create.selectPlaceholder": "Choose…",
+
+  "cases.create.errors.required": "This field is required",
+  "cases.create.errors.tooShort": "Must be at least {min} characters",
+  "cases.create.errors.tooLong": "Must be {max} characters or fewer",
+  "cases.create.errors.notNumber": "Must be a number",
+  "cases.create.errors.notMultipleOf": "Must be a multiple of {step}",
+  "cases.create.errors.lt": "Must be at least {min}",
+  "cases.create.errors.gt": "Must be at most {max}",
+  "cases.create.errors.notDate": "Must be a date (YYYY-MM-DD)",
+  "cases.create.errors.dateRange": "Must be between {min} and {max}",
+  "cases.create.errors.notInList": "Pick one of the available options",
+  "cases.create.errors.mustCheck": "You must check this box to proceed",
+
+  "cases.created.announcement": "Case {idShort} created",
+
+  "login.errors.notEmail": "Enter a valid email address",
+  "login.errors.passwordRequired": "Password is required"
 }

--- a/frontend/src/lib/buildCaseColumns.test.tsx
+++ b/frontend/src/lib/buildCaseColumns.test.tsx
@@ -120,7 +120,6 @@ describe('buildCaseColumns', () => {
           required: false,
           order: 2,
           options: [],
-          slots: null,
         } satisfies FieldDefinition,
         {
           id: 'attach',
@@ -129,7 +128,6 @@ describe('buildCaseColumns', () => {
           required: false,
           order: 3,
           options: [],
-          slots: null,
         } satisfies FieldDefinition,
       ],
       listColumns: [...caseType.listColumns, 'notes', 'attach'],

--- a/frontend/src/lib/buildZodFromFieldDefs.test.ts
+++ b/frontend/src/lib/buildZodFromFieldDefs.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FieldDefinition } from '@/types/caseType';
+
+import { buildZodFromFieldDefs } from './buildZodFromFieldDefs';
+
+function field(over: Partial<FieldDefinition>): FieldDefinition {
+  return {
+    id: 'x',
+    displayName: 'X',
+    type: 'text',
+    required: true,
+    requiredOnCreate: true,
+    order: 0,
+    options: [],
+    ...over,
+  };
+}
+
+describe('buildZodFromFieldDefs — create mode filter', () => {
+  it('only includes fields where requiredOnCreate is true', () => {
+    const schema = buildZodFromFieldDefs(
+      [field({ id: 'a', requiredOnCreate: true }), field({ id: 'b', requiredOnCreate: false })],
+      'create',
+    );
+    expect(Object.keys(schema.shape)).toEqual(['a']);
+  });
+});
+
+describe('buildZodFromFieldDefs — text', () => {
+  it('rejects empty string with required message', () => {
+    const schema = buildZodFromFieldDefs([field({ id: 'a', maxLength: 10 })], 'create');
+    const result = schema.safeParse({ a: '' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.issues[0]?.message).toMatch(/required/i);
+  });
+
+  it('rejects strings longer than maxLength', () => {
+    const schema = buildZodFromFieldDefs([field({ id: 'a', maxLength: 3 })], 'create');
+    const result = schema.safeParse({ a: 'abcd' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.issues[0]?.message).toMatch(/3/);
+  });
+
+  it('honours minLength when > 1', () => {
+    const schema = buildZodFromFieldDefs([field({ id: 'a', minLength: 5 })], 'create');
+    const result = schema.safeParse({ a: 'abc' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.issues[0]?.message).toMatch(/5/);
+  });
+});
+
+describe('buildZodFromFieldDefs — number', () => {
+  it('rejects empty string with required message (not 0)', () => {
+    const schema = buildZodFromFieldDefs([field({ id: 'a', type: 'number' })], 'create');
+    const result = schema.safeParse({ a: '' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.issues[0]?.message).toMatch(/required/i);
+  });
+
+  it('rejects "abc" with notNumber message (not NaN-passes-as-number)', () => {
+    const schema = buildZodFromFieldDefs([field({ id: 'a', type: 'number' })], 'create');
+    const result = schema.safeParse({ a: 'abc' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.issues[0]?.message).toMatch(/number/i);
+  });
+
+  it('honours min/max', () => {
+    const schema = buildZodFromFieldDefs(
+      [field({ id: 'a', type: 'number', min: 10, max: 20 })],
+      'create',
+    );
+    expect(schema.safeParse({ a: '5' }).success).toBe(false);
+    expect(schema.safeParse({ a: '25' }).success).toBe(false);
+    expect(schema.safeParse({ a: '15' }).success).toBe(true);
+  });
+
+  it('honours step (multipleOf) within float epsilon', () => {
+    const schema = buildZodFromFieldDefs([field({ id: 'a', type: 'number', step: 0.5 })], 'create');
+    expect(schema.safeParse({ a: '1' }).success).toBe(true);
+    expect(schema.safeParse({ a: '1.5' }).success).toBe(true);
+    expect(schema.safeParse({ a: '1.3' }).success).toBe(false);
+  });
+});
+
+describe('buildZodFromFieldDefs — date', () => {
+  it('requires YYYY-MM-DD format', () => {
+    const schema = buildZodFromFieldDefs([field({ id: 'a', type: 'date' })], 'create');
+    expect(schema.safeParse({ a: '2026-1-1' }).success).toBe(false);
+    expect(schema.safeParse({ a: '2026-01-01' }).success).toBe(true);
+  });
+
+  it('normalises non-zero-padded dateMin/dateMax for compare', () => {
+    // YAML author may write "2026-2-3" (non-zero-padded). Lexicographic compare without
+    // normalisation would fail "2026-12-01" >= "2026-2-3" → wrong outcome.
+    const schema = buildZodFromFieldDefs(
+      [field({ id: 'a', type: 'date', dateMin: '2026-2-3', dateMax: '2026-12-31' })],
+      'create',
+    );
+    expect(schema.safeParse({ a: '2026-12-01' }).success).toBe(true);
+    expect(schema.safeParse({ a: '2026-01-15' }).success).toBe(false);
+  });
+});
+
+describe('buildZodFromFieldDefs — select', () => {
+  it('rejects empty value with required message (not notInList)', () => {
+    const schema = buildZodFromFieldDefs(
+      [
+        field({
+          id: 'a',
+          type: 'select',
+          options: [
+            { value: 'x', label: 'X' },
+            { value: 'y', label: 'Y' },
+          ],
+        }),
+      ],
+      'create',
+    );
+    const result = schema.safeParse({ a: '' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.issues[0]?.message).toMatch(/required/i);
+  });
+
+  it('rejects off-list value with notInList message', () => {
+    const schema = buildZodFromFieldDefs(
+      [
+        field({
+          id: 'a',
+          type: 'select',
+          options: [{ value: 'x', label: 'X' }],
+        }),
+      ],
+      'create',
+    );
+    const result = schema.safeParse({ a: 'z' });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.issues[0]?.message).toMatch(/options/i);
+  });
+});
+
+describe('buildZodFromFieldDefs — checkbox', () => {
+  it('requires === true in create mode when requiredOnCreate', () => {
+    const schema = buildZodFromFieldDefs([field({ id: 'a', type: 'checkbox' })], 'create');
+    expect(schema.safeParse({ a: false }).success).toBe(false);
+    expect(schema.safeParse({ a: true }).success).toBe(true);
+  });
+
+  it('uses f.required (not requiredOnCreate) in edit mode', () => {
+    const schema = buildZodFromFieldDefs(
+      [field({ id: 'a', type: 'checkbox', required: true, requiredOnCreate: false })],
+      'edit',
+    );
+    expect(schema.safeParse({ a: false }).success).toBe(false);
+    expect(schema.safeParse({ a: true }).success).toBe(true);
+  });
+});
+
+describe('buildZodFromFieldDefs — file', () => {
+  it('treats file fields as optional even when requiredOnCreate (3.1 lands the upload)', () => {
+    const schema = buildZodFromFieldDefs([field({ id: 'a', type: 'file' })], 'create');
+    expect(schema.safeParse({}).success).toBe(true);
+    expect(schema.safeParse({ a: undefined }).success).toBe(true);
+  });
+});

--- a/frontend/src/lib/buildZodFromFieldDefs.ts
+++ b/frontend/src/lib/buildZodFromFieldDefs.ts
@@ -1,0 +1,176 @@
+import { z } from 'zod';
+
+import { t } from '@/i18n';
+import type { FieldDefinition } from '@/types/caseType';
+
+/**
+ * Story 2.7 AC4 — runtime Zod schema builder for the create-case form. Pure function: takes the
+ * case-type's `fields[]` (post-filter to `requiredOnCreate: true` for the create form) and returns
+ * a `z.ZodObject` whose property schemas mirror per-type slots.
+ *
+ * Architecture note: the runtime build (NOT a build-time codegen) is the contract from
+ * architecture.md §Decision 12 — schemas reflect the most recently deployed YAML, with no
+ * recompile.
+ *
+ * Specific error messages per slot (epic AC4) — no generic "Invalid input". Strings come from
+ * `i18n/en.json` keyed by error variant.
+ */
+export type BuildMode = 'create' | 'edit';
+
+export function buildZodFromFieldDefs(
+  fields: FieldDefinition[],
+  mode: BuildMode = 'create',
+): z.ZodObject<z.ZodRawShape> {
+  const shape: z.ZodRawShape = {};
+  const filtered = mode === 'create' ? fields.filter((f) => f.requiredOnCreate) : fields;
+  for (const f of filtered) {
+    shape[f.id] = schemaForField(f, mode);
+  }
+  return z.object(shape);
+}
+
+function schemaForField(f: FieldDefinition, mode: BuildMode): z.ZodTypeAny {
+  switch (f.type) {
+    case 'text':
+    case 'textarea':
+      return textSchema(f);
+    case 'number':
+      return numberSchema(f);
+    case 'date':
+      return dateSchema(f);
+    case 'select':
+      return selectSchema(f);
+    case 'checkbox':
+      return checkboxSchema(f, mode);
+    case 'file':
+      // AC3 — `file` is treated as optional on the frontend until Story 3.1 ships upload.
+      return z.unknown().optional();
+    default:
+      return z.unknown();
+  }
+}
+
+function textSchema(f: FieldDefinition): z.ZodTypeAny {
+  const minLen = typeof f.minLength === 'number' && f.minLength > 0 ? f.minLength : 1;
+  let s = z.string({ required_error: t('cases.create.errors.required') }).min(minLen, {
+    message:
+      minLen > 1
+        ? t('cases.create.errors.tooShort', { min: String(minLen) })
+        : t('cases.create.errors.required'),
+  });
+  if (typeof f.maxLength === 'number') {
+    s = s.max(f.maxLength, {
+      message: t('cases.create.errors.tooLong', { max: String(f.maxLength) }),
+    });
+  }
+  return s;
+}
+
+function numberSchema(f: FieldDefinition): z.ZodTypeAny {
+  // P3 — `z.coerce.number()` traps: empty-string coerces to 0 (silent data corruption); "abc"
+  // coerces to NaN that JSON.stringify converts to null. Preprocess empty-ish inputs to undefined
+  // (so `required_error` fires), then guard against NaN explicitly.
+  const base = z.preprocess(
+    (v) => {
+      if (v === '' || v === null || v === undefined) return undefined;
+      if (typeof v === 'string') {
+        const trimmed = v.trim();
+        if (trimmed === '') return undefined;
+        const n = Number(trimmed);
+        return Number.isFinite(n) ? n : NaN;
+      }
+      return v;
+    },
+    z
+      .number({
+        invalid_type_error: t('cases.create.errors.notNumber'),
+        required_error: t('cases.create.errors.required'),
+      })
+      .refine((n) => Number.isFinite(n), { message: t('cases.create.errors.notNumber') }),
+  );
+
+  let s: z.ZodTypeAny = base;
+  if (typeof f.min === 'number') {
+    s = s.refine((n) => typeof n !== 'number' || n >= f.min!, {
+      message: t('cases.create.errors.lt', { min: String(f.min) }),
+    });
+  }
+  if (typeof f.max === 'number') {
+    s = s.refine((n) => typeof n !== 'number' || n <= f.max!, {
+      message: t('cases.create.errors.gt', { max: String(f.max) }),
+    });
+  }
+  if (typeof f.step === 'number' && f.step > 0) {
+    // P17 — multipleOf: tolerate floating-point dust by checking against a small epsilon scaled
+    // to the step (covers e.g. 0.1+0.2 ≈ 0.3 drift).
+    const step = f.step;
+    s = s.refine(
+      (n) => {
+        if (typeof n !== 'number' || !Number.isFinite(n)) return true;
+        const ratio = n / step;
+        return Math.abs(ratio - Math.round(ratio)) < 1e-9;
+      },
+      { message: t('cases.create.errors.notMultipleOf', { step: String(step) }) },
+    );
+  }
+  return s;
+}
+
+function dateSchema(f: FieldDefinition): z.ZodTypeAny {
+  // P18 — `dateMin`/`dateMax` from YAML may be non-zero-padded (e.g. "2024-2-3"). Lexicographic
+  // compare is unsafe in that case — normalise to YYYY-MM-DD before compare.
+  const normalize = (raw: string | null | undefined): string | null => {
+    if (!raw) return null;
+    const m = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(raw.trim());
+    if (!m) return null;
+    return `${m[1]}-${m[2]!.padStart(2, '0')}-${m[3]!.padStart(2, '0')}`;
+  };
+  const min = normalize(f.dateMin ?? null);
+  const max = normalize(f.dateMax ?? null);
+  const iso = z
+    .string({ required_error: t('cases.create.errors.required') })
+    .regex(/^\d{4}-\d{2}-\d{2}$/, { message: t('cases.create.errors.notDate') });
+  if (min || max) {
+    return iso.refine((v) => (!min || v >= min) && (!max || v <= max), {
+      message: t('cases.create.errors.dateRange', {
+        min: min ?? '',
+        max: max ?? '',
+      }),
+    });
+  }
+  return iso;
+}
+
+function selectSchema(f: FieldDefinition): z.ZodTypeAny {
+  const values = f.options.map((o) => o.value);
+  if (values.length === 0) {
+    // ConfigValidator already blocks required+select with 0 options at YAML load — defensive
+    // fallback only.
+    return z
+      .string({ required_error: t('cases.create.errors.required') })
+      .min(1, { message: t('cases.create.errors.required') });
+  }
+  // P13 — disambiguate "user hasn't picked anything" (required) from "user picked an off-list
+  // value" (notInList) so the inline message matches what the user actually did wrong.
+  return z.enum(values as [string, ...string[]], {
+    errorMap: (issue, ctx) => {
+      if (issue.code === 'invalid_type' || ctx.data === undefined || ctx.data === '') {
+        return { message: t('cases.create.errors.required') };
+      }
+      return { message: t('cases.create.errors.notInList') };
+    },
+  });
+}
+
+function checkboxSchema(f: FieldDefinition, mode: BuildMode): z.ZodTypeAny {
+  // P12 — in 'edit' mode the `requiredOnCreate` flag is the wrong axis: it's a create-time
+  // gate, not an edit-time one. Use `f.required` for non-create modes so editing still enforces
+  // any always-required boolean (e.g. an "active" flag).
+  const isRequired = mode === 'create' ? f.requiredOnCreate : f.required;
+  if (isRequired) {
+    return z
+      .boolean({ required_error: t('cases.create.errors.mustCheck') })
+      .refine((v) => v === true, { message: t('cases.create.errors.mustCheck') });
+  }
+  return z.boolean().optional();
+}

--- a/frontend/src/lib/fieldFormatters.test.ts
+++ b/frontend/src/lib/fieldFormatters.test.ts
@@ -12,7 +12,6 @@ function field(over: Partial<FieldDefinition>): FieldDefinition {
     required: false,
     order: 0,
     options: [],
-    slots: null,
     ...over,
   };
 }

--- a/frontend/src/pages/CasesPage.tsx
+++ b/frontend/src/pages/CasesPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { CaseDataTable } from '@/components/workspace/CaseDataTable';
 import { CaseFilterBar } from '@/components/workspace/CaseFilterBar';
 import { CaseWorkspace } from '@/components/workspace/CaseWorkspace';
+import { NewCaseButton } from '@/components/workspace/NewCaseButton';
 import { useCases } from '@/hooks/useCases';
 import { useCaseTypes, useCaseTypeViews } from '@/hooks/useCaseTypes';
 import { t } from '@/i18n';
@@ -163,7 +164,10 @@ export function CasesPage() {
   return (
     <section className="flex flex-1 flex-col">
       {selectedCaseId === null ? (
-        <h1 className="font-heading text-2xl font-semibold">{t('cases.title')}</h1>
+        <header className="flex items-center justify-between">
+          <h1 className="font-heading text-2xl font-semibold">{t('cases.title')}</h1>
+          <NewCaseButton />
+        </header>
       ) : null}
 
       <div className="mt-4 flex flex-1 flex-col gap-4">

--- a/frontend/src/pages/LoginPage.rhf.test.tsx
+++ b/frontend/src/pages/LoginPage.rhf.test.tsx
@@ -1,0 +1,46 @@
+import userEvent from '@testing-library/user-event';
+import { Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '@/test/renderWithProviders';
+
+import { LoginPage } from './LoginPage';
+
+function loginAt(path = '/login') {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/cases" element={<div>cases page</div>} />
+    </Routes>,
+    { initialPath: path, initialAuth: { status: 'unauthenticated' } },
+  );
+}
+
+describe('LoginPage — RHF + Zod retrofit (AC11)', () => {
+  it('shows the localized email-format error when an invalid email is submitted', async () => {
+    const user = userEvent.setup();
+    const { getByLabelText, getByRole, findByText } = loginAt();
+    await user.type(getByLabelText(/email/i), 'not-an-email');
+    await user.type(getByLabelText(/password/i), 'something');
+    await user.click(getByRole('button', { name: /sign in/i }));
+    expect(await findByText(/valid email/i)).toBeInTheDocument();
+  });
+
+  it('shows the password-required error when password is empty on submit', async () => {
+    const user = userEvent.setup();
+    const { getByLabelText, getByRole, findByText } = loginAt();
+    await user.type(getByLabelText(/email/i), 'a@b.com');
+    await user.click(getByRole('button', { name: /sign in/i }));
+    expect(await findByText(/password is required/i)).toBeInTheDocument();
+  });
+
+  it('email field is wired aria-invalid + aria-describedby when in error', async () => {
+    const user = userEvent.setup();
+    const { getByLabelText, getByRole } = loginAt();
+    await user.type(getByLabelText(/email/i), 'bad');
+    await user.click(getByRole('button', { name: /sign in/i }));
+    const email = getByLabelText(/email/i);
+    expect(email).toHaveAttribute('aria-invalid', 'true');
+    expect(email.getAttribute('aria-describedby')).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -49,14 +49,14 @@ describe('LoginPage', () => {
     );
     const user = userEvent.setup();
     const { findByRole, getByLabelText, getByRole } = loginAt();
-    await user.type(getByLabelText(/email/i), 'a@b.c');
+    await user.type(getByLabelText(/email/i), 'a@b.com');
     await user.type(getByLabelText(/password/i), 'pw');
     await user.click(getByRole('button', { name: /sign in/i }));
     const alert = await findByRole('alert');
     expect(alert).toHaveTextContent(/something went wrong/i);
   });
 
-  it('native :invalid blocks submission when required fields are empty', async () => {
+  it('RHF + Zod blocks submission and shows a field-level error when required fields are empty (Story 2.7 retrofit)', async () => {
     let callCount = 0;
     server.use(
       http.post('/api/auth/login', () => {
@@ -65,12 +65,13 @@ describe('LoginPage', () => {
       }),
     );
     const user = userEvent.setup();
-    const { getByLabelText, getByRole } = loginAt();
+    const { findAllByRole, getByRole } = loginAt();
     await user.click(getByRole('button', { name: /sign in/i }));
     // No custom client-side error message, no network request.
     expect(callCount).toBe(0);
-    const emailInput = getByLabelText(/email/i) as HTMLInputElement;
-    expect(emailInput.validity.valid).toBe(false);
+    // RHF + Zod surfaces the error via role="alert" on the FormField wrapper.
+    const alerts = await findAllByRole('alert');
+    expect(alerts.length).toBeGreaterThan(0);
   });
 
   it('double-submit protection: only one network request is fired and the button is disabled during the in-flight call', async () => {
@@ -90,7 +91,7 @@ describe('LoginPage', () => {
     );
     const user = userEvent.setup();
     const { getByLabelText, getByRole, findByText } = loginAt();
-    await user.type(getByLabelText(/email/i), 'a@b.c');
+    await user.type(getByLabelText(/email/i), 'a@b.com');
     await user.type(getByLabelText(/password/i), 'pw');
     const button = getByRole('button', { name: /sign in/i });
     // Click twice in immediate succession; the second click should be a no-op.

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,12 +1,16 @@
-import { type FormEvent, useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { ApiError } from '@/api/client';
 import { Alert } from '@/components/ui/Alert';
-import { Button } from '@/components/ui/Button';
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/Card';
+import { FormField } from '@/components/ui/FormField';
 import { Input } from '@/components/ui/Input';
+import { MutationButton, type MutationButtonState } from '@/components/ui/MutationButton';
 import { t } from '@/i18n';
+import { loginSchema, type LoginValues } from '@/pages/login/loginSchema';
 import { useAuthStore } from '@/stores/authStore';
 
 export function safeReturnTo(value: string | null): string {
@@ -27,31 +31,44 @@ export function safeReturnTo(value: string | null): string {
   return url.pathname + url.search + url.hash;
 }
 
+/**
+ * Story 2.7 AC11 — LoginPage retrofitted to RHF + Zod. The reference pattern the case-creation
+ * dialog inherits. {@code MutationButton} drives the 4-state visual; the existing 1-3 auth
+ * envelope wiring (401 → invalid copy, anything else → generic copy) is unchanged.
+ */
 export function LoginPage() {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const login = useAuthStore((s) => s.login);
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<{ message: string } | null>(null);
 
-  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
-    e.preventDefault();
-    if (submitting) return;
-    setSubmitting(true);
-    setErrorMessage(null);
+  const form = useForm<LoginValues>({
+    resolver: zodResolver(loginSchema),
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+    shouldFocusError: true,
+    defaultValues: { email: '', password: '' },
+  });
+
+  const state: MutationButtonState = form.formState.isSubmitting
+    ? 'confirming'
+    : form.formState.isSubmitSuccessful
+      ? 'confirmed'
+      : serverError
+        ? 'failed'
+        : 'idle';
+
+  async function onSubmit(values: LoginValues): Promise<void> {
+    setServerError(null);
     try {
-      await login(email, password);
+      await login(values.email, values.password);
       navigate(safeReturnTo(params.get('returnTo')), { replace: true });
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
-        setErrorMessage(t('login.error.invalid'));
+        setServerError({ message: t('login.error.invalid') });
       } else {
-        setErrorMessage(t('login.error.generic'));
+        setServerError({ message: t('login.error.generic') });
       }
-    } finally {
-      setSubmitting(false);
     }
   }
 
@@ -65,46 +82,53 @@ export function LoginPage() {
           {t('login.title')}
         </h1>
       </CardHeader>
-      <form
-        onSubmit={handleSubmit}
-        autoComplete="on"
-        aria-describedby={errorMessage ? 'login-error' : undefined}
-      >
-        <CardContent className="flex flex-col gap-[var(--space-4)]">
-          <label className="flex flex-col gap-[var(--space-2)] text-sm">
-            <span>{t('login.email')}</span>
-            <Input
-              type="email"
-              autoComplete="username"
-              required
-              disabled={submitting}
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-          </label>
-          <label className="flex flex-col gap-[var(--space-2)] text-sm">
-            <span>{t('login.password')}</span>
-            <Input
-              type="password"
-              autoComplete="current-password"
-              required
-              disabled={submitting}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-          </label>
-          {errorMessage ? (
-            <Alert id="login-error" variant="destructive" className="py-[var(--space-2)] text-xs">
-              {errorMessage}
-            </Alert>
-          ) : null}
-        </CardContent>
-        <CardFooter>
-          <Button type="submit" disabled={submitting} className="w-full">
-            {submitting ? t('login.submitting') : t('login.submit')}
-          </Button>
-        </CardFooter>
-      </form>
+      <FormProvider {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          autoComplete="on"
+          noValidate
+          aria-describedby={serverError ? 'login-error' : undefined}
+        >
+          <CardContent className="flex flex-col gap-[var(--space-4)]">
+            <FormField<LoginValues> name="email" label={t('login.email')} required>
+              {(field) => (
+                <Input
+                  type="email"
+                  autoComplete="username"
+                  disabled={state === 'confirming'}
+                  {...field}
+                />
+              )}
+            </FormField>
+            <FormField<LoginValues> name="password" label={t('login.password')} required>
+              {(field) => (
+                <Input
+                  type="password"
+                  autoComplete="current-password"
+                  disabled={state === 'confirming'}
+                  {...field}
+                />
+              )}
+            </FormField>
+            {serverError ? (
+              <Alert id="login-error" variant="destructive" className="py-[var(--space-2)] text-xs">
+                {serverError.message}
+              </Alert>
+            ) : null}
+          </CardContent>
+          <CardFooter>
+            <MutationButton
+              state={state}
+              className="w-full"
+              confirmingLabel={t('login.submitting')}
+              confirmedLabel={t('login.submit')}
+              failedLabel={t('common.lifecycle.failed')}
+            >
+              {t('login.submit')}
+            </MutationButton>
+          </CardFooter>
+        </form>
+      </FormProvider>
     </Card>
   );
 }

--- a/frontend/src/pages/login/loginSchema.ts
+++ b/frontend/src/pages/login/loginSchema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+import { t } from '@/i18n';
+
+/**
+ * Story 2.7 AC11 — RHF + Zod schema for the LoginPage. This is the **reference pattern** the
+ * case-creation surface inherits. The retrofit closes the 1-3 deferred-work entry: "LoginPage
+ * uses native HTML validation; no React Hook Form / Zod in 1.3".
+ *
+ * Locale is module-frozen at build time (1-3 chunk-2 deferred-work) — `t()` is called once at
+ * schema construction. When dynamic locale switching lands, this schema becomes a function.
+ */
+export const loginSchema = z.object({
+  email: z.string().email(t('login.errors.notEmail')),
+  password: z.string().min(1, t('login.errors.passwordRequired')),
+});
+
+export type LoginValues = z.infer<typeof loginSchema>;

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -64,6 +64,31 @@ export interface UiState {
   caseListFilters: CaseListFilters;
   setCaseListFilters: (next: CaseListFilters) => void;
   clearCaseListFilters: () => void;
+
+  /**
+   * Story 2.7 AC8 — case ids freshly created in this session. The case-list row uses this to
+   * paint a {@code border-l-3 border-primary} highlight + an aria-live announcement (one-shot
+   * per id). Each id auto-clears 6 seconds after push; explicit clear is supported for tests.
+   */
+  recentlyCreatedCaseIds: ReadonlySet<string>;
+  pushRecentlyCreated: (id: string) => void;
+  clearRecentlyCreated: (id: string) => void;
+}
+
+const RECENTLY_CREATED_TTL_MS = 6_000;
+
+// P19 — track per-id timer handles so we can cancel pending expiries on explicit clear,
+// store reset, or page visibility change. Without this, N pending timers stack up under bulk
+// creates and SSR-like environments leak ids forever. Uses `number` (DOM `setTimeout` return
+// type) since the timer is scheduled via `window.setTimeout`.
+const recentlyCreatedTimers = new Map<string, number>();
+
+function cancelRecentlyCreatedTimer(id: string): void {
+  const handle = recentlyCreatedTimers.get(id);
+  if (handle !== undefined) {
+    clearTimeout(handle);
+    recentlyCreatedTimers.delete(id);
+  }
 }
 
 export const useUiStore = create<UiState>((set, get) => ({
@@ -87,4 +112,44 @@ export const useUiStore = create<UiState>((set, get) => ({
     writeFilters(EMPTY_FILTERS);
     set({ caseListFilters: EMPTY_FILTERS });
   },
+
+  recentlyCreatedCaseIds: new Set<string>(),
+  pushRecentlyCreated(id) {
+    const current = get().recentlyCreatedCaseIds;
+    if (current.has(id)) return;
+    const next = new Set(current);
+    next.add(id);
+    set({ recentlyCreatedCaseIds: next });
+    if (typeof window === 'undefined') return;
+    cancelRecentlyCreatedTimer(id);
+    const handle = window.setTimeout(() => {
+      recentlyCreatedTimers.delete(id);
+      const after = get().recentlyCreatedCaseIds;
+      if (!after.has(id)) return;
+      const reduced = new Set(after);
+      reduced.delete(id);
+      set({ recentlyCreatedCaseIds: reduced });
+    }, RECENTLY_CREATED_TTL_MS);
+    recentlyCreatedTimers.set(id, handle);
+  },
+  clearRecentlyCreated(id) {
+    cancelRecentlyCreatedTimer(id);
+    const current = get().recentlyCreatedCaseIds;
+    if (!current.has(id)) return;
+    const next = new Set(current);
+    next.delete(id);
+    set({ recentlyCreatedCaseIds: next });
+  },
 }));
+
+// Drop pending highlight timers when the tab is hidden — leaving them alive risks announcing or
+// flashing rows on a page the user can't see, and the highlight is a freshness affordance that
+// loses meaning across a backgrounded session.
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState !== 'hidden') return;
+    for (const id of Array.from(recentlyCreatedTimers.keys())) {
+      useUiStore.getState().clearRecentlyCreated(id);
+    }
+  });
+}

--- a/frontend/src/stores/useUiStore.recentlyCreated.test.ts
+++ b/frontend/src/stores/useUiStore.recentlyCreated.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUiStore } from './uiStore';
+
+describe('uiStore.recentlyCreatedCaseIds', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useUiStore.setState({ recentlyCreatedCaseIds: new Set() });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('pushRecentlyCreated adds the id to the set', () => {
+    useUiStore.getState().pushRecentlyCreated('case-1');
+    expect(useUiStore.getState().recentlyCreatedCaseIds.has('case-1')).toBe(true);
+  });
+
+  it('auto-clears the id after 6s', () => {
+    useUiStore.getState().pushRecentlyCreated('case-1');
+    expect(useUiStore.getState().recentlyCreatedCaseIds.has('case-1')).toBe(true);
+    vi.advanceTimersByTime(6_001);
+    expect(useUiStore.getState().recentlyCreatedCaseIds.has('case-1')).toBe(false);
+  });
+
+  it('does not stack timers when the same id is pushed twice within TTL', () => {
+    useUiStore.getState().pushRecentlyCreated('case-1');
+    vi.advanceTimersByTime(3_000);
+    useUiStore.getState().pushRecentlyCreated('case-1');
+    // First timer is canceled and replaced — at original-T+6s the id is still cleared based on
+    // the most recent push.
+    vi.advanceTimersByTime(3_001);
+    // 6001ms total since first push: id should be cleared by the (still-only-one) timer.
+    expect(useUiStore.getState().recentlyCreatedCaseIds.has('case-1')).toBe(false);
+  });
+
+  it('clearRecentlyCreated removes the id and cancels its pending timer', () => {
+    useUiStore.getState().pushRecentlyCreated('case-1');
+    useUiStore.getState().clearRecentlyCreated('case-1');
+    expect(useUiStore.getState().recentlyCreatedCaseIds.has('case-1')).toBe(false);
+    // No subsequent timer should fire — advancing past TTL is a no-op.
+    vi.advanceTimersByTime(10_000);
+    expect(useUiStore.getState().recentlyCreatedCaseIds.size).toBe(0);
+  });
+
+  it('handles multiple ids independently', () => {
+    useUiStore.getState().pushRecentlyCreated('case-a');
+    vi.advanceTimersByTime(2_000);
+    useUiStore.getState().pushRecentlyCreated('case-b');
+    vi.advanceTimersByTime(4_001); // case-a now > 6s, case-b at ~4s
+    expect(useUiStore.getState().recentlyCreatedCaseIds.has('case-a')).toBe(false);
+    expect(useUiStore.getState().recentlyCreatedCaseIds.has('case-b')).toBe(true);
+    vi.advanceTimersByTime(2_000);
+    expect(useUiStore.getState().recentlyCreatedCaseIds.has('case-b')).toBe(false);
+  });
+});

--- a/frontend/src/test/fixtures/buildCaseListFixture.ts
+++ b/frontend/src/test/fixtures/buildCaseListFixture.ts
@@ -1,5 +1,5 @@
 import type { CaseSummary } from '@/types/case';
-import type { CaseTypeView } from '@/types/caseType';
+import type { CaseTypeSummary, CaseTypeView } from '@/types/caseType';
 
 /**
  * Story 2.5 AC8 perf-guardrail support — builds N synthetic `CaseSummary` rows for the
@@ -42,18 +42,21 @@ export function loanApplicationCaseTypeView(): CaseTypeView {
         displayName: 'Applicant',
         type: 'text',
         required: true,
+        requiredOnCreate: true,
         order: 0,
         options: [],
-        slots: null,
+        maxLength: 100,
       },
       {
         id: 'amount',
         displayName: 'Amount',
         type: 'number',
         required: false,
+        requiredOnCreate: true,
         order: 1,
         options: [],
-        slots: null,
+        min: 1,
+        max: 1_000_000,
       },
     ],
     statuses: [
@@ -63,5 +66,17 @@ export function loanApplicationCaseTypeView(): CaseTypeView {
       { id: 'resolved', displayName: 'Resolved', color: 'emerald' },
     ],
     listColumns: ['applicant_name', 'amount'],
+  };
+}
+
+export function caseTypeSummaryFixture(over: Partial<CaseTypeSummary> = {}): CaseTypeSummary {
+  return {
+    id: 'loan-application',
+    displayName: 'Loan Application',
+    version: 1,
+    statusCount: 4,
+    fieldCount: 2,
+    permissions: ['view', 'create'],
+    ...over,
   };
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -4,6 +4,18 @@ import { afterAll, afterEach, beforeAll } from 'vitest';
 
 import { server } from './server';
 
+// jsdom polyfills for Radix UI primitives (Select, Dialog, etc.) that probe Pointer Events APIs
+// not implemented by jsdom. Without these, Radix throws "target.hasPointerCapture is not a
+// function" / "Element.scrollIntoView is not a function" the moment a Radix combobox opens.
+if (typeof window !== 'undefined' && !window.HTMLElement.prototype.hasPointerCapture) {
+  window.HTMLElement.prototype.hasPointerCapture = () => false;
+  window.HTMLElement.prototype.releasePointerCapture = () => {};
+  window.HTMLElement.prototype.setPointerCapture = () => {};
+}
+if (typeof window !== 'undefined' && !window.HTMLElement.prototype.scrollIntoView) {
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+}
+
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());

--- a/frontend/src/types/caseType.ts
+++ b/frontend/src/types/caseType.ts
@@ -1,9 +1,14 @@
 /**
  * 1:1 mirror of the backend `CaseTypeViewDto` (Story 2.3 → exposed by Story 2.5 on
- * `GET /api/case-types/{id}`). The frontend never invents derived fields here — derived state
- * (e.g. resolved status colors, accessor functions) lives in `lib/`.
+ * `GET /api/case-types/{id}`, widened in Story 2.7). The frontend never invents derived fields
+ * here — derived state (e.g. resolved status colors, accessor functions) lives in `lib/`.
  *
- * The `CaseTypeSummary` mirrors `CaseTypeSummaryDto` for the list endpoint.
+ * Story 2.7 widens `FieldDefinition` to the flattened `FieldView` wire shape: per-type validation
+ * slots (`minLength`, `maxLength`, `min`, `max`, `step`, etc.) are top-level + nullable, and
+ * `requiredOnCreate` controls whether the create-form dialog asks for the field at case creation.
+ *
+ * `CaseTypeSummary` gains `permissions: string[]` — the verbs the caller holds on this case-type,
+ * used to filter the Create-Case selector dropdown without an extra round-trip.
  */
 
 import type { FieldType } from './fieldType';
@@ -14,7 +19,19 @@ export interface FieldOption {
   label: string;
 }
 
-export interface FieldTypeSlots {
+export interface FieldDefinition {
+  id: string;
+  displayName: string;
+  type: FieldType;
+  required: boolean;
+  /**
+   * Story 2.7 — controls whether the create-form dialog asks for this field. Optional in TS for
+   * backward-compat with pre-2.7 fixtures; the wire shape always includes it.
+   */
+  requiredOnCreate?: boolean;
+  order: number;
+  options: FieldOption[];
+  // Per-type validation slots — only the slots relevant to `type` are populated.
   minLength?: number | null;
   maxLength?: number | null;
   min?: number | null;
@@ -24,16 +41,6 @@ export interface FieldTypeSlots {
   dateMax?: string | null;
   maxBytes?: number | null;
   allowedMimeTypes?: string[] | null;
-}
-
-export interface FieldDefinition {
-  id: string;
-  displayName: string;
-  type: FieldType;
-  required: boolean;
-  order: number;
-  options: FieldOption[];
-  slots: FieldTypeSlots | null;
 }
 
 export interface StatusDefinition {
@@ -48,6 +55,11 @@ export interface CaseTypeSummary {
   version: number;
   statusCount: number;
   fieldCount: number;
+  /**
+   * Story 2.7 — verbs the caller holds on this case-type. Subset of declared role verbs.
+   * Optional in TS for backward-compat with pre-2.7 fixtures; the wire shape always includes it.
+   */
+  permissions?: string[];
 }
 
 export interface CaseTypeView {


### PR DESCRIPTION
## Summary

- Ships YAML-driven case creation: `requiredOnCreate` grammar, `CaseTypeViewDto`/`CaseTypeSummaryDto` widening with caller permissions, runtime-built Zod schemas, `NewCaseButton` + `NewCaseDialog` over the 4-state `MutationButton` lifecycle, plus the `recentlyCreatedCaseIds` row-highlight + aria-live announcement on `CaseDataTable`.
- Closes folded debt from prior stories: `LoginPage` retrofit to RHF + Zod (1.3), `pointerToField` field-id roundtrip on the validator (2.3-r2), `FormField` aria-describedby wiring (1.3-chunk-3).
- Code review applied: **28 patches**, 4 deferred to follow-up stories, 2 dismissed on inspection. Largest fix: `CaseDataTable` AC8 highlight + announcement (was entirely missing). Largest refactor: `FormField` switched to `useController` per AC12, eliminating the manual `form.watch + form.setValue` dual-track for `Select`/`Checkbox`.
- Test surface: **+15 frontend test files (+61 tests)** and **2 new backend ITs** — `CaseTypeControllerIT.summaryIncludesPermissionsForCaller`, `CaseFlowIT.createReturns422WithFieldId`.

## Test plan

- [x] `cd frontend && npm run lint` — 0 problems
- [x] `cd frontend && npm run format:check` — all files pass Prettier
- [x] `cd frontend && npx tsc -b` — clean
- [x] `cd frontend && npm test` — 57 files / 211 tests pass
- [x] `cd backend && ./mvnw test` — 241 tests pass
- [x] `cd backend && ./mvnw verify` — 56 ITs pass (incl. 2 new)
- [x] `docker build -f docker/Dockerfile -t wkspower/wks-platform:local-2-7 .` — exit 0; image size 332 MB (parity with `local-2-6`; AC16 budget honored)
- [ ] Manual smoke in a real browser: open the workspace, click "New Case" with 1 case type → dialog opens directly; with ≥2 → dropdown picker; submit a valid payload → row highlights for 6s and aria-live announces; submit a 422-triggering payload → field error appears inline; submit on an account without `create` → 403 banner copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)