### PR TITLE
Story 2.8: Task Completion with Honest Lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,11 +462,35 @@ Case types are declared as YAML files in a directory mounted into the container.
   date → `.regex(YYYY-MM-DD).refine(dateRange)`, select → `z.enum(options[].value)`,
   checkbox → required-on-create boolean, file → `z.unknown().optional()` until
   Story 3.1). Specific error message per slot from `i18n/en.json` (`cases.create.errors.*`).
-- **`<MutationButton>`** (`components/ui/MutationButton.tsx`): 4-state slice of
-  `TaskLifecycleButton` (`idle | confirming | confirmed | failed`). Presentational
-  only — parent drives transitions via `state` prop. Story 2.8 extends with
-  `processing` (5th state, 2s-without-confirmation timer) for task-completion
-  surfaces; the TS literal-union is forward-compatible.
+- **`<MutationButton>`** (`components/ui/MutationButton.tsx`): 4-state presentational
+  primitive (`idle | confirming | confirmed | failed`). Story 2.8 widened the TS
+  union to add `processing` — non-breaking. Parent drives transitions via `state`
+  prop. Use this for **synchronous** form submits (case creation, login, etc.)
+  where the REST round-trip is the source of truth.
+- **`<TaskLifecycleButton>`** (`components/workspace/TaskLifecycleButton.tsx`):
+  5-state owner (`idle | confirming | processing | confirmed | failed`) that
+  composes `MutationButton` for the four shared states and adds the `processing`
+  visual + task-specific footer actions (`[Retry]` for 5xx, `[Refresh case]` for
+  409 conflict, `[View Updated Case]`). Owns its state machine internally via
+  `useReducer`. Use this for backend mutations whose true completion is signalled
+  async (Phase 2 SSE, Story 4.3) **or** that may genuinely take >2s.
+- **Universal mutation lifecycle** (Story 2.8 AC7): every platform mutation —
+  task completion, escalation/reassignment/add-note (Epic 8), document upload
+  (Epic 3), config deploy (Epic 6) — MUST follow one of these two components.
+  No parallel patterns. The 5-state superset is opt-in for surfaces whose backend
+  may genuinely take >2s; otherwise stay on `MutationButton`.
+- **Confidence-not-safety copy**: "Confirmed" / "This task was already completed
+  by {name}. No changes were made." — confirm the user's mental model rather
+  than reassure them about platform safety. Failure copy interpolates `{reason}`
+  via `t('task.failed', { reason })` so the SR announcement and visible chip
+  carry the actual server message.
+- **`<FormErrorsBanner>`** (`components/ui/FormErrorsBanner.tsx`): Story 2.8
+  generic multi-field errors-count banner. ICU-style singular/plural via two i18n
+  keys (`cases.create.errorsCount.one` + `.errorsCount`). One anchor link per
+  failing field, sorted by `field.order` ascending. Anchor click routes through
+  RHF's `form.setFocus(name)` so controlled Radix primitives focus via
+  `field.ref`. Single ARIA-live region (`role="alert"` + `aria-live="polite"`);
+  per-field inline errors continue to render alongside the banner.
 - **`LoginPage` is the reference pattern**. Read `pages/LoginPage.tsx` for the
   canonical wiring of `FormProvider` + `useForm({resolver: zodResolver(schema)})` +
   `<FormField>` + `<MutationButton>`. The case-creation dialog inherits the same
@@ -479,6 +503,29 @@ Case types are declared as YAML files in a directory mounted into the container.
   case. Your input is preserved. Try again or correct the highlighted fields."
 
 ## Change Log
+
+- 2026-04-27 — Story 2.8: Task Completion with Honest Lifecycle — backend
+  `WorkflowEngine` port gains `findTasksByCase(UUID)` + `readActionLabel(pdId,
+  taskKey)`; CIB seven adapter implements via `taskService.createTaskQuery()
+  .processVariableValueEquals("caseId", ...).active()` and reads the BPMN
+  `camunda:property name="actionLabel"` (fallback userTask.name). New `TaskDto`
+  + `TaskDtoMapper` (per-request `(processDefinitionId, taskDefinitionKey)`
+  cache); domain `Task` gains nullable `processDefinitionId`. New endpoint
+  `GET /api/cases/{id}/tasks` (verb gate `view`, 200 with `data: []` on
+  terminal end-event). Frontend: `MutationButton` literal-union widens to add
+  `processing` (non-breaking). New `TaskLifecycleButton` (5-state owner with
+  internal `useReducer`, `VITE_WKS_SSE_ENABLED` flag for Phase 2 SSE plumbing,
+  conflict-vs-retryable failure classification, `[Retry]`/`[Refresh case]`/
+  `[View Updated Case]` actions). New `CaseActionBar` slotted into
+  `CaseDetailPanel` between heading row and tabs; renders primary CTA with
+  `task.actionLabel` and the "Next case (`J`)" hint after 4s on empty. New
+  `FormErrorsBanner` (generic, owned-source) wired into `NewCaseDialog` —
+  closes 2.7 deferred-work entry "AC4 errors-count banner with anchor links".
+  `formatFieldValue` select coercion fix — `String(stored) === String(opt
+  .value)` — closes 2.6 deferred-work entry "select-field strict-equality".
+  New `frontend/src/api/tasks.ts`, `types/task.ts`, `taskQueryKeys`,
+  `useCaseTasks` + `useCompleteTask`. ~12 new i18n keys (`task.*` +
+  `case.nextCaseHint` + `cases.create.errorsCount.one`).
 
 - 2026-04-27 — Story 2.7: Case Creation Flow — backend YAML grammar gains
   `requiredOnCreate: bool` (default-on-omit = `required`), `WKS-CFG-013` reserved

--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
@@ -6,7 +6,9 @@ import com.wkspower.platform.api.dto.request.TransitionRequest;
 import com.wkspower.platform.api.dto.request.UpdateCaseRequest;
 import com.wkspower.platform.api.dto.response.CaseDto;
 import com.wkspower.platform.api.dto.response.CaseSummaryDto;
+import com.wkspower.platform.api.dto.response.TaskDto;
 import com.wkspower.platform.api.mapper.CaseDtoMapper;
+import com.wkspower.platform.api.mapper.TaskDtoMapper;
 import com.wkspower.platform.api.pagination.PageRequestParams;
 import com.wkspower.platform.api.pagination.SortSpec;
 import com.wkspower.platform.api.pagination.SortWhitelist;
@@ -20,6 +22,7 @@ import com.wkspower.platform.domain.page.Page;
 import com.wkspower.platform.domain.page.PageRequest;
 import com.wkspower.platform.domain.page.SortOrder;
 import com.wkspower.platform.domain.service.CaseService;
+import com.wkspower.platform.domain.service.TaskService;
 import com.wkspower.platform.security.CaseTypePermissionEvaluator;
 import com.wkspower.platform.security.WksUserPrincipal;
 import jakarta.validation.Valid;
@@ -58,10 +61,13 @@ public class CaseController {
       () -> Set.of("updatedAt", "createdAt", "status");
 
   private final CaseService caseService;
+  private final TaskService taskService;
   private final CaseTypePermissionEvaluator evaluator;
 
-  public CaseController(CaseService caseService, CaseTypePermissionEvaluator evaluator) {
+  public CaseController(
+      CaseService caseService, TaskService taskService, CaseTypePermissionEvaluator evaluator) {
     this.caseService = caseService;
+    this.taskService = taskService;
     this.evaluator = evaluator;
   }
 
@@ -84,6 +90,21 @@ public class CaseController {
     requireVerb(actor, found.caseTypeId(), "view");
     CaseTypeConfig caseType = caseService.requireCaseType(found.caseTypeId());
     return ApiResponse.success(CaseDtoMapper.toDto(found, caseType));
+  }
+
+  /**
+   * Story 2.8 AC1 — list pending (active, uncompleted) BPMN user tasks for a case. 404 when the
+   * case does not exist; 403 when the caller lacks the {@code view} verb on its case-type. An empty
+   * list (case at terminal end-event) returns {@code 200 data: []}.
+   */
+  @GetMapping("/{id}/tasks")
+  public ApiResponse<List<TaskDto>> listTasks(
+      @PathVariable("id") UUID id, @AuthenticationPrincipal WksUserPrincipal actor) {
+    Case found = caseService.findById(id);
+    requireVerb(actor, found.caseTypeId(), "view");
+    List<TaskDto> dtos =
+        TaskDtoMapper.toDtos(taskService.findByCase(id), taskService::readActionLabel);
+    return ApiResponse.success(dtos);
   }
 
   @GetMapping

--- a/backend/src/main/java/com/wkspower/platform/api/controller/TaskController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/TaskController.java
@@ -3,6 +3,8 @@ package com.wkspower.platform.api.controller;
 import com.wkspower.platform.api.dto.ApiResponse;
 import com.wkspower.platform.api.dto.request.CompleteTaskRequest;
 import com.wkspower.platform.api.dto.response.TaskActionResponse;
+import com.wkspower.platform.domain.exception.WksConflictException;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.model.Task;
 import com.wkspower.platform.domain.port.Clock;
 import com.wkspower.platform.domain.service.TaskService;
@@ -43,10 +45,25 @@ public class TaskController {
       @PathVariable("id") String id,
       @RequestBody(required = false) CompleteTaskRequest request,
       @AuthenticationPrincipal WksUserPrincipal actor) {
-    Task task = taskService.findById(id);
+    Task task;
+    try {
+      task = taskService.findById(id);
+    } catch (WksNotFoundException ex) {
+      // The client thought this task was active when they clicked, but the engine no longer has
+      // it — another action (typically another user / another tab) already completed it. AC5
+      // requires this surface as 409 (conflict), not 404 (not found): from the client's point of
+      // view the truth has moved on, and the [Refresh case] action is the right recovery.
+      throw alreadyCompleted(id, ex);
+    }
     requireVerb(actor, task.caseTypeId());
-    Task completed =
-        taskService.complete(id, request == null ? null : request.variables(), actor.id());
+    Task completed;
+    try {
+      completed =
+          taskService.complete(id, request == null ? null : request.variables(), actor.id());
+    } catch (WksNotFoundException ex) {
+      // Same TOCTOU window — task disappeared between findById and the engine call.
+      throw alreadyCompleted(id, ex);
+    }
     // Snapshot is taken before engine.complete, so processInstanceId is still populated. The
     // assignee surfaced on /complete is the actor (which the service has just verified) — null
     // would suggest the action was anonymous, which it never is.
@@ -76,6 +93,17 @@ public class TaskController {
                 claimed.archetype(),
                 claimed.assignee(),
                 clock.now())));
+  }
+
+  /**
+   * Translate "task is gone in the engine" into the AC5 conflict envelope. Phase 0 cannot
+   * distinguish "task never existed" from "task already completed" at the engine layer — both paths
+   * surface as the same conflict copy because that's the realistic root cause from a UI driven by
+   * server-supplied task ids.
+   */
+  private static WksConflictException alreadyCompleted(String taskId, Throwable cause) {
+    return new WksConflictException(
+        "Task " + taskId + " was already completed. Refresh to see the latest case state.", cause);
   }
 
   private void requireVerb(WksUserPrincipal actor, String caseTypeId) {

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/TaskDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/TaskDto.java
@@ -4,8 +4,8 @@ import java.time.Instant;
 import java.util.UUID;
 
 /**
- * Story 2.8 AC1 — wire shape for {@code GET /api/cases/{id}/tasks}. One entry per pending
- * (active, uncompleted) BPMN user task in engine create-time order.
+ * Story 2.8 AC1 — wire shape for {@code GET /api/cases/{id}/tasks}. One entry per pending (active,
+ * uncompleted) BPMN user task in engine create-time order.
  *
  * <p>{@code actionLabel} is the user-facing CTA copy shown on the {@code TaskLifecycleButton}. It
  * is read from the BPMN {@code userTask} {@code camunda:property name="actionLabel"} when present,

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/TaskDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/TaskDto.java
@@ -1,0 +1,27 @@
+package com.wkspower.platform.api.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Story 2.8 AC1 — wire shape for {@code GET /api/cases/{id}/tasks}. One entry per pending
+ * (active, uncompleted) BPMN user task in engine create-time order.
+ *
+ * <p>{@code actionLabel} is the user-facing CTA copy shown on the {@code TaskLifecycleButton}. It
+ * is read from the BPMN {@code userTask} {@code camunda:property name="actionLabel"} when present,
+ * falling back to the {@code userTask.name} attribute. The mapper resolves it via {@code
+ * WorkflowEngine.readActionLabel} so the domain {@link com.wkspower.platform.domain.model.Task}
+ * stays lean (UI-string concerns belong at the API edge).
+ */
+public record TaskDto(
+    String id,
+    String processInstanceId,
+    UUID caseId,
+    String caseTypeId,
+    String taskDefinitionKey,
+    String name,
+    UUID assignee,
+    String archetype,
+    String actionLabel,
+    Instant createdAt,
+    Instant dueAt) {}

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/TaskDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/TaskDtoMapper.java
@@ -1,0 +1,65 @@
+package com.wkspower.platform.api.mapper;
+
+import com.wkspower.platform.api.dto.response.TaskDto;
+import com.wkspower.platform.domain.model.Task;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * Story 2.8 AC1 — domain {@link Task} → {@link TaskDto} mapping with per-request action-label
+ * caching keyed by {@code (processDefinitionId, taskDefinitionKey)}. The cache lifetime is the
+ * single mapper invocation; cross-request caching ships in a later perf pass (story Dev Notes).
+ */
+public final class TaskDtoMapper {
+
+  private TaskDtoMapper() {}
+
+  /**
+   * Map a list of tasks to DTOs, resolving each task's {@code actionLabel} via {@code
+   * actionLabelLookup}. The lookup is invoked at most once per {@code (processDefinitionId,
+   * taskDefinitionKey)} pair within this call.
+   */
+  public static List<TaskDto> toDtos(
+      List<Task> tasks, BiFunction<String, String, String> actionLabelLookup) {
+    Map<String, String> cache = new HashMap<>();
+    return tasks.stream().map(t -> toDto(t, actionLabelLookup, cache)).toList();
+  }
+
+  private static TaskDto toDto(
+      Task task, BiFunction<String, String, String> lookup, Map<String, String> cache) {
+    String actionLabel = resolveActionLabel(task, lookup, cache);
+    return new TaskDto(
+        task.id(),
+        task.processInstanceId(),
+        task.caseId(),
+        task.caseTypeId(),
+        task.taskDefinitionKey(),
+        task.name(),
+        task.assignee(),
+        task.archetype(),
+        actionLabel,
+        task.createdAt(),
+        task.dueAt());
+  }
+
+  private static String resolveActionLabel(
+      Task task, BiFunction<String, String, String> lookup, Map<String, String> cache) {
+    if (task.processDefinitionId() == null || task.taskDefinitionKey() == null) {
+      // Fall back to task.name when we cannot read the BPMN — never leave actionLabel blank.
+      return task.name();
+    }
+    String key = task.processDefinitionId() + "::" + task.taskDefinitionKey();
+    String cached = cache.get(key);
+    if (cached != null) {
+      return cached;
+    }
+    String resolved = lookup.apply(task.processDefinitionId(), task.taskDefinitionKey());
+    if (resolved == null || resolved.isBlank()) {
+      resolved = task.name();
+    }
+    cache.put(key, resolved);
+    return resolved;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/TaskDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/TaskDtoMapper.java
@@ -55,7 +55,14 @@ public final class TaskDtoMapper {
     if (cached != null) {
       return cached;
     }
-    String resolved = lookup.apply(task.processDefinitionId(), task.taskDefinitionKey());
+    String resolved;
+    try {
+      resolved = lookup.apply(task.processDefinitionId(), task.taskDefinitionKey());
+    } catch (RuntimeException ex) {
+      // One unloadable BPMN model must not 500 the entire list. Fall back to task.name and cache
+      // the fallback so subsequent tasks with the same key don't retry the failing lookup.
+      resolved = task.name();
+    }
     if (resolved == null || resolved.isBlank()) {
       resolved = task.name();
     }

--- a/backend/src/main/java/com/wkspower/platform/domain/model/Task.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/Task.java
@@ -19,6 +19,10 @@ import java.util.UUID;
  * @param processInstanceId BPMN process instance id (correlates with engine logs); used to populate
  *     {@code TaskActionResponse.processInstanceId} on the {@code /complete} and {@code /claim}
  *     responses since the snapshot is taken before completion (Story 2.4 review).
+ * @param processDefinitionId BPMN process definition id (engine-assigned). Story 2.8 surfaces it so
+ *     the API mapper can read user-task BPMN extension properties (e.g. {@code actionLabel}) via
+ *     {@code WorkflowEngine.readActionLabel} without an extra engine round-trip. Nullable for
+ *     backward compatibility with pre-2.8 producers; populate from the engine in new paths.
  * @param caseId case the task belongs to (read from the {@code caseId} process variable set by
  *     {@code CaseService.create} in Story 2.3)
  * @param caseTypeId case type id from the case row — needed by the API layer's permission gate
@@ -33,6 +37,7 @@ import java.util.UUID;
 public record Task(
     String id,
     String processInstanceId,
+    String processDefinitionId,
     UUID caseId,
     String caseTypeId,
     String taskDefinitionKey,

--- a/backend/src/main/java/com/wkspower/platform/domain/port/WorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/WorkflowEngine.java
@@ -4,6 +4,7 @@ import com.wkspower.platform.domain.model.Task;
 import com.wkspower.platform.domain.workflow.DeploymentInfo;
 import com.wkspower.platform.domain.workflow.DeploymentRequest;
 import com.wkspower.platform.domain.workflow.DeploymentResult;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -55,6 +56,25 @@ public interface WorkflowEngine {
    * com.wkspower.platform.domain.exception.WksWorkflowEngineException}.
    */
   Optional<Task> findTask(String taskId);
+
+  /**
+   * List active (uncompleted, unsuspended) user tasks for a case, ordered by engine create time.
+   * Story 2.8 AC1 — backs {@code GET /api/cases/{id}/tasks}. Returns an empty list when the case has
+   * reached a terminal end-event (no active tasks); callers MUST NOT translate empty to 404.
+   *
+   * <p>Implementations MUST translate engine exceptions into {@link
+   * com.wkspower.platform.domain.exception.WksWorkflowEngineException}.
+   */
+  List<Task> findTasksByCase(UUID caseId);
+
+  /**
+   * Read the {@code actionLabel} {@code camunda:property} for a user task definition, falling back
+   * to the {@code userTask.name} when the property is absent or blank. Returns {@code null} only
+   * when the BPMN cannot be located (defensive — should not happen for an active task). Story 2.8
+   * AC1 surfaces this on {@code TaskDto.actionLabel}; the domain {@link Task} model intentionally
+   * does not carry it (lean domain).
+   */
+  String readActionLabel(String processDefinitionId, String taskDefinitionKey);
 
   /**
    * Complete a user task. {@code variables} are merged into process variables — pass simple scalars

--- a/backend/src/main/java/com/wkspower/platform/domain/port/WorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/WorkflowEngine.java
@@ -59,8 +59,8 @@ public interface WorkflowEngine {
 
   /**
    * List active (uncompleted, unsuspended) user tasks for a case, ordered by engine create time.
-   * Story 2.8 AC1 — backs {@code GET /api/cases/{id}/tasks}. Returns an empty list when the case has
-   * reached a terminal end-event (no active tasks); callers MUST NOT translate empty to 404.
+   * Story 2.8 AC1 — backs {@code GET /api/cases/{id}/tasks}. Returns an empty list when the case
+   * has reached a terminal end-event (no active tasks); callers MUST NOT translate empty to 404.
    *
    * <p>Implementations MUST translate engine exceptions into {@link
    * com.wkspower.platform.domain.exception.WksWorkflowEngineException}.

--- a/backend/src/main/java/com/wkspower/platform/domain/service/TaskService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/TaskService.java
@@ -6,6 +6,7 @@ import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.exception.WksValidationException;
 import com.wkspower.platform.domain.model.Task;
 import com.wkspower.platform.domain.port.WorkflowEngine;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -34,6 +35,23 @@ public class TaskService {
 
   public TaskService(WorkflowEngine workflowEngine) {
     this.workflowEngine = Objects.requireNonNull(workflowEngine, "workflowEngine");
+  }
+
+  /**
+   * List active user tasks for a case (Story 2.8 AC1). Empty list when the case is at a terminal
+   * end-event or no active tasks remain — callers MUST NOT translate empty to 404.
+   */
+  public List<Task> findByCase(UUID caseId) {
+    Objects.requireNonNull(caseId, "caseId");
+    return workflowEngine.findTasksByCase(caseId);
+  }
+
+  /**
+   * Read the {@code actionLabel} for a task definition (Story 2.8 AC1). Falls back to the
+   * userTask's {@code name} attribute when the property is absent.
+   */
+  public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+    return workflowEngine.readActionLabel(processDefinitionId, taskDefinitionKey);
   }
 
   /** Lookup a task by id; 404 if unknown. */

--- a/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -253,6 +254,7 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
         new Task(
             engineTask.getId(),
             engineTask.getProcessInstanceId(),
+            engineTask.getProcessDefinitionId(),
             caseId,
             caseTypeId,
             engineTask.getTaskDefinitionKey(),
@@ -261,6 +263,112 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
             archetype,
             createdAt,
             dueAt));
+  }
+
+  @Override
+  public List<Task> findTasksByCase(UUID caseId) {
+    Objects.requireNonNull(caseId, "caseId");
+    List<org.cibseven.bpm.engine.task.Task> engineTasks;
+    try {
+      engineTasks =
+          taskService
+              .createTaskQuery()
+              .processVariableValueEquals("caseId", caseId.toString())
+              .active()
+              .orderByTaskCreateTime()
+              .asc()
+              .list();
+    } catch (ProcessEngineException ex) {
+      throw new WksWorkflowEngineException(
+          "CIB seven task query failed for caseId=" + caseId, ex);
+    }
+    if (engineTasks.isEmpty()) {
+      return List.of();
+    }
+    java.util.ArrayList<Task> out = new java.util.ArrayList<>(engineTasks.size());
+    for (org.cibseven.bpm.engine.task.Task engineTask : engineTasks) {
+      String caseTypeId = readCaseTypeId(engineTask, caseId);
+      if (caseTypeId == null) {
+        // Process instance terminated between query and variable read — drop the task rather than
+        // 500 the whole list.
+        continue;
+      }
+      String archetype =
+          readArchetype(engineTask.getProcessDefinitionId(), engineTask.getTaskDefinitionKey());
+      UUID assignee = parseAssignee(engineTask.getAssignee());
+      Instant createdAt =
+          engineTask.getCreateTime() == null
+              ? Instant.EPOCH
+              : engineTask.getCreateTime().toInstant();
+      Instant dueAt =
+          engineTask.getDueDate() == null ? null : engineTask.getDueDate().toInstant();
+      out.add(
+          new Task(
+              engineTask.getId(),
+              engineTask.getProcessInstanceId(),
+              engineTask.getProcessDefinitionId(),
+              caseId,
+              caseTypeId,
+              engineTask.getTaskDefinitionKey(),
+              engineTask.getName(),
+              assignee,
+              archetype,
+              createdAt,
+              dueAt));
+    }
+    return List.copyOf(out);
+  }
+
+  @Override
+  public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+    if (processDefinitionId == null || taskDefinitionKey == null) {
+      return null;
+    }
+    BpmnModelInstance model;
+    try {
+      model = repositoryService.getBpmnModelInstance(processDefinitionId);
+    } catch (ProcessEngineException ex) {
+      throw new WksWorkflowEngineException(
+          "CIB seven BPMN model lookup failed for processDefinitionId=" + processDefinitionId, ex);
+    }
+    if (model == null) {
+      return null;
+    }
+    var element = model.getModelElementById(taskDefinitionKey);
+    if (!(element instanceof UserTask userTask)) {
+      return null;
+    }
+    String fromProperty = readUserTaskProperty(userTask, "actionLabel");
+    if (fromProperty != null && !fromProperty.isBlank()) {
+      return fromProperty;
+    }
+    String name = userTask.getName();
+    return (name == null || name.isBlank()) ? null : name;
+  }
+
+  private String readCaseTypeId(org.cibseven.bpm.engine.task.Task engineTask, UUID caseId) {
+    Map<String, Object> processVars;
+    try {
+      processVars = runtimeService.getVariables(engineTask.getProcessInstanceId());
+    } catch (NullValueException ex) {
+      return null;
+    } catch (ProcessEngineException ex) {
+      String msg = ex.getMessage() == null ? "" : ex.getMessage();
+      if (msg.contains("execution") && msg.contains("doesn't exist")) {
+        return null;
+      }
+      throw new WksWorkflowEngineException(
+          "CIB seven process-variable lookup failed for taskId=" + engineTask.getId(), ex);
+    }
+    String caseTypeId = (String) processVars.get("caseTypeId");
+    if (caseTypeId == null) {
+      throw new WksWorkflowEngineException(
+          "Process instance "
+              + engineTask.getProcessInstanceId()
+              + " is missing the 'caseTypeId' variable expected on every WKS process — caseId="
+              + caseId);
+    }
+    return caseTypeId;
   }
 
   @Override
@@ -359,6 +467,11 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
     if (!(element instanceof UserTask userTask)) {
       return null;
     }
+    return readUserTaskProperty(userTask, "archetype");
+  }
+
+  /** Read a single named {@code camunda:property} from a user task's extension elements. */
+  private static String readUserTaskProperty(UserTask userTask, String name) {
     ExtensionElements ext = userTask.getExtensionElements();
     if (ext == null) {
       return null;
@@ -366,7 +479,7 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
     Collection<CamundaProperties> blocks = ext.getChildElementsByType(CamundaProperties.class);
     for (CamundaProperties block : blocks) {
       for (CamundaProperty p : block.getCamundaProperties()) {
-        if ("archetype".equals(p.getCamundaName())) {
+        if (name.equals(p.getCamundaName())) {
           return p.getCamundaValue();
         }
       }

--- a/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
@@ -279,8 +279,7 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
               .asc()
               .list();
     } catch (ProcessEngineException ex) {
-      throw new WksWorkflowEngineException(
-          "CIB seven task query failed for caseId=" + caseId, ex);
+      throw new WksWorkflowEngineException("CIB seven task query failed for caseId=" + caseId, ex);
     }
     if (engineTasks.isEmpty()) {
       return List.of();
@@ -300,8 +299,7 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
           engineTask.getCreateTime() == null
               ? Instant.EPOCH
               : engineTask.getCreateTime().toInstant();
-      Instant dueAt =
-          engineTask.getDueDate() == null ? null : engineTask.getDueDate().toInstant();
+      Instant dueAt = engineTask.getDueDate() == null ? null : engineTask.getDueDate().toInstant();
       out.add(
           new Task(
               engineTask.getId(),

--- a/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/CibSevenWorkflowEngine.java
@@ -284,9 +284,14 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
     if (engineTasks.isEmpty()) {
       return List.of();
     }
+    // Cache caseTypeId by processInstanceId — multiple pending tasks on the same process instance
+    // share variables, so a single getVariables call serves them all.
+    Map<String, String> caseTypeByProcessInstance = new java.util.HashMap<>();
     java.util.ArrayList<Task> out = new java.util.ArrayList<>(engineTasks.size());
     for (org.cibseven.bpm.engine.task.Task engineTask : engineTasks) {
-      String caseTypeId = readCaseTypeId(engineTask, caseId);
+      String pi = engineTask.getProcessInstanceId();
+      String caseTypeId =
+          caseTypeByProcessInstance.computeIfAbsent(pi, k -> readCaseTypeId(engineTask, caseId));
       if (caseTypeId == null) {
         // Process instance terminated between query and variable read — drop the task rather than
         // 500 the whole list.
@@ -376,10 +381,12 @@ public class CibSevenWorkflowEngine implements WorkflowEngine {
     try {
       taskService.complete(taskId, safeVars);
     } catch (NullValueException ex) {
-      // CIB seven's TaskService.complete throws NullValueException when the task does not exist
-      // (already completed or never existed).
-      throw new WksNotFoundException(
-          "Task " + taskId + " not found (already completed or unknown)");
+      // Task is gone between the load and the complete call — typically another action (another
+      // tab, another user) already completed it. AC5 requires this surface as a conflict (the
+      // truth has moved on), not 404 — the [Refresh case] recovery action depends on the 409
+      // envelope.
+      throw new WksConflictException(
+          "Task " + taskId + " was already completed. Refresh to see the latest case state.", ex);
     } catch (TaskAlreadyClaimedException ex) {
       // Spec Task 2.2 names this exception explicitly. Surfaces when complete() runs against a
       // task whose assignee differs from the actor at the engine boundary (defence-in-depth on

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
@@ -69,6 +69,9 @@ class CaseControllerTest {
   @MockitoBean(name = "wksCaseService")
   CaseService caseService;
 
+  @MockitoBean(name = "wksTaskService")
+  com.wkspower.platform.domain.service.TaskService taskService;
+
   @MockitoBean(name = "caseTypePermissionEvaluator")
   CaseTypePermissionEvaluator caseTypePermissionEvaluator;
 
@@ -194,6 +197,106 @@ class CaseControllerTest {
   @Test
   void listWithoutCaseTypeParamReturns400() throws Exception {
     mockMvc.perform(get("/api/cases").with(officerAuth())).andExpect(status().isBadRequest());
+  }
+
+  // ---- GET /api/cases/{id}/tasks (Story 2.8 AC1) -------------------------
+
+  @Test
+  void listTasksReturns200WithPendingTasks() throws Exception {
+    UUID caseId = UUID.randomUUID();
+    Case sample = sampleCase(caseId);
+    when(caseService.findById(caseId)).thenReturn(sample);
+    when(caseTypePermissionEvaluator.hasVerb(any(), eq("loan-application"), eq("view")))
+        .thenReturn(true);
+    when(taskService.findByCase(caseId))
+        .thenReturn(
+            List.of(
+                new com.wkspower.platform.domain.model.Task(
+                    "t1",
+                    "pi-1",
+                    "pd-1",
+                    caseId,
+                    "loan-application",
+                    "draft",
+                    "Draft application",
+                    null,
+                    "draft_section",
+                    NOW,
+                    null)));
+    when(taskService.readActionLabel("pd-1", "draft")).thenReturn("Draft application");
+
+    mockMvc
+        .perform(get("/api/cases/" + caseId + "/tasks").with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.length()").value(1))
+        .andExpect(jsonPath("$.data[0].id").value("t1"))
+        .andExpect(jsonPath("$.data[0].actionLabel").value("Draft application"))
+        .andExpect(jsonPath("$.data[0].caseId").value(caseId.toString()));
+  }
+
+  @Test
+  void listTasksReturns200EmptyForTerminalCase() throws Exception {
+    UUID caseId = UUID.randomUUID();
+    Case sample = sampleCase(caseId);
+    when(caseService.findById(caseId)).thenReturn(sample);
+    when(caseTypePermissionEvaluator.hasVerb(any(), anyString(), eq("view"))).thenReturn(true);
+    when(taskService.findByCase(caseId)).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/cases/" + caseId + "/tasks").with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.length()").value(0));
+  }
+
+  @Test
+  void listTasksReturns403WithoutViewVerb() throws Exception {
+    UUID caseId = UUID.randomUUID();
+    Case sample = sampleCase(caseId);
+    when(caseService.findById(caseId)).thenReturn(sample);
+    when(caseTypePermissionEvaluator.hasVerb(any(), anyString(), eq("view"))).thenReturn(false);
+
+    mockMvc
+        .perform(get("/api/cases/" + caseId + "/tasks").with(officerAuth()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void listTasksReturns404WhenCaseUnknown() throws Exception {
+    UUID caseId = UUID.randomUUID();
+    when(caseService.findById(caseId)).thenThrow(new WksNotFoundException("missing"));
+
+    mockMvc
+        .perform(get("/api/cases/" + caseId + "/tasks").with(officerAuth()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void listTasksFallsBackToTaskNameWhenActionLabelMissing() throws Exception {
+    UUID caseId = UUID.randomUUID();
+    Case sample = sampleCase(caseId);
+    when(caseService.findById(caseId)).thenReturn(sample);
+    when(caseTypePermissionEvaluator.hasVerb(any(), anyString(), eq("view"))).thenReturn(true);
+    when(taskService.findByCase(caseId))
+        .thenReturn(
+            List.of(
+                new com.wkspower.platform.domain.model.Task(
+                    "t1",
+                    "pi-1",
+                    "pd-1",
+                    caseId,
+                    "loan-application",
+                    "draft",
+                    "Review",
+                    null,
+                    "draft_section",
+                    NOW,
+                    null)));
+    when(taskService.readActionLabel("pd-1", "draft")).thenReturn(null);
+
+    mockMvc
+        .perform(get("/api/cases/" + caseId + "/tasks").with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].actionLabel").value("Review"));
   }
 
   // ---- PUT /api/cases/{id} -----------------------------------------------

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
@@ -59,6 +59,9 @@ class CaseTransitionControllerTest {
   @MockitoBean(name = "wksCaseService")
   CaseService caseService;
 
+  @MockitoBean(name = "wksTaskService")
+  com.wkspower.platform.domain.service.TaskService taskService;
+
   @MockitoBean(name = "caseTypePermissionEvaluator")
   CaseTypePermissionEvaluator evaluator;
 

--- a/backend/src/test/java/com/wkspower/platform/api/controller/TaskControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/TaskControllerTest.java
@@ -218,6 +218,7 @@ class TaskControllerTest {
     return new Task(
         "t1",
         "pi-1",
+        "pd-1",
         CASE_ID,
         "loan-application",
         "draft",

--- a/backend/src/test/java/com/wkspower/platform/api/controller/TaskControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/TaskControllerTest.java
@@ -110,13 +110,20 @@ class TaskControllerTest {
   }
 
   @Test
-  void completeReturns404WhenTaskUnknown() throws Exception {
+  void completeReturns409WhenTaskAlreadyCompleted() throws Exception {
+    // Story 2.8 AC5 — a task that disappeared between client load and the complete click
+    // (typically: another user / another tab completed it concurrently) MUST surface as 409 so
+    // the frontend conflict path renders the [Refresh case] recovery action. Returning 404 here
+    // breaks AC5 because `classifyError` would treat it as a generic non-conflict failure.
     when(taskService.findById("nope")).thenThrow(new WksNotFoundException("task missing"));
 
     mockMvc
         .perform(post("/api/tasks/nope/complete").with(officerAuth()))
-        .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.error.code").value("WKS-API-404"));
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.error.code").value("WKS-RTM-409"))
+        .andExpect(
+            jsonPath("$.error.message")
+                .value(org.hamcrest.Matchers.containsString("already completed")));
   }
 
   @Test
@@ -144,6 +151,46 @@ class TaskControllerTest {
         .perform(post("/api/tasks/t1/complete").with(officerAuth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.archetype").value("business_final"));
+  }
+
+  // ---- AC13-named coverage (Story 2.8) -----------------------------------
+  // The three tests below mirror the named cases listed in Story 2.8 AC13. They duplicate the
+  // scenarios already covered above with the spec-aligned identifiers so the test surface matches
+  // the AC text verbatim.
+
+  @Test
+  void complete_409_unknown_task_treated_as_already_completed() throws Exception {
+    // AC5 contract: any "task is gone" condition surfaces as 409 (conflict), not 404. The Phase
+    // 0 backend cannot distinguish "never existed" from "already completed" at the engine layer
+    // — both paths surface as the same conflict copy because that's the realistic root cause
+    // from a UI driven by server-supplied task ids.
+    when(taskService.findById("nope")).thenThrow(new WksNotFoundException("task missing"));
+    mockMvc
+        .perform(post("/api/tasks/nope/complete").with(officerAuth()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.error.code").value("WKS-RTM-409"));
+  }
+
+  @Test
+  void complete_403_missing_verb() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("draft_section", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(false);
+    mockMvc
+        .perform(post("/api/tasks/t1/complete").with(officerAuth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.error.code").value("WKS-API-403"));
+  }
+
+  @Test
+  void complete_409_already_completed_by_other() throws Exception {
+    when(taskService.findById("t1")).thenReturn(sampleTask("draft_section", null));
+    when(evaluator.hasVerb(any(), anyString(), eq("transition"))).thenReturn(true);
+    when(taskService.complete(eq("t1"), any(), any()))
+        .thenThrow(new WksConflictException("Task t1 already completed"));
+    mockMvc
+        .perform(post("/api/tasks/t1/complete").with(officerAuth()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.error.code").value("WKS-RTM-409"));
   }
 
   // ---- POST /api/tasks/{id}/claim ----------------------------------------

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
@@ -313,6 +313,16 @@ class CaseServiceTest {
     @Override
     public void signalTransition(
         String processInstanceId, String action, Map<String, Object> variables) {}
+
+    @Override
+    public List<com.wkspower.platform.domain.model.Task> findTasksByCase(UUID caseId) {
+      return List.of();
+    }
+
+    @Override
+    public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+      return null;
+    }
   }
 
   private static final class StubPublisher implements EventPublisher {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
@@ -273,6 +273,17 @@ class ConfigServiceDeployTest {
 
           @Override
           public void signalTransition(String pid, String action, Map<String, Object> vars) {}
+
+          @Override
+          public java.util.List<com.wkspower.platform.domain.model.Task> findTasksByCase(
+              java.util.UUID caseId) {
+            return java.util.List.of();
+          }
+
+          @Override
+          public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+            return null;
+          }
         };
 
     ConfigService svc =
@@ -458,6 +469,17 @@ class ConfigServiceDeployTest {
     @Override
     public void signalTransition(
         String processInstanceId, String action, java.util.Map<String, Object> variables) {}
+
+    @Override
+    public java.util.List<com.wkspower.platform.domain.model.Task> findTasksByCase(
+        java.util.UUID caseId) {
+      return java.util.List.of();
+    }
+
+    @Override
+    public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+      return null;
+    }
   }
 
   private static final class RecordingPublisher implements EventPublisher {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/TaskServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/TaskServiceTest.java
@@ -89,6 +89,7 @@ class TaskServiceTest {
         new Task(
             "t1",
             "pi-1",
+            "pd-1",
             CASE,
             "loan-application",
             "draft",
@@ -115,6 +116,7 @@ class TaskServiceTest {
         new Task(
             "t1",
             "pi-1",
+            "pd-1",
             CASE,
             "loan-application",
             "draft",
@@ -169,6 +171,7 @@ class TaskServiceTest {
         new Task(
             "t1",
             "pi-1",
+            "pd-1",
             CASE,
             "loan-application",
             "draft",
@@ -210,6 +213,7 @@ class TaskServiceTest {
     return new Task(
         id,
         "pi-1",
+        "pd-1",
         CASE,
         "loan-application",
         "draft",
@@ -291,6 +295,16 @@ class TaskServiceTest {
     public void signalTransition(
         String processInstanceId, String action, Map<String, Object> variables) {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Task> findTasksByCase(UUID caseId) {
+      return List.of();
+    }
+
+    @Override
+    public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+      return null;
     }
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/engine/CibSevenWorkflowEngineIT.java
+++ b/backend/src/test/java/com/wkspower/platform/engine/CibSevenWorkflowEngineIT.java
@@ -201,6 +201,46 @@ class CibSevenWorkflowEngineIT {
   }
 
   @Test
+  void findTasksByCaseFiltersByCaseIdVar() {
+    // Story 2.8 AC1 — list pending tasks scoped to a single caseId. A second case in the same
+    // process must NOT bleed through.
+    UUID caseA = UUID.randomUUID();
+    UUID caseB = UUID.randomUUID();
+    String piA = startWithUserTask("by-case-a", caseA, "loan-application");
+    String piB = startWithUserTask("by-case-b", caseB, "loan-application");
+
+    java.util.List<Task> tasksA = workflowEngine.findTasksByCase(caseA);
+    java.util.List<Task> tasksB = workflowEngine.findTasksByCase(caseB);
+
+    assertThat(tasksA).hasSize(1);
+    assertThat(tasksA.get(0).caseId()).isEqualTo(caseA);
+    assertThat(tasksA.get(0).processInstanceId()).isEqualTo(piA);
+    assertThat(tasksB).hasSize(1);
+    assertThat(tasksB.get(0).caseId()).isEqualTo(caseB);
+    assertThat(tasksB.get(0).processInstanceId()).isEqualTo(piB);
+  }
+
+  @Test
+  void findTasksByCaseReturnsEmptyForUnknownCase() {
+    assertThat(workflowEngine.findTasksByCase(UUID.randomUUID())).isEmpty();
+  }
+
+  @Test
+  void readActionLabelFallsBackToTaskName() {
+    UUID caseId = UUID.randomUUID();
+    String pi = startWithUserTask("read-action-label", caseId, "loan-application");
+    String taskId = currentTaskId(pi);
+    Optional<Task> task = workflowEngine.findTask(taskId);
+    assertThat(task).isPresent();
+    String label =
+        workflowEngine.readActionLabel(
+            task.get().processDefinitionId(), task.get().taskDefinitionKey());
+    // The minimal BPMN fixture sets no actionLabel property and no userTask name — null is the
+    // honest answer; the DTO mapper's fallback to task.name() handles the rest.
+    assertThat(label).isNull();
+  }
+
+  @Test
   void completeUnknownTaskThrowsNotFound() {
     assertThatThrownBy(() -> workflowEngine.completeTask("nope", Map.of()))
         .isInstanceOf(WksNotFoundException.class);

--- a/backend/src/test/java/com/wkspower/platform/engine/CibSevenWorkflowEngineIT.java
+++ b/backend/src/test/java/com/wkspower/platform/engine/CibSevenWorkflowEngineIT.java
@@ -227,23 +227,44 @@ class CibSevenWorkflowEngineIT {
 
   @Test
   void readActionLabelFallsBackToTaskName() {
+    // AC1 — when the userTask has no `actionLabel` camunda:property but does set the `name`
+    // attribute, readActionLabel returns the userTask name (not null).
     UUID caseId = UUID.randomUUID();
-    String pi = startWithUserTask("read-action-label", caseId, "loan-application");
+    String key = "read-action-label";
+    byte[] bpmn = bpmnWithUserTaskName(key, "Draft application").getBytes(StandardCharsets.UTF_8);
+    workflowEngine.deploy(new DeploymentRequest(key, key, bpmn, "loan-application", 1));
+    String pi =
+        workflowEngine.startProcessInstance(
+            key, Map.of("caseId", caseId.toString(), "caseTypeId", "loan-application"));
     String taskId = currentTaskId(pi);
     Optional<Task> task = workflowEngine.findTask(taskId);
     assertThat(task).isPresent();
     String label =
         workflowEngine.readActionLabel(
             task.get().processDefinitionId(), task.get().taskDefinitionKey());
-    // The minimal BPMN fixture sets no actionLabel property and no userTask name — null is the
-    // honest answer; the DTO mapper's fallback to task.name() handles the rest.
+    assertThat(label).isEqualTo("Draft application");
+  }
+
+  @Test
+  void readActionLabelReturnsNullWhenBothPropertyAndNameAbsent() {
+    UUID caseId = UUID.randomUUID();
+    String pi = startWithUserTask("read-action-label-empty", caseId, "loan-application");
+    String taskId = currentTaskId(pi);
+    Optional<Task> task = workflowEngine.findTask(taskId);
+    assertThat(task).isPresent();
+    String label =
+        workflowEngine.readActionLabel(
+            task.get().processDefinitionId(), task.get().taskDefinitionKey());
     assertThat(label).isNull();
   }
 
   @Test
-  void completeUnknownTaskThrowsNotFound() {
+  void completeUnknownTaskThrowsConflict() {
+    // Story 2.8 — "task is gone" at the engine layer surfaces as conflict (AC5), so the
+    // controller can return 409 and the frontend renders [Refresh case]. 404 would short-circuit
+    // the conflict UX.
     assertThatThrownBy(() -> workflowEngine.completeTask("nope", Map.of()))
-        .isInstanceOf(WksNotFoundException.class);
+        .isInstanceOf(WksConflictException.class);
   }
 
   @Test
@@ -285,6 +306,32 @@ class CibSevenWorkflowEngineIT {
             "Story 2.3 AC4: ProcessEngineException for unknown key wraps to"
                 + " WksWorkflowEngineException")
         .isInstanceOf(WksWorkflowEngineException.class);
+  }
+
+  /** Variant of {@link #simpleBpmn} that sets the userTask name attribute. */
+  private static String bpmnWithUserTaskName(String key, String userTaskName) {
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<bpmn:definitions xmlns:bpmn=\"http://www.omg.org/spec/BPMN/20100524/MODEL\""
+        + " xmlns:camunda=\"http://camunda.org/schema/1.0/bpmn\""
+        + " targetNamespace=\"http://wkspower.com/bpmn/test\">"
+        + "<bpmn:process id=\""
+        + key
+        + "\" isExecutable=\"true\" camunda:historyTimeToLive=\"30\">"
+        + "<bpmn:startEvent id=\"start\"/>"
+        + "<bpmn:userTask id=\"draft\" name=\""
+        + userTaskName
+        + "\">"
+        + "<bpmn:extensionElements>"
+        + "<camunda:properties>"
+        + "<camunda:property name=\"archetype\" value=\"submit_for_processing\"/>"
+        + "</camunda:properties>"
+        + "</bpmn:extensionElements>"
+        + "</bpmn:userTask>"
+        + "<bpmn:endEvent id=\"end\"/>"
+        + "<bpmn:sequenceFlow id=\"f1\" sourceRef=\"start\" targetRef=\"draft\"/>"
+        + "<bpmn:sequenceFlow id=\"f2\" sourceRef=\"draft\" targetRef=\"end\"/>"
+        + "</bpmn:process>"
+        + "</bpmn:definitions>";
   }
 
   /** Minimal BPMN 2.0 fixture used by every test in this class. */

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoaderTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoaderTest.java
@@ -139,6 +139,17 @@ class CaseTypeStartupLoaderTest {
           @Override
           public void signalTransition(
               String processInstanceId, String action, java.util.Map<String, Object> variables) {}
+
+          @Override
+          public java.util.List<com.wkspower.platform.domain.model.Task> findTasksByCase(
+              java.util.UUID caseId) {
+            return java.util.List.of();
+          }
+
+          @Override
+          public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+            return null;
+          }
         },
         event -> {});
   }

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -1,0 +1,37 @@
+import type { TaskActionResponse, TaskDto } from '@/types/task';
+
+import { apiFetch } from './client';
+
+/** Story 2.8 AC1 — list pending user tasks for a case. */
+export async function listTasksByCase(caseId: string): Promise<TaskDto[]> {
+  const result = await apiFetch<TaskDto[]>(`/api/cases/${encodeURIComponent(caseId)}/tasks`);
+  return result.data;
+}
+
+/**
+ * Story 2.4 — complete a user task. Phase 0 (Story 2.8) ships click-to-complete with empty
+ * variables; task forms with custom variables are out of scope (story §Out of scope).
+ */
+export async function completeTask(
+  taskId: string,
+  variables: Record<string, unknown> = {},
+): Promise<TaskActionResponse> {
+  const result = await apiFetch<TaskActionResponse>(
+    `/api/tasks/${encodeURIComponent(taskId)}/complete`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ variables }),
+    },
+  );
+  return result.data;
+}
+
+/** Story 2.4 — claim an unassigned user task. */
+export async function claimTask(taskId: string): Promise<TaskActionResponse> {
+  const result = await apiFetch<TaskActionResponse>(
+    `/api/tasks/${encodeURIComponent(taskId)}/claim`,
+    { method: 'POST' },
+  );
+  return result.data;
+}

--- a/frontend/src/components/ui/FormErrorsBanner.test.tsx
+++ b/frontend/src/components/ui/FormErrorsBanner.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FormErrorsBanner } from './FormErrorsBanner';
+
+describe('FormErrorsBanner (Story 2.8 AC9)', () => {
+  it('renders nothing when there are no errors', () => {
+    const { container } = render(<FormErrorsBanner errors={[]} onAnchorClick={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders singular copy when count is 1', () => {
+    render(
+      <FormErrorsBanner
+        errors={[{ field: 'name', displayName: 'Name', order: 0 }]}
+        onAnchorClick={() => {}}
+      />,
+    );
+    expect(screen.getByText('1 field needs attention')).toBeInTheDocument();
+  });
+
+  it('renders plural copy with the count interpolated', () => {
+    render(
+      <FormErrorsBanner
+        errors={[
+          { field: 'name', displayName: 'Name', order: 0 },
+          { field: 'email', displayName: 'Email', order: 1 },
+        ]}
+        onAnchorClick={() => {}}
+      />,
+    );
+    expect(screen.getByText('2 fields need attention')).toBeInTheDocument();
+  });
+
+  it('renders anchor links sorted by field.order ascending', () => {
+    render(
+      <FormErrorsBanner
+        errors={[
+          { field: 'b', displayName: 'Beta', order: 2 },
+          { field: 'a', displayName: 'Alpha', order: 1 },
+        ]}
+        onAnchorClick={() => {}}
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.map((b) => b.textContent)).toEqual(['Alpha', 'Beta']);
+  });
+
+  it('uses role="alert" + aria-live="polite" (single live region per AC9)', () => {
+    render(
+      <FormErrorsBanner
+        errors={[{ field: 'name', displayName: 'Name', order: 0 }]}
+        onAnchorClick={() => {}}
+      />,
+    );
+    const region = screen.getByRole('alert');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('invokes onAnchorClick with the field id', () => {
+    const onAnchorClick = vi.fn();
+    render(
+      <FormErrorsBanner
+        errors={[{ field: 'name', displayName: 'Name', order: 0 }]}
+        onAnchorClick={onAnchorClick}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Name' }));
+    expect(onAnchorClick).toHaveBeenCalledWith('name');
+  });
+});

--- a/frontend/src/components/ui/FormErrorsBanner.tsx
+++ b/frontend/src/components/ui/FormErrorsBanner.tsx
@@ -1,0 +1,62 @@
+import { t } from '@/i18n';
+
+/**
+ * Story 2.8 AC9 — generic multi-field errors-count banner with anchor links. Shipped as a reusable
+ * component (owned-source) so future task forms / document upload metadata / config deploy errors
+ * can wire it without re-implementing the count copy + focus management.
+ *
+ * Renders nothing when {@code errors.length === 0}. Single ARIA-live region with {@code
+ * aria-live="polite"}; per-field inline errors continue to render alongside this banner — the
+ * banner is the orientation device for screen readers + keyboard users, the per-field error is
+ * the spatial cue for sighted users (Story 2.8 §AC9).
+ */
+export interface FormErrorEntry {
+  field: string;
+  displayName: string;
+  order: number;
+}
+
+export interface FormErrorsBannerProps {
+  errors: FormErrorEntry[];
+  /**
+   * Click handler for the per-field anchor link — the parent typically routes this through
+   * RHF's {@code form.setFocus(name)} so controlled Radix primitives (Select, Checkbox) focus
+   * correctly via {@code field.ref}.
+   */
+  onAnchorClick: (field: string) => void;
+}
+
+export function FormErrorsBanner({ errors, onAnchorClick }: FormErrorsBannerProps) {
+  if (errors.length === 0) return null;
+  const sorted = [...errors].sort((a, b) => a.order - b.order);
+  const count = sorted.length;
+  // Manual ICU plural — the i18n engine does simple `{name}` substitution; keep the singular and
+  // plural copies as separate keys (single key would either drop the count or read awkwardly).
+  const heading =
+    count === 1
+      ? t('cases.create.errorsCount.one')
+      : t('cases.create.errorsCount', { count: String(count) });
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="rounded-[var(--radius-md)] border border-[var(--destructive)] bg-[var(--destructive)]/10 px-3 py-2 text-sm"
+    >
+      <p className="font-medium text-[var(--destructive)]">{heading}</p>
+      <ul className="mt-1 flex flex-wrap gap-x-3 gap-y-1">
+        {sorted.map((e) => (
+          <li key={e.field}>
+            <button
+              type="button"
+              className="text-[var(--primary)] underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+              onClick={() => onAnchorClick(e.field)}
+            >
+              {e.displayName}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/MutationButton.tsx
+++ b/frontend/src/components/ui/MutationButton.tsx
@@ -45,6 +45,12 @@ export interface MutationButtonProps extends Omit<
   failedLabel?: string;
   /** Optional retry slot; renders only on `failed`. */
   retryAction?: ReactNode;
+  /**
+   * Optional override for the `aria-live` announcement. When provided, the live region announces
+   * this string instead of the visible-state label — used by `TaskLifecycleButton` to surface the
+   * "Press Enter to refresh." hint on the conflict path without changing the visible button text.
+   */
+  announcement?: string;
 }
 
 export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>(
@@ -57,6 +63,7 @@ export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>
       confirmedLabel = 'Confirmed',
       failedLabel = 'Failed',
       retryAction,
+      announcement,
       className,
       disabled,
       ...rest
@@ -84,7 +91,8 @@ export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>
     // makes some AT engines drop region tracking. Failed state is still loud because the text
     // changes, the region just doesn't switch to assertive.
     const announce =
-      state === 'confirming'
+      announcement ??
+      (state === 'confirming'
         ? confirmingLabel
         : state === 'processing'
           ? processingLabel
@@ -92,7 +100,7 @@ export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>
             ? confirmedLabel
             : state === 'failed'
               ? failedLabel
-              : '';
+              : '');
 
     const stateClass =
       state === 'confirming'
@@ -118,6 +126,7 @@ export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>
           ref={ref}
           type={rest.type ?? 'submit'}
           aria-busy={state === 'confirming' || state === 'processing' ? true : undefined}
+          aria-disabled={buttonDisabled || undefined}
           disabled={buttonDisabled}
           data-state={confirmedFaded && state === 'confirmed' ? 'idle' : state}
           className={cn(stateClass, className)}

--- a/frontend/src/components/ui/MutationButton.tsx
+++ b/frontend/src/components/ui/MutationButton.tsx
@@ -13,16 +13,18 @@ import { cn } from '@/lib/cn';
 import { Button } from './Button';
 
 /**
- * Story 2.7 — 4-state slice of the TaskLifecycleButton state machine (UX spec §TaskLifecycleButton
- * lines 716-744). The 5-state owner with the {@code processing} state ships in Story 2.8 — at that
- * point this component is either renamed or wrapped. The TS literal-union here is forward-
- * compatible: 2.8 widens the union to add {@code 'processing'}.
+ * Story 2.7 — 4-state slice of the lifecycle. Story 2.8 widened the union to add {@code
+ * 'processing'} (5-state superset owned by {@code TaskLifecycleButton} for backend mutations that
+ * may genuinely take >2s or whose true completion is signalled async via SSE — Story 4.3). This
+ * component remains the 4-state presentational primitive; consumers like the case-creation form
+ * (synchronous backend) stay on it. {@code TaskLifecycleButton} composes it for the four shared
+ * states and adds the {@code processing} visual itself.
  *
  * Presentational: parents drive transitions via the {@code state} prop (typically derived from
  * RHF's {@code formState.isSubmitting} + a TanStack Query mutation's {@code isPending} /
  * {@code isSuccess} / {@code isError}). The component itself owns no state machine.
  */
-export type MutationButtonState = 'idle' | 'confirming' | 'confirmed' | 'failed';
+export type MutationButtonState = 'idle' | 'confirming' | 'processing' | 'confirmed' | 'failed';
 
 const CONFIRMED_FADE_MS = 2_000;
 
@@ -35,6 +37,8 @@ export interface MutationButtonProps extends Omit<
   children: ReactNode;
   /** Label for confirming state — parent supplies localised string. */
   confirmingLabel?: string;
+  /** Label for processing state — Story 2.8; only shown when `state === 'processing'`. */
+  processingLabel?: string;
   /** Label for confirmed state — parent supplies localised string. */
   confirmedLabel?: string;
   /** Reason-bearing label for failed state — parent supplies localised string. */
@@ -49,6 +53,7 @@ export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>
       state,
       children,
       confirmingLabel = 'Confirming…',
+      processingLabel = 'Processing…',
       confirmedLabel = 'Confirmed',
       failedLabel = 'Failed',
       retryAction,
@@ -81,42 +86,50 @@ export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>
     const announce =
       state === 'confirming'
         ? confirmingLabel
-        : state === 'confirmed'
-          ? confirmedLabel
-          : state === 'failed'
-            ? failedLabel
-            : '';
+        : state === 'processing'
+          ? processingLabel
+          : state === 'confirmed'
+            ? confirmedLabel
+            : state === 'failed'
+              ? failedLabel
+              : '';
 
     const stateClass =
       state === 'confirming'
         ? 'bg-[var(--ring)] text-white animate-pulse'
-        : state === 'confirmed'
-          ? confirmedFaded
-            ? ''
-            : 'bg-emerald-600 text-white hover:bg-emerald-600'
-          : state === 'failed'
-            ? 'bg-[var(--destructive)] text-white hover:bg-[var(--destructive)]'
-            : '';
+        : state === 'processing'
+          ? // Slower pulse to differentiate from `confirming`; same indigo accent.
+            'bg-[var(--ring)] text-white animate-pulse [animation-duration:2s]'
+          : state === 'confirmed'
+            ? confirmedFaded
+              ? ''
+              : 'bg-emerald-600 text-white hover:bg-emerald-600'
+            : state === 'failed'
+              ? 'bg-[var(--destructive)] text-white hover:bg-[var(--destructive)]'
+              : '';
 
     const isVisuallyConfirmed = state === 'confirmed' && !confirmedFaded;
-    const buttonDisabled = disabled || state === 'confirming' || isVisuallyConfirmed;
+    const buttonDisabled =
+      disabled || state === 'confirming' || state === 'processing' || isVisuallyConfirmed;
 
     return (
       <div className={cn('inline-flex items-center gap-2')}>
         <Button
           ref={ref}
           type={rest.type ?? 'submit'}
-          aria-busy={state === 'confirming' ? true : undefined}
+          aria-busy={state === 'confirming' || state === 'processing' ? true : undefined}
           disabled={buttonDisabled}
           data-state={confirmedFaded && state === 'confirmed' ? 'idle' : state}
           className={cn(stateClass, className)}
           {...rest}
         >
           {state === 'confirming' && <Loader2 className="size-4 animate-spin" aria-hidden />}
+          {state === 'processing' && <Loader2 className="size-4 animate-spin" aria-hidden />}
           {isVisuallyConfirmed && <Check className="size-4" aria-hidden />}
           {state === 'failed' && <X className="size-4" aria-hidden />}
           {(state === 'idle' || (state === 'confirmed' && confirmedFaded)) && children}
           {state === 'confirming' && confirmingLabel}
+          {state === 'processing' && processingLabel}
           {isVisuallyConfirmed && confirmedLabel}
           {state === 'failed' && failedLabel}
           <span key={announceKey.current} className="sr-only" aria-live="polite">

--- a/frontend/src/components/workspace/CaseActionBar.test.tsx
+++ b/frontend/src/components/workspace/CaseActionBar.test.tsx
@@ -53,13 +53,25 @@ describe('CaseActionBar (Story 2.8 AC8/AC10)', () => {
       http.get(`/api/cases/${CASE_ID}/tasks`, () => HttpResponse.json({ data: [], meta: {} })),
     );
     render(wrap(<CaseActionBar caseId={CASE_ID} />));
-    // Wait for the empty data to land first
-    await waitFor(() => expect(screen.queryByTestId('case-action-bar')).not.toBeInTheDocument());
-    expect(screen.queryByTestId('case-action-bar-empty-hint')).not.toBeInTheDocument();
+    // Wait for the empty-data state to settle: the populated bar is gone, the empty hint is not
+    // yet visible (4s timer not yet fired).
+    await waitFor(() => {
+      expect(screen.queryByTestId('case-action-bar')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('case-action-bar-empty-hint')).not.toBeInTheDocument();
+    });
     act(() => {
       vi.advanceTimersByTime(4_500);
     });
     expect(screen.getByTestId('case-action-bar-empty-hint')).toBeInTheDocument();
     expect(screen.getByText('Next case (J)')).toBeInTheDocument();
+  });
+
+  it('renders an inline retry when the tasks endpoint fails', async () => {
+    server.use(
+      http.get(`/api/cases/${CASE_ID}/tasks`, () => HttpResponse.json({}, { status: 500 })),
+    );
+    render(wrap(<CaseActionBar caseId={CASE_ID} />));
+    await waitFor(() => expect(screen.getByTestId('case-action-bar-error')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/workspace/CaseActionBar.test.tsx
+++ b/frontend/src/components/workspace/CaseActionBar.test.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '@/test/server';
+import type { TaskDto } from '@/types/task';
+
+import { CaseActionBar } from './CaseActionBar';
+
+const CASE_ID = 'case-1';
+
+const TASK: TaskDto = {
+  id: 't1',
+  processInstanceId: 'pi-1',
+  caseId: CASE_ID,
+  caseTypeId: 'loan-application',
+  taskDefinitionKey: 'draft',
+  name: 'Draft application',
+  assignee: null,
+  archetype: 'draft_section',
+  actionLabel: 'Draft application',
+  createdAt: '2026-04-26T10:00:00Z',
+  dueAt: null,
+};
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{node}</QueryClientProvider>;
+}
+
+describe('CaseActionBar (Story 2.8 AC8/AC10)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the primary CTA with task.actionLabel when a task is pending', async () => {
+    server.use(
+      http.get(`/api/cases/${CASE_ID}/tasks`, () => HttpResponse.json({ data: [TASK], meta: {} })),
+    );
+    render(wrap(<CaseActionBar caseId={CASE_ID} />));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Draft application' })).toBeInTheDocument(),
+    );
+  });
+
+  it('shows the "Next case" hint after a 4s delay when no tasks are pending', async () => {
+    server.use(
+      http.get(`/api/cases/${CASE_ID}/tasks`, () => HttpResponse.json({ data: [], meta: {} })),
+    );
+    render(wrap(<CaseActionBar caseId={CASE_ID} />));
+    // Wait for the empty data to land first
+    await waitFor(() => expect(screen.queryByTestId('case-action-bar')).not.toBeInTheDocument());
+    expect(screen.queryByTestId('case-action-bar-empty-hint')).not.toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(4_500);
+    });
+    expect(screen.getByTestId('case-action-bar-empty-hint')).toBeInTheDocument();
+    expect(screen.getByText('Next case (J)')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/workspace/CaseActionBar.tsx
+++ b/frontend/src/components/workspace/CaseActionBar.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+import { useCaseTasks } from '@/hooks/useTasks';
+import { t } from '@/i18n';
+
+import { TaskLifecycleButton } from './TaskLifecycleButton';
+
+const NEXT_CASE_HINT_DELAY_MS = 4_000;
+
+/**
+ * Story 2.8 AC8 / AC10 — primary CTA placement. Lives between the case heading row and the tabs.
+ * Renders a {@link TaskLifecycleButton} per pending task (topmost-by-createdAt is the primary CTA;
+ * subsequent tasks render in a vertical stack below it). When the case has no pending tasks, a
+ * subtle "Next case ({@code J})" hint appears after a 4s delay (the J/K shortcut already lives in
+ * {@code CaseWorkspace}; 2.8 only ships the visible affordance).
+ */
+export interface CaseActionBarProps {
+  caseId: string;
+}
+
+export function CaseActionBar({ caseId }: CaseActionBarProps) {
+  const tasksQuery = useCaseTasks(caseId);
+  const [showHint, setShowHint] = useState(false);
+
+  const hasTasks = (tasksQuery.data?.length ?? 0) > 0;
+
+  // Empty-state hint: show after 4s, hide the moment a task arrives. Reset the timer when caseId
+  // changes (J/K stepping to a new case).
+  useEffect(() => {
+    setShowHint(false);
+    if (tasksQuery.isLoading) return undefined;
+    if (hasTasks) return undefined;
+    const handle = window.setTimeout(() => setShowHint(true), NEXT_CASE_HINT_DELAY_MS);
+    return () => clearTimeout(handle);
+  }, [caseId, tasksQuery.isLoading, hasTasks]);
+
+  if (tasksQuery.isError) {
+    // Phase 0 — fail quietly. The case panel owns the case-level error UI; surfacing a second
+    // error band here would double-announce. Re-fetch happens on focus (TanStack Query default).
+    return null;
+  }
+
+  if (!tasksQuery.data || tasksQuery.data.length === 0) {
+    if (!showHint) return null;
+    return (
+      <div
+        data-testid="case-action-bar-empty-hint"
+        className="px-4 py-2 text-xs text-[var(--muted-foreground)]"
+      >
+        {t('case.nextCaseHint', { shortcut: 'J' })}
+      </div>
+    );
+  }
+
+  const [primary, ...secondary] = tasksQuery.data;
+  if (!primary) return null;
+
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3" data-testid="case-action-bar">
+      <TaskLifecycleButton task={primary} />
+      {secondary.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          {secondary.map((task) => (
+            <TaskLifecycleButton key={task.id} task={task} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/CaseActionBar.tsx
+++ b/frontend/src/components/workspace/CaseActionBar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { Button } from '@/components/ui/Button';
 import { useCaseTasks } from '@/hooks/useTasks';
 import { t } from '@/i18n';
 
@@ -35,9 +36,19 @@ export function CaseActionBar({ caseId }: CaseActionBarProps) {
   }, [caseId, tasksQuery.isLoading, hasTasks]);
 
   if (tasksQuery.isError) {
-    // Phase 0 — fail quietly. The case panel owns the case-level error UI; surfacing a second
-    // error band here would double-announce. Re-fetch happens on focus (TanStack Query default).
-    return null;
+    // Surface an honest, retryable error rather than silently hiding the CTA. The case panel's
+    // case-level error UI does not cover the tasks endpoint specifically.
+    return (
+      <div
+        data-testid="case-action-bar-error"
+        className="flex items-center gap-2 px-4 py-2 text-xs text-[var(--destructive)]"
+      >
+        <span>{t('case.tasks.error')}</span>
+        <Button type="button" variant="ghost" onClick={() => tasksQuery.refetch()}>
+          {t('common.retry')}
+        </Button>
+      </div>
+    );
   }
 
   if (!tasksQuery.data || tasksQuery.data.length === 0) {

--- a/frontend/src/components/workspace/CaseDetailPanel.actionBar.test.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.actionBar.test.tsx
@@ -1,0 +1,105 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import { loanApplicationCaseTypeView } from '@/test/fixtures/buildCaseListFixture';
+import { server } from '@/test/server';
+
+import { CaseDetailPanel } from './CaseDetailPanel';
+
+const CASE_ID = '11111111-1111-1111-1111-111111111111';
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TooltipProvider delayDuration={0}>{node}</TooltipProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('CaseDetailPanel — action bar slot integration (Story 2.8 AC8/AC11)', () => {
+  it('renders the CaseActionBar between the heading and the tabs', async () => {
+    const view = loanApplicationCaseTypeView();
+    server.use(
+      http.get(`/api/cases/${CASE_ID}`, () =>
+        HttpResponse.json({
+          data: {
+            id: CASE_ID,
+            caseTypeId: view.id,
+            caseTypeVersion: view.version,
+            status: view.statuses[0]?.id ?? 'open',
+            statusLabel: view.statuses[0]?.displayName ?? 'Open',
+            data: {},
+            createdAt: '2026-04-26T10:00:00Z',
+            updatedAt: '2026-04-26T10:00:00Z',
+            caseType: view,
+          },
+          meta: {},
+        }),
+      ),
+      http.get(`/api/cases/${CASE_ID}/tasks`, () => HttpResponse.json({ data: [], meta: {} })),
+    );
+    render(wrap(<CaseDetailPanel caseId={CASE_ID} onClose={() => {}} />));
+    await waitFor(() => expect(screen.getByRole('tablist')).toBeInTheDocument());
+  });
+
+  it('AC11 — renders exactly one aria-live="polite" region across panel + action bar', async () => {
+    const view = loanApplicationCaseTypeView();
+    server.use(
+      http.get(`/api/cases/${CASE_ID}`, () =>
+        HttpResponse.json({
+          data: {
+            id: CASE_ID,
+            caseTypeId: view.id,
+            caseTypeVersion: view.version,
+            status: view.statuses[0]?.id ?? 'open',
+            statusLabel: view.statuses[0]?.displayName ?? 'Open',
+            data: {},
+            createdAt: '2026-04-26T10:00:00Z',
+            updatedAt: '2026-04-26T10:00:00Z',
+            caseType: view,
+          },
+          meta: {},
+        }),
+      ),
+      http.get(`/api/cases/${CASE_ID}/tasks`, () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: 't1',
+              processInstanceId: 'pi-1',
+              caseId: CASE_ID,
+              caseTypeId: view.id,
+              taskDefinitionKey: 'draft',
+              name: 'Draft application',
+              assignee: null,
+              archetype: 'draft_section',
+              actionLabel: 'Draft application',
+              createdAt: '2026-04-26T10:00:00Z',
+              dueAt: null,
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+    const { container } = render(wrap(<CaseDetailPanel caseId={CASE_ID} onClose={() => {}} />));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Draft application' })).toBeInTheDocument(),
+    );
+    // The panel owns one polite live region (the heading announcement). MutationButton owns its
+    // own sr-only polite span (single primary CTA → exactly one). No extra region in the action
+    // bar's takingLonger span (Story 2.8 P1 fix). Total expected = 2 across the integrated tree.
+    const liveRegions = container.querySelectorAll('[aria-live="polite"]');
+    expect(liveRegions.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/frontend/src/components/workspace/CaseDetailPanel.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.tsx
@@ -9,6 +9,7 @@ import { useCase } from '@/hooks/useCases';
 import { t } from '@/i18n';
 
 import { ActivityTabPlaceholder } from './ActivityTabPlaceholder';
+import { CaseActionBar } from './CaseActionBar';
 import { CaseBreadcrumbs } from './CaseBreadcrumbs';
 import { DocumentsTabPlaceholder } from './DocumentsTabPlaceholder';
 import { PropertiesTab } from './PropertiesTab';
@@ -212,6 +213,7 @@ export function CaseDetailPanel({ caseId, onClose }: CaseDetailPanelProps) {
           {t('case.detail.announcement', { idShort })}
         </span>
       </header>
+      <CaseActionBar caseId={caseId} />
       <Tabs value={tab} onValueChange={setTab} className="flex flex-1 flex-col">
         <TabsList className="px-4">
           <TabsTrigger value="activity">{t('tabs.activity')}</TabsTrigger>

--- a/frontend/src/components/workspace/CaseDetailPanel.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.tsx
@@ -13,6 +13,7 @@ import { CaseActionBar } from './CaseActionBar';
 import { CaseBreadcrumbs } from './CaseBreadcrumbs';
 import { DocumentsTabPlaceholder } from './DocumentsTabPlaceholder';
 import { PropertiesTab } from './PropertiesTab';
+import { StatusBadge } from './StatusBadge';
 
 const HEADING_ID = 'case-detail-heading';
 
@@ -206,9 +207,12 @@ export function CaseDetailPanel({ caseId, onClose }: CaseDetailPanelProps) {
           <CaseBreadcrumbs caseIdShort={idShort} />
           <CloseButton onClose={onClose} />
         </div>
-        <HeadingFocusable shouldFocus={shouldFocusHeading}>
-          {t('case.heading', { idShort })}
-        </HeadingFocusable>
+        <div className="flex items-center gap-2">
+          <HeadingFocusable shouldFocus={shouldFocusHeading}>
+            {t('case.heading', { idShort })}
+          </HeadingFocusable>
+          <StatusBadge status={caseDto.status} caseType={caseDto.caseType} />
+        </div>
         <span className="sr-only" aria-live="polite">
           {t('case.detail.announcement', { idShort })}
         </span>

--- a/frontend/src/components/workspace/NewCaseDialog.test.tsx
+++ b/frontend/src/components/workspace/NewCaseDialog.test.tsx
@@ -115,6 +115,18 @@ describe('NewCaseDialog — submit failure paths (AC5/P2/P4)', () => {
     await waitFor(() => expect(screen.getByText('Amount too high')).toBeInTheDocument());
   });
 
+  it('renders the multi-field errors banner with anchor links after submit (Story 2.8 AC9)', async () => {
+    const user = userEvent.setup();
+    const view = loanApplicationCaseTypeView();
+    renderWithProviders(<NewCaseDialog open caseType={view} onOpenChange={() => {}} />);
+    // Submit empty — both required fields fail at once.
+    await user.click(screen.getByRole('button', { name: /create case/i }));
+    await waitFor(() => expect(screen.getByText(/2 fields need attention/i)).toBeInTheDocument());
+    // Anchor links exist for each failing field, with role=button (FormErrorsBanner uses buttons).
+    expect(screen.getAllByRole('button', { name: /Applicant/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: /Amount/i }).length).toBeGreaterThan(0);
+  });
+
   it('403 surfaces auth-specific banner copy (P4)', async () => {
     const user = userEvent.setup();
     const view = loanApplicationCaseTypeView();

--- a/frontend/src/components/workspace/NewCaseDialog.tsx
+++ b/frontend/src/components/workspace/NewCaseDialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/Dialog';
+import { FormErrorsBanner, type FormErrorEntry } from '@/components/ui/FormErrorsBanner';
 import { FormField, type FormFieldRenderProps } from '@/components/ui/FormField';
 import { Input } from '@/components/ui/Input';
 import { MutationButton, type MutationButtonState } from '@/components/ui/MutationButton';
@@ -248,6 +249,12 @@ export function NewCaseDialog({ open, caseType, onOpenChange }: NewCaseDialogPro
             ) : (
               requiredFields.map((f) => renderField(f, isPending, form))
             )}
+            {form.formState.isSubmitted ? (
+              <FormErrorsBanner
+                errors={collectFormErrors(form, requiredFields)}
+                onAnchorClick={(field) => form.setFocus(field)}
+              />
+            ) : null}
             {serverError ? (
               <Alert
                 ref={bannerRef}
@@ -284,6 +291,20 @@ export function NewCaseDialog({ open, caseType, onOpenChange }: NewCaseDialogPro
       </DialogContent>
     </Dialog>
   );
+}
+
+function collectFormErrors(
+  form: UseFormReturn<Record<string, unknown>>,
+  requiredFields: FieldDefinition[],
+): FormErrorEntry[] {
+  const errs = form.formState.errors;
+  const out: FormErrorEntry[] = [];
+  for (const f of requiredFields) {
+    if (errs[f.id]) {
+      out.push({ field: f.id, displayName: f.displayName, order: f.order });
+    }
+  }
+  return out;
 }
 
 function renderField(

--- a/frontend/src/components/workspace/TaskLifecycleButton.test.tsx
+++ b/frontend/src/components/workspace/TaskLifecycleButton.test.tsx
@@ -1,0 +1,104 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@/test/server';
+import type { TaskDto } from '@/types/task';
+
+import { TaskLifecycleButton } from './TaskLifecycleButton';
+
+const TASK: TaskDto = {
+  id: 't1',
+  processInstanceId: 'pi-1',
+  caseId: 'c1',
+  caseTypeId: 'loan-application',
+  taskDefinitionKey: 'draft',
+  name: 'Draft application',
+  assignee: null,
+  archetype: 'draft_section',
+  actionLabel: 'Draft application',
+  createdAt: '2026-04-26T10:00:00Z',
+  dueAt: null,
+};
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{node}</QueryClientProvider>;
+}
+
+describe('TaskLifecycleButton (Story 2.8 AC2/AC3/AC5)', () => {
+  it('renders idle state with the task actionLabel', () => {
+    render(wrap(<TaskLifecycleButton task={TASK} />));
+    expect(screen.getByRole('button', { name: 'Draft application' })).toBeInTheDocument();
+  });
+
+  it('falls back to task.name when actionLabel is null', () => {
+    render(wrap(<TaskLifecycleButton task={{ ...TASK, actionLabel: null, name: 'Review' }} />));
+    expect(screen.getByRole('button', { name: 'Review' })).toBeInTheDocument();
+  });
+
+  it('transitions idle → confirming → confirmed on REST 2xx', async () => {
+    server.use(
+      http.post('/api/tasks/t1/complete', () =>
+        HttpResponse.json(
+          {
+            data: {
+              taskId: 't1',
+              processInstanceId: 'pi-1',
+              caseId: 'c1',
+              archetype: 'draft_section',
+              assignee: null,
+              at: '2026-04-26T10:00:01Z',
+            },
+            meta: {},
+          },
+          { headers: { 'X-Correlation-Id': 'cid' } },
+        ),
+      ),
+    );
+    render(wrap(<TaskLifecycleButton task={TASK} />));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft application' }));
+    await waitFor(() =>
+      expect(screen.getByRole('button')).toHaveAttribute('data-state', 'confirmed'),
+    );
+  });
+
+  it('shows [Refresh case] (not [Retry]) on a 409 conflict', async () => {
+    server.use(
+      http.post('/api/tasks/t1/complete', () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 'WKS-RTM-409',
+              message: 'Task t1 already completed',
+              field: null,
+            },
+            meta: {},
+          },
+          { status: 409 },
+        ),
+      ),
+    );
+    render(wrap(<TaskLifecycleButton task={TASK} />));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft application' }));
+    await waitFor(() => expect(screen.getByText('Refresh case')).toBeInTheDocument());
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument();
+  });
+
+  it('shows [Retry] on a 5xx failure', async () => {
+    server.use(
+      http.post('/api/tasks/t1/complete', () =>
+        HttpResponse.json(
+          { error: { code: 'WKS-API-500', message: 'boom', field: null }, meta: {} },
+          { status: 500 },
+        ),
+      ),
+    );
+    render(wrap(<TaskLifecycleButton task={TASK} />));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft application' }));
+    await waitFor(() => expect(screen.getByText('Retry')).toBeInTheDocument());
+    expect(screen.queryByText('Refresh case')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/workspace/TaskLifecycleButton.tsx
+++ b/frontend/src/components/workspace/TaskLifecycleButton.tsx
@@ -11,6 +11,7 @@ import type { ConflictReason, TaskActionResponse, TaskDto } from '@/types/task';
 
 const PROCESSING_TIMER_MS = 2_000;
 const TAKING_LONGER_TIMER_MS = 30_000;
+const CONFIRMED_FADE_MS = 2_000;
 
 /**
  * Story 2.8 AC2 / AC3 / AC4 — universal mutation lifecycle for backend mutations whose true
@@ -18,11 +19,6 @@ const TAKING_LONGER_TIMER_MS = 30_000;
  * internally via {@code useReducer}; composes {@link MutationButton} for the four shared visual
  * states (idle / confirming / confirmed / failed) and adds the {@code processing} visual + the
  * task-specific {@code [Retry]} / {@code [View Updated Case]} / {@code [Refresh case]} actions.
- *
- * <p>Phase 1 (Story 2.8) — REST-only. The 2s `processing` timer is armed at `confirming` entry
- * but cleared the instant the REST response lands; Phase 1 therefore never enters `processing`.
- * Phase 2 (Story 4.3) — SSE flips the source-of-truth: {@code VITE_WKS_SSE_ENABLED=true} arms
- * `processing` pre-emptively while the component waits for the SSE confirmation event.
  */
 export interface TaskLifecycleButtonProps {
   task: TaskDto;
@@ -65,6 +61,9 @@ function reducer(state: State, action: Action): State {
       if (state.kind !== 'confirming' && state.kind !== 'processing') return state;
       return { kind: 'confirmed' };
     case 'rest_failure':
+      // Only accept failures from in-flight states. Late dispatches from a previous mutation
+      // (e.g. retried after success) must not demote a `confirmed` UI back to `failed`.
+      if (state.kind !== 'confirming' && state.kind !== 'processing') return state;
       return {
         kind: 'failed',
         message: action.message,
@@ -80,6 +79,39 @@ function reducer(state: State, action: Action): State {
   }
 }
 
+interface ConflictPayload {
+  reason: ConflictReason;
+  actorName: string | null;
+}
+
+function parseConflictPayload(err: ApiError): ConflictPayload {
+  // The 409 envelope (GlobalExceptionHandler) carries `{ error: { code: 'WKS-RTM-409', message } }`.
+  // Phase 0 messages do not carry a structured `completedBy` actor name yet; we best-effort parse a
+  // trailing `by {name}` substring so Phase 1 backend upgrades light up the {name} interpolation
+  // automatically. Engine reasons are derived from the message text — narrow recognised patterns
+  // map to the typed ConflictReason; everything else falls to 'unknown'.
+  const msg = err.message ?? '';
+  const lower = msg.toLowerCase();
+  let reason: ConflictReason;
+  if (lower.includes('already completed') || lower.includes('already_completed')) {
+    reason = 'already_completed';
+  } else if (
+    lower.includes('reassigned') ||
+    lower.includes('claimed') ||
+    lower.includes('assignee')
+  ) {
+    reason = 'reassigned';
+  } else if (lower.includes('engine') || lower.includes('unavailable')) {
+    reason = 'engine_unavailable';
+  } else {
+    reason = 'unknown';
+  }
+  // Best-effort actor parse: "...completed by {Name}" or "...completed by {Name}.".
+  const byMatch = /\bby\s+([^.]+?)(?:\.|$)/i.exec(msg);
+  const actorName = byMatch?.[1]?.trim() ?? null;
+  return { reason, actorName };
+}
+
 function classifyError(err: unknown): {
   message: string;
   conflict: boolean;
@@ -88,12 +120,17 @@ function classifyError(err: unknown): {
 } {
   if (err instanceof ApiError) {
     if (err.status === 409) {
-      // Phase 0: the engine returns a generic message without the actor's display name. The copy
-      // degrades to the no-name variant per AC5.
+      const { reason, actorName } = parseConflictPayload(err);
+      const message =
+        reason === 'already_completed' && actorName
+          ? t('task.conflict.completedByOther', { name: actorName })
+          : reason === 'already_completed'
+            ? t('task.conflict.completedByUnknown')
+            : err.message;
       return {
-        message: t('task.conflict.completedByUnknown'),
+        message,
         conflict: true,
-        conflictReason: 'already_completed',
+        conflictReason: reason,
         retryable: false,
       };
     }
@@ -105,7 +142,6 @@ function classifyError(err: unknown): {
         retryable: false,
       };
     }
-    // 5xx: retryable.
     return {
       message: err.message,
       conflict: false,
@@ -113,7 +149,6 @@ function classifyError(err: unknown): {
       retryable: err.status >= 500,
     };
   }
-  // Network / unknown — treat as retryable.
   return {
     message: err instanceof Error ? err.message : String(err),
     conflict: false,
@@ -126,38 +161,27 @@ export function TaskLifecycleButton({ task, onCompleted, onConflict }: TaskLifec
   const queryClient = useQueryClient();
   const [state, dispatch] = useReducer(reducer, { kind: 'idle' } as State);
   const completeTask = useCompleteTask();
-  const processingTimerRef = useRef<number | null>(null);
-  const takingLongerTimerRef = useRef<number | null>(null);
   const [takingLonger, setTakingLonger] = useReducer(
     (_prev: boolean, next: boolean) => next,
     false,
   );
-  // Story 4.3 will flip this to true; keep wiring in place so 4.3 only flips the env flag.
   const sseEnabled = import.meta.env.VITE_WKS_SSE_ENABLED === 'true';
 
-  // Arm the processing timer on `confirming` entry; clear it on any other state.
   useEffect(() => {
     if (state.kind === 'confirming') {
       const handle = window.setTimeout(() => {
         dispatch({ type: 'processing_timer' });
       }, PROCESSING_TIMER_MS);
-      processingTimerRef.current = handle;
-      return () => {
-        clearTimeout(handle);
-        processingTimerRef.current = null;
-      };
+      return () => clearTimeout(handle);
     }
     return undefined;
   }, [state.kind]);
 
-  // Arm the 30s "Taking longer than expected" timer on `processing` entry.
   useEffect(() => {
     if (state.kind === 'processing') {
       const handle = window.setTimeout(() => setTakingLonger(true), TAKING_LONGER_TIMER_MS);
-      takingLongerTimerRef.current = handle;
       return () => {
         clearTimeout(handle);
-        takingLongerTimerRef.current = null;
         setTakingLonger(false);
       };
     }
@@ -165,13 +189,24 @@ export function TaskLifecycleButton({ task, onCompleted, onConflict }: TaskLifec
     return undefined;
   }, [state.kind]);
 
-  // Reset to idle a brief moment after `confirmed` so the user can act again or move on. The
-  // green chip fade is owned by MutationButton (2s); we don't auto-reset here in Phase 1 because
-  // task completion typically navigates the user to the next task or the case detail refetch
-  // surfaces a new pending task.
-  // Phase 2 (SSE) arrival → `confirmed` is dispatched by the SSE listener; same handling.
+  // Auto-reset confirmed → idle after the fade window, and refresh the task list at the same
+  // moment. Keeping byCase invalidation here (instead of in `useCompleteTask.onSettled`) lets the
+  // user see the green "Confirmed" chip for the full 2s before the parent refetch unmounts the
+  // button (Story 2.8 P4 — invalidation race fix).
+  useEffect(() => {
+    if (state.kind !== 'confirmed') return undefined;
+    const handle = window.setTimeout(() => {
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.byCase(task.caseId) });
+      dispatch({ type: 'reset' });
+    }, CONFIRMED_FADE_MS);
+    return () => clearTimeout(handle);
+  }, [state.kind, queryClient, task.caseId]);
 
   function fire(): void {
+    // P16 — guard against concurrent mutations from a fast retry / double-click. Reset any
+    // previous mutation result before kicking off a fresh attempt.
+    if (completeTask.isPending) return;
+    completeTask.reset();
     dispatch({ type: 'click' });
     completeTask.mutate(
       { taskId: task.id, caseId: task.caseId },
@@ -192,8 +227,6 @@ export function TaskLifecycleButton({ task, onCompleted, onConflict }: TaskLifec
         },
       },
     );
-    // Phase 2 (SSE on): keep `processing` armed; success arrives via SSE. Phase 1 (SSE off): the
-    // REST onSuccess above lands well before the 2s timer in the common case.
     void sseEnabled;
   }
 
@@ -211,13 +244,15 @@ export function TaskLifecycleButton({ task, onCompleted, onConflict }: TaskLifec
   const failedReason = state.kind === 'failed' ? state.message : null;
   const failedLabel = failedReason
     ? t('task.failed', { reason: failedReason })
-    : t('task.failed', { reason: '' });
+    : t('common.lifecycle.failedNoReason');
+
+  // P2 — AC11: conflict path announces "...Press Enter to refresh." via the same live region.
+  const announcement =
+    state.kind === 'failed' && state.conflict ? t('task.conflict.refreshAnnouncement') : undefined;
 
   const retryRef = useRef<HTMLButtonElement | null>(null);
   const refreshRef = useRef<HTMLButtonElement | null>(null);
 
-  // AC11 — focus the recovery action when state lands in `failed`. Conflict path focuses
-  // [Refresh case]; retryable failures focus [Retry].
   useEffect(() => {
     if (state.kind !== 'failed') return;
     const handle = requestAnimationFrame(() => {
@@ -284,6 +319,7 @@ export function TaskLifecycleButton({ task, onCompleted, onConflict }: TaskLifec
         processingLabel={t('task.processing')}
         confirmedLabel={t('task.confirmed')}
         failedLabel={failedLabel}
+        announcement={announcement}
         onClick={() => {
           if (state.kind === 'idle') fire();
         }}
@@ -298,7 +334,7 @@ export function TaskLifecycleButton({ task, onCompleted, onConflict }: TaskLifec
         {idleLabel}
       </MutationButton>
       {state.kind === 'processing' && takingLonger ? (
-        <span className="text-xs text-[var(--muted-foreground)]" aria-live="polite">
+        <span className="text-xs text-[var(--muted-foreground)]">
           {t('task.processing.takingLonger')}
         </span>
       ) : null}

--- a/frontend/src/components/workspace/TaskLifecycleButton.tsx
+++ b/frontend/src/components/workspace/TaskLifecycleButton.tsx
@@ -1,0 +1,307 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useReducer, useRef } from 'react';
+
+import { ApiError } from '@/api/client';
+import { Button } from '@/components/ui/Button';
+import { MutationButton, type MutationButtonState } from '@/components/ui/MutationButton';
+import { useCompleteTask } from '@/hooks/useTasks';
+import { t } from '@/i18n';
+import { caseQueryKeys, taskQueryKeys } from '@/lib/queryKeys';
+import type { ConflictReason, TaskActionResponse, TaskDto } from '@/types/task';
+
+const PROCESSING_TIMER_MS = 2_000;
+const TAKING_LONGER_TIMER_MS = 30_000;
+
+/**
+ * Story 2.8 AC2 / AC3 / AC4 — universal mutation lifecycle for backend mutations whose true
+ * completion is signalled async (Phase 2 SSE) or may genuinely take >2s. Owns its 5-state machine
+ * internally via {@code useReducer}; composes {@link MutationButton} for the four shared visual
+ * states (idle / confirming / confirmed / failed) and adds the {@code processing} visual + the
+ * task-specific {@code [Retry]} / {@code [View Updated Case]} / {@code [Refresh case]} actions.
+ *
+ * <p>Phase 1 (Story 2.8) — REST-only. The 2s `processing` timer is armed at `confirming` entry
+ * but cleared the instant the REST response lands; Phase 1 therefore never enters `processing`.
+ * Phase 2 (Story 4.3) — SSE flips the source-of-truth: {@code VITE_WKS_SSE_ENABLED=true} arms
+ * `processing` pre-emptively while the component waits for the SSE confirmation event.
+ */
+export interface TaskLifecycleButtonProps {
+  task: TaskDto;
+  onCompleted?: (response: TaskActionResponse) => void;
+  onConflict?: (reason: ConflictReason) => void;
+}
+
+type State =
+  | { kind: 'idle' }
+  | { kind: 'confirming' }
+  | { kind: 'processing' }
+  | { kind: 'confirmed' }
+  | {
+      kind: 'failed';
+      message: string;
+      conflict: boolean;
+      conflictReason: ConflictReason | null;
+      retryable: boolean;
+    };
+
+type Action =
+  | { type: 'click' }
+  | { type: 'rest_success' }
+  | {
+      type: 'rest_failure';
+      message: string;
+      conflict: boolean;
+      conflictReason: ConflictReason | null;
+      retryable: boolean;
+    }
+  | { type: 'processing_timer' }
+  | { type: 'reset' };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'click':
+      if (state.kind !== 'idle' && state.kind !== 'failed') return state;
+      return { kind: 'confirming' };
+    case 'rest_success':
+      if (state.kind !== 'confirming' && state.kind !== 'processing') return state;
+      return { kind: 'confirmed' };
+    case 'rest_failure':
+      return {
+        kind: 'failed',
+        message: action.message,
+        conflict: action.conflict,
+        conflictReason: action.conflictReason,
+        retryable: action.retryable,
+      };
+    case 'processing_timer':
+      if (state.kind !== 'confirming') return state;
+      return { kind: 'processing' };
+    case 'reset':
+      return { kind: 'idle' };
+  }
+}
+
+function classifyError(err: unknown): {
+  message: string;
+  conflict: boolean;
+  conflictReason: ConflictReason | null;
+  retryable: boolean;
+} {
+  if (err instanceof ApiError) {
+    if (err.status === 409) {
+      // Phase 0: the engine returns a generic message without the actor's display name. The copy
+      // degrades to the no-name variant per AC5.
+      return {
+        message: t('task.conflict.completedByUnknown'),
+        conflict: true,
+        conflictReason: 'already_completed',
+        retryable: false,
+      };
+    }
+    if (err.status === 403 || err.status === 404) {
+      return {
+        message: err.message,
+        conflict: false,
+        conflictReason: null,
+        retryable: false,
+      };
+    }
+    // 5xx: retryable.
+    return {
+      message: err.message,
+      conflict: false,
+      conflictReason: null,
+      retryable: err.status >= 500,
+    };
+  }
+  // Network / unknown — treat as retryable.
+  return {
+    message: err instanceof Error ? err.message : String(err),
+    conflict: false,
+    conflictReason: null,
+    retryable: true,
+  };
+}
+
+export function TaskLifecycleButton({ task, onCompleted, onConflict }: TaskLifecycleButtonProps) {
+  const queryClient = useQueryClient();
+  const [state, dispatch] = useReducer(reducer, { kind: 'idle' } as State);
+  const completeTask = useCompleteTask();
+  const processingTimerRef = useRef<number | null>(null);
+  const takingLongerTimerRef = useRef<number | null>(null);
+  const [takingLonger, setTakingLonger] = useReducer(
+    (_prev: boolean, next: boolean) => next,
+    false,
+  );
+  // Story 4.3 will flip this to true; keep wiring in place so 4.3 only flips the env flag.
+  const sseEnabled = import.meta.env.VITE_WKS_SSE_ENABLED === 'true';
+
+  // Arm the processing timer on `confirming` entry; clear it on any other state.
+  useEffect(() => {
+    if (state.kind === 'confirming') {
+      const handle = window.setTimeout(() => {
+        dispatch({ type: 'processing_timer' });
+      }, PROCESSING_TIMER_MS);
+      processingTimerRef.current = handle;
+      return () => {
+        clearTimeout(handle);
+        processingTimerRef.current = null;
+      };
+    }
+    return undefined;
+  }, [state.kind]);
+
+  // Arm the 30s "Taking longer than expected" timer on `processing` entry.
+  useEffect(() => {
+    if (state.kind === 'processing') {
+      const handle = window.setTimeout(() => setTakingLonger(true), TAKING_LONGER_TIMER_MS);
+      takingLongerTimerRef.current = handle;
+      return () => {
+        clearTimeout(handle);
+        takingLongerTimerRef.current = null;
+        setTakingLonger(false);
+      };
+    }
+    setTakingLonger(false);
+    return undefined;
+  }, [state.kind]);
+
+  // Reset to idle a brief moment after `confirmed` so the user can act again or move on. The
+  // green chip fade is owned by MutationButton (2s); we don't auto-reset here in Phase 1 because
+  // task completion typically navigates the user to the next task or the case detail refetch
+  // surfaces a new pending task.
+  // Phase 2 (SSE) arrival → `confirmed` is dispatched by the SSE listener; same handling.
+
+  function fire(): void {
+    dispatch({ type: 'click' });
+    completeTask.mutate(
+      { taskId: task.id, caseId: task.caseId },
+      {
+        onSuccess: (response) => {
+          dispatch({ type: 'rest_success' });
+          onCompleted?.(response);
+        },
+        onError: (err) => {
+          const classified = classifyError(err);
+          dispatch({
+            type: 'rest_failure',
+            ...classified,
+          });
+          if (classified.conflict && classified.conflictReason) {
+            onConflict?.(classified.conflictReason);
+          }
+        },
+      },
+    );
+    // Phase 2 (SSE on): keep `processing` armed; success arrives via SSE. Phase 1 (SSE off): the
+    // REST onSuccess above lands well before the 2s timer in the common case.
+    void sseEnabled;
+  }
+
+  const buttonState: MutationButtonState =
+    state.kind === 'idle'
+      ? 'idle'
+      : state.kind === 'confirming'
+        ? 'confirming'
+        : state.kind === 'processing'
+          ? 'processing'
+          : state.kind === 'confirmed'
+            ? 'confirmed'
+            : 'failed';
+
+  const failedReason = state.kind === 'failed' ? state.message : null;
+  const failedLabel = failedReason
+    ? t('task.failed', { reason: failedReason })
+    : t('task.failed', { reason: '' });
+
+  const retryRef = useRef<HTMLButtonElement | null>(null);
+  const refreshRef = useRef<HTMLButtonElement | null>(null);
+
+  // AC11 — focus the recovery action when state lands in `failed`. Conflict path focuses
+  // [Refresh case]; retryable failures focus [Retry].
+  useEffect(() => {
+    if (state.kind !== 'failed') return;
+    const handle = requestAnimationFrame(() => {
+      if (state.conflict) {
+        refreshRef.current?.focus();
+      } else if (state.retryable) {
+        retryRef.current?.focus();
+      }
+    });
+    return () => cancelAnimationFrame(handle);
+  }, [state]);
+
+  const retryAction =
+    state.kind === 'failed' && state.retryable && !state.conflict ? (
+      <Button
+        ref={retryRef}
+        type="button"
+        variant="ghost"
+        onClick={() => {
+          dispatch({ type: 'reset' });
+          fire();
+        }}
+      >
+        {t('task.retry')}
+      </Button>
+    ) : null;
+
+  const refreshAction =
+    state.kind === 'failed' && state.conflict ? (
+      <Button
+        ref={refreshRef}
+        type="button"
+        variant="ghost"
+        onClick={() => {
+          queryClient.invalidateQueries({ queryKey: taskQueryKeys.byCase(task.caseId) });
+          queryClient.invalidateQueries({ queryKey: caseQueryKeys.detail(task.caseId) });
+          dispatch({ type: 'reset' });
+        }}
+      >
+        {t('task.refreshCase')}
+      </Button>
+    ) : null;
+
+  const viewUpdatedCaseAction =
+    state.kind === 'failed' && state.retryable ? (
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => {
+          queryClient.invalidateQueries({ queryKey: caseQueryKeys.detail(task.caseId) });
+        }}
+      >
+        {t('task.viewUpdatedCase')}
+      </Button>
+    ) : null;
+
+  const idleLabel = task.actionLabel ?? task.name;
+
+  return (
+    <div className="inline-flex items-center gap-2">
+      <MutationButton
+        state={buttonState}
+        confirmingLabel={t('task.confirming')}
+        processingLabel={t('task.processing')}
+        confirmedLabel={t('task.confirmed')}
+        failedLabel={failedLabel}
+        onClick={() => {
+          if (state.kind === 'idle') fire();
+        }}
+        retryAction={
+          <>
+            {retryAction}
+            {refreshAction}
+            {viewUpdatedCaseAction}
+          </>
+        }
+      >
+        {idleLabel}
+      </MutationButton>
+      {state.kind === 'processing' && takingLonger ? (
+        <span className="text-xs text-[var(--muted-foreground)]" aria-live="polite">
+          {t('task.processing.takingLonger')}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useTasks.test.tsx
+++ b/frontend/src/hooks/useTasks.test.tsx
@@ -1,0 +1,58 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { taskQueryKeys } from '@/lib/queryKeys';
+import { server } from '@/test/server';
+import type { TaskDto } from '@/types/task';
+
+import { useCaseTasks } from './useTasks';
+
+const CASE_ID = '11111111-2222-3333-4444-555555555555';
+
+const TASK_FIXTURE: TaskDto = {
+  id: 't1',
+  processInstanceId: 'pi-1',
+  caseId: CASE_ID,
+  caseTypeId: 'loan-application',
+  taskDefinitionKey: 'draft',
+  name: 'Draft application',
+  assignee: null,
+  archetype: 'draft_section',
+  actionLabel: 'Draft application',
+  createdAt: '2026-04-26T10:00:00Z',
+  dueAt: null,
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCaseTasks', () => {
+  it('is disabled when caseId is null', () => {
+    const { result } = renderHook(() => useCaseTasks(null), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('uses taskQueryKeys.byCase as the query key', () => {
+    expect(taskQueryKeys.byCase(CASE_ID)).toEqual(['tasks', 'byCase', CASE_ID]);
+  });
+
+  it('fetches and unwraps the envelope', async () => {
+    server.use(
+      http.get(`/api/cases/${CASE_ID}/tasks`, () =>
+        HttpResponse.json(
+          { data: [TASK_FIXTURE], meta: {} },
+          { headers: { 'X-Correlation-Id': 'cid' } },
+        ),
+      ),
+    );
+    const { result } = renderHook(() => useCaseTasks(CASE_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([TASK_FIXTURE]);
+  });
+});

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -23,7 +23,11 @@ export function useCaseTasks(caseId: string | null): UseQueryResult<TaskDto[], E
     queryKey: caseId ? taskQueryKeys.byCase(caseId) : taskQueryKeys.byCase('__disabled__'),
     queryFn: caseId ? () => listTasksByCase(caseId) : skipToken,
     staleTime: STALE_TIME_MS,
-    refetchOnWindowFocus: true,
+    // Story 2.8 — task list invalidation is driven by `useCompleteTask` (on error) and by the
+    // lifecycle button after the confirmed fade. A focus-refetch here would silently hide the
+    // CTA in the conflict-replay scenario (J6) before the second tab can fire the duplicate
+    // request that surfaces the 409 + [Refresh case] recovery — defeating AC5.
+    refetchOnWindowFocus: false,
   });
 }
 
@@ -48,9 +52,12 @@ export function useCompleteTask(): UseMutationResult<TaskActionResponse, Error, 
     mutationKey: ['tasks', 'complete'],
     mutationFn: ({ taskId, variables }) => completeTask(taskId, variables ?? {}),
     onSettled: (_data, _error, { caseId }) => {
-      // Both success and failure refresh the case + task views — on 409 the truth has moved on,
-      // and on 5xx a refetch may still pick up partial engine state for diagnostics.
-      queryClient.invalidateQueries({ queryKey: taskQueryKeys.byCase(caseId) });
+      // Refresh case detail so the user sees the engine's truth (status / data). Task list
+      // invalidation is intentionally NOT done here — on success it is handled by
+      // `TaskLifecycleButton` after the 2s confirmed fade so the green chip survives, and on
+      // error (especially 409 conflict) invalidating would unmount the button before the user
+      // sees the failed state and the [Refresh case] / [Retry] recovery actions. The user-driven
+      // actions invalidate the task list themselves when invoked.
       queryClient.invalidateQueries({ queryKey: caseQueryKeys.detail(caseId) });
     },
     retry: false,

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -1,0 +1,58 @@
+import {
+  skipToken,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import { completeTask, listTasksByCase } from '@/api/tasks';
+import { caseQueryKeys, taskQueryKeys } from '@/lib/queryKeys';
+import type { TaskActionResponse, TaskDto } from '@/types/task';
+
+const STALE_TIME_MS = 30_000;
+
+/**
+ * Story 2.8 AC1 — list pending user tasks for a case. Disabled when {@code caseId} is falsy
+ * (e.g. detail panel before a case is selected). The {@code enabled} gate uses {@code skipToken}
+ * (per Story 2.5 review) so the queryFn never runs with a null id.
+ */
+export function useCaseTasks(caseId: string | null): UseQueryResult<TaskDto[], Error> {
+  return useQuery<TaskDto[], Error>({
+    queryKey: caseId ? taskQueryKeys.byCase(caseId) : taskQueryKeys.byCase('__disabled__'),
+    queryFn: caseId ? () => listTasksByCase(caseId) : skipToken,
+    staleTime: STALE_TIME_MS,
+    refetchOnWindowFocus: true,
+  });
+}
+
+export interface CompleteTaskArgs {
+  taskId: string;
+  caseId: string;
+  variables?: Record<string, unknown>;
+}
+
+/**
+ * Story 2.8 AC3 — complete a user task. On 2xx (and on 409 — the conflict resolution UX surfaces
+ * stale data immediately) invalidates {@code taskQueryKeys.byCase(caseId)} and {@code
+ * caseQueryKeys.detail(caseId)} so the action bar repaints with the engine's truth. List queries
+ * are NOT invalidated here — Story 4.3's SSE channel covers the cross-case feed.
+ *
+ * No automatic retry — `[Retry]` lives in the UI lifecycle so users see exactly when a retry
+ * fires, and 409 conflicts MUST not silently re-issue.
+ */
+export function useCompleteTask(): UseMutationResult<TaskActionResponse, Error, CompleteTaskArgs> {
+  const queryClient = useQueryClient();
+  return useMutation<TaskActionResponse, Error, CompleteTaskArgs>({
+    mutationKey: ['tasks', 'complete'],
+    mutationFn: ({ taskId, variables }) => completeTask(taskId, variables ?? {}),
+    onSettled: (_data, _error, { caseId }) => {
+      // Both success and failure refresh the case + task views — on 409 the truth has moved on,
+      // and on 5xx a refetch may still pick up partial engine state for diagnostics.
+      queryClient.invalidateQueries({ queryKey: taskQueryKeys.byCase(caseId) });
+      queryClient.invalidateQueries({ queryKey: caseQueryKeys.detail(caseId) });
+    },
+    retry: false,
+  });
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -91,6 +91,7 @@
   "case.heading": "Case {idShort}",
   "case.detail.announcement": "Case detail: {idShort}",
   "case.nextCaseHint": "Next case ({shortcut})",
+  "case.tasks.error": "Couldn't load actions for this case.",
 
   "breadcrumbs.label": "Breadcrumbs",
 
@@ -132,6 +133,7 @@
   "task.refreshCase": "Refresh case",
   "task.conflict.completedByOther": "This task was already completed by {name}. No changes were made.",
   "task.conflict.completedByUnknown": "This task was already completed. No changes were made.",
+  "task.conflict.refreshAnnouncement": "This task was already completed. Press Enter to refresh.",
 
   "cases.create.button": "New case",
   "cases.create.dialogTitle": "New {caseTypeName}",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -90,6 +90,7 @@
   "case.error.body": "Your filter and selection are intact. Try again, or pick a different case.",
   "case.heading": "Case {idShort}",
   "case.detail.announcement": "Case detail: {idShort}",
+  "case.nextCaseHint": "Next case ({shortcut})",
 
   "breadcrumbs.label": "Breadcrumbs",
 
@@ -121,6 +122,17 @@
   "common.lifecycle.failedNoReason": "Failed",
   "common.lifecycle.retry": "Retry",
 
+  "task.confirming": "Confirming…",
+  "task.processing": "Processing…",
+  "task.processing.takingLonger": "Taking longer than expected",
+  "task.confirmed": "Confirmed",
+  "task.failed": "Failed — {reason}",
+  "task.retry": "Retry",
+  "task.viewUpdatedCase": "View updated case",
+  "task.refreshCase": "Refresh case",
+  "task.conflict.completedByOther": "This task was already completed by {name}. No changes were made.",
+  "task.conflict.completedByUnknown": "This task was already completed. No changes were made.",
+
   "cases.create.button": "New case",
   "cases.create.dialogTitle": "New {caseTypeName}",
   "cases.create.dialogClose": "Close create case dialog",
@@ -130,6 +142,7 @@
   "cases.create.noRequired": "No fields are required to create a {caseTypeName}. Click create to start.",
   "cases.create.fileNotYet": "File upload arrives in Epic 3 — Story 3.1.",
   "cases.create.errorsCount": "{count} fields need attention",
+  "cases.create.errorsCount.one": "1 field needs attention",
   "cases.create.errorBanner.title": "Couldn't create case",
   "cases.create.errorBanner.body": "Your input is preserved. Try again or correct the highlighted fields.",
   "cases.create.errorBanner.networkBody": "Couldn't reach the server. Your input is preserved — check your connection and try again.",

--- a/frontend/src/lib/fieldFormatters.selectCoercion.test.ts
+++ b/frontend/src/lib/fieldFormatters.selectCoercion.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FieldDefinition } from '@/types/caseType';
+
+import { formatFieldValue } from './fieldFormatters';
+
+const baseSelect: FieldDefinition = {
+  id: 'priority',
+  displayName: 'Priority',
+  type: 'select',
+  requiredOnCreate: false,
+  order: 0,
+  options: [
+    { value: 1, label: 'High' },
+    { value: 2, label: 'Medium' },
+    { value: 3, label: 'Low' },
+  ],
+} as unknown as FieldDefinition;
+
+describe('formatFieldValue select coercion (Story 2.8 AC12)', () => {
+  it('matches when stored value is string but option.value is numeric', () => {
+    expect(formatFieldValue(baseSelect, '1')).toBe('High');
+  });
+
+  it('matches when stored value is numeric and option.value is numeric', () => {
+    expect(formatFieldValue(baseSelect, 1)).toBe('High');
+  });
+
+  it('matches when stored value is numeric but option.value is string', () => {
+    const stringOpts: FieldDefinition = {
+      ...baseSelect,
+      options: [
+        { value: '1', label: 'High' },
+        { value: '2', label: 'Medium' },
+      ],
+    } as unknown as FieldDefinition;
+    expect(formatFieldValue(stringOpts, 2)).toBe('Medium');
+  });
+
+  it('returns em-dash for null/undefined', () => {
+    expect(formatFieldValue(baseSelect, null)).toBe('—');
+    expect(formatFieldValue(baseSelect, undefined)).toBe('—');
+  });
+
+  it('returns em-dash for empty string', () => {
+    expect(formatFieldValue(baseSelect, '')).toBe('—');
+  });
+});

--- a/frontend/src/lib/fieldFormatters.ts
+++ b/frontend/src/lib/fieldFormatters.ts
@@ -28,7 +28,11 @@ export function formatFieldValue(field: FieldDefinition, value: unknown): string
     case 'file':
       return t('cases.field.file.placeholder');
     case 'select': {
-      const match = field.options?.find((opt) => opt.value === value);
+      // Story 2.8 AC12 — coerce both sides to string before compare. YAML may declare numeric
+      // option values (`value: 1`) while the JSONB round-trip stringifies stored data; strict
+      // equality across that type boundary silently fails to label-match.
+      const stored = String(value);
+      const match = field.options?.find((opt) => String(opt.value) === stored);
       if (match) return match.label;
       // eslint-disable-next-line no-console
       console.warn(`formatFieldValue: select '${field.id}' has no option for '${String(value)}'`);

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -24,3 +24,14 @@ export const caseTypeQueryKeys = {
   list: () => ['caseTypes', 'list'] as const,
   detail: (id: string) => ['caseTypes', 'detail', id] as const,
 } as const;
+
+/**
+ * Story 2.8 — keys for `useCaseTasks` (per-case pending list) and `useTask` (single task detail,
+ * reserved for Phase 1). Story 4.3 SSE invalidation will hit `taskQueryKeys.byCase(caseId)` on
+ * `task-completed` and `task-failed` events — same prefix-invalidation shape as `caseQueryKeys`.
+ */
+export const taskQueryKeys = {
+  all: () => ['tasks'] as const,
+  byCase: (caseId: string) => ['tasks', 'byCase', caseId] as const,
+  detail: (taskId: string) => ['task', taskId] as const,
+} as const;

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -1,0 +1,35 @@
+/**
+ * Story 2.8 — wire types for `/api/cases/{id}/tasks` and `/api/tasks/{id}/{complete,claim}`.
+ * Mirrors backend `TaskDto` (Story 2.8 AC1) and `TaskActionResponse` (Story 2.4).
+ */
+
+export interface TaskDto {
+  id: string;
+  processInstanceId: string;
+  caseId: string;
+  caseTypeId: string;
+  taskDefinitionKey: string;
+  name: string;
+  assignee: string | null;
+  archetype: string | null;
+  /** BPMN-author-supplied CTA copy with userTask.name fallback (Story 2.8 AC1). */
+  actionLabel: string | null;
+  createdAt: string;
+  dueAt: string | null;
+}
+
+export interface TaskActionResponse {
+  taskId: string;
+  processInstanceId: string;
+  caseId: string;
+  archetype: string | null;
+  assignee: string | null;
+  at: string;
+}
+
+/**
+ * Discriminator for the `failed` lifecycle state when the engine returned a 409 conflict. The
+ * `unknown` arm is the safe fallback when the envelope code is `WKS-RTM-409` but the message
+ * does not match a known shape — UI still shows "already completed" copy.
+ */
+export type ConflictReason = 'already_completed' | 'reassigned' | 'engine_unavailable' | 'unknown';


### PR DESCRIPTION
## Summary

Implements **Story 2.8 — Task Completion with Honest Lifecycle**: new `GET /api/cases/{id}/tasks` endpoint, 5-state `TaskLifecycleButton` (composes `MutationButton` 4-state, adds `processing` + task-specific actions), `CaseActionBar` slotted into `CaseDetailPanel`, generic `FormErrorsBanner` (closes 2-7 deferred debt), `select`-field strict-equality coercion fix (closes 2-6 deferred debt), conflict-vs-retryable failure classification, full Phase 2 SSE plumbing behind `VITE_WKS_SSE_ENABLED` (default `false`; Story 4.3 flips it).

This branch carries **9 implementation commits** plus **1 fix commit** consolidating:
- 19 code-review patches (5 decisions resolved, 7 deferrals, 8 dismissed) — see story file `### Review Findings`.
- Post-review fixes from manual J6 walkthrough: AC5 conflict path was unreachable (404 instead of 409); fixed in `TaskController` + engine adapter + `useCaseTasks` `refetchOnWindowFocus: false` + `useCompleteTask.onSettled` no longer invalidates `byCase` (it was unmounting the failed-state button mid-render).
- Small follow-up: `CaseDetailPanel` now renders a `StatusBadge` next to the heading so status transitions are visible without leaving the panel.

## Highlights

- **Backend** — `WorkflowEngine` port: `findTasksByCase` + `readActionLabel`. `TaskDtoMapper` with per-request BPMN-instance cache + `task.name()` fallback. `findTasksByCase` caches `caseTypeId` by `processInstanceId` (eliminates N+1). `TaskController.complete` + engine `completeTask` map "task gone" → `WksConflictException` (409) per AC5.
- **Frontend** — `TaskLifecycleButton` (5-state internal `useReducer`, conflict reason classification, `[Retry]` / `[Refresh case]` / `[View Updated Case]` actions, 2s `processing` timer + 30s `takingLonger` helper text). `MutationButton` literal-union widens to 5 states (non-breaking). `aria-disabled` mirror, single ARIA-live region, conflict-path "Press Enter to refresh" announcement via new `announcement` prop. Reducer guards `rest_failure` to in-flight only; auto-resets `confirmed → idle` after fade.
- **Folded debt closes** — 2-7 errors-count banner with anchor links (AC9), 2-7 `MutationButton.processing` 5th state (AC2), 2-6 `select` strict-equality (AC12). Re-pinned: idempotency-key on `POST /api/tasks/{id}/complete` (Phase 1 hardening).
- **Tests** — 21 new tests across backend + frontend (236/236 frontend, all backend slice + IT green). Covers all 13 ACs.
- **Local CI gauntlet** — backend `mvn verify` ✓, frontend `lint + format:check + test (236/236) + build` ✓, Docker build ✓ (`local-2-8` image 332MB, parity with `local-2-7`).

## Test plan

- [x] Backend `./mvnw -B -ntp verify` (incl. Spotless, ArchUnit, slice tests, engine ITs)
- [x] Frontend `npm run lint && npm run format:check && npm test -- --run && npm run build`
- [x] Docker build via `docker build -f docker/Dockerfile -t wkspower/wks-platform:local-2-8 .`
- [x] Manual walkthrough of journey kit `seed/JOURNEYS.md` (J1–J6) — surfaces J6 conflict bug now fixed; verified 409 + `[Refresh case]` UI in two-tab replay.
- [x] Live curl probe — second complete on the same task id returns 409 with the AC5 envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)