### PR TITLE
Story 3.0: Zero tenant_id CI lint rule (D25 Sprint 1 prereq)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,14 @@ jobs:
             exit 1
           fi
 
+  tenant-invariant:
+    name: Tenant invariant (D25)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan protected packages
+        run: ./backend/.ci/check-tenant-invariant.sh
+
   docker-build:
     name: Docker image (build only, no push)
     runs-on: ubuntu-latest

--- a/backend/.ci/check-tenant-invariant.sh
+++ b/backend/.ci/check-tenant-invariant.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Tenant invariant (D25) — Zero tenant_id lint
+#
+# Phase 0 scope: backend domain/persistence/audit. Frontend has no equivalent
+# packages today; expand the SCAN_PATHS variable when frontend grows a domain
+# layer (post-Epic 6 if Developer Console introduces one).
+#
+# Source of truth: docs/zero-tenant-id.md
+# Background: Decision 25 in _bmad-output/planning-artifacts/architecture.md
+#             (planning repo) — wks-platform2.
+#
+# Invoked from .github/workflows/ci.yml and runnable locally from any cwd.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+SCAN_PATHS=(
+  "backend/src/main/java/com/wkspower/platform/domain"
+  "backend/src/main/java/com/wkspower/platform/infrastructure/persistence"
+  "backend/src/main/java/com/wkspower/platform/audit"
+  "backend/src/test/java/com/wkspower/platform/domain"
+  "backend/src/test/java/com/wkspower/platform/infrastructure/persistence"
+  "backend/src/test/java/com/wkspower/platform/audit"
+)
+
+FORBIDDEN='(tenant_id|tenantId|WHERE[[:space:]]+tenant_id|@TenantId)'
+ALLOWLIST_FILE="backend/.ci/tenant-invariant-allowlist.txt"
+DOC_LINK="docs/zero-tenant-id.md"
+FAIL_SUFFIX="Forbidden by Decision 25 (Zero tenant_id invariant). See ${DOC_LINK} for the rationale and approved alternatives."
+
+# Load allowlist globs (skip blank/# lines). Tolerate missing file.
+allowlist=()
+if [[ -f "$ALLOWLIST_FILE" ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      ''|\#*) continue ;;
+      *) allowlist+=("$line") ;;
+    esac
+  done < "$ALLOWLIST_FILE"
+fi
+
+is_allowlisted() {
+  local path="$1"
+  local glob
+  for glob in "${allowlist[@]+"${allowlist[@]}"}"; do
+    # shellcheck disable=SC2254
+    case "$path" in
+      $glob) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Build existing-paths list (silently skip missing — first-run safety).
+existing=()
+for p in "${SCAN_PATHS[@]}"; do
+  [[ -d "$p" ]] && existing+=("$p")
+done
+
+violations=0
+files_seen=""  # newline-delimited; uniqued at end (bash 3.2 has no assoc arrays)
+
+if [[ ${#existing[@]} -gt 0 ]]; then
+  # grep returns non-zero when no matches — tolerate via || true.
+  while IFS= read -r match; do
+    [[ -z "$match" ]] && continue
+    # match format: path:line:content
+    path="${match%%:*}"
+    rest="${match#*:}"
+    line="${rest%%:*}"
+    content="${rest#*:}"
+
+    if is_allowlisted "$path"; then
+      continue
+    fi
+
+    # Identify which forbidden token matched (first hit on the line).
+    if [[ "$content" =~ WHERE[[:space:]]+tenant_id ]]; then
+      ident="WHERE tenant_id"
+    elif [[ "$content" =~ @TenantId ]]; then
+      ident="@TenantId"
+    elif [[ "$content" =~ tenantId ]]; then
+      ident="tenantId"
+    elif [[ "$content" =~ tenant_id ]]; then
+      ident="tenant_id"
+    else
+      ident="(unknown)"
+    fi
+
+    printf '%s:%s: %s — %s\n' "$path" "$line" "$ident" "$FAIL_SUFFIX"
+    violations=$((violations + 1))
+    files_seen="${files_seen}${path}"$'\n'
+  done < <(grep -RnE "$FORBIDDEN" "${existing[@]}" || true)
+fi
+
+if [[ "$violations" -eq 0 ]]; then
+  echo "Tenant invariant (D25) OK"
+  exit 0
+fi
+
+file_count=$(printf '%s' "$files_seen" | sort -u | grep -c .)
+echo "Tenant invariant (D25) FAILED: ${violations} violations across ${file_count} files"
+exit 1

--- a/backend/.ci/check-tenant-invariant.sh
+++ b/backend/.ci/check-tenant-invariant.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Tenant invariant (D25) — Zero tenant_id lint
 #
-# Phase 0 scope: backend domain/persistence/audit. Frontend has no equivalent
+# Phase 0 scope: backend domain/persistence/audit (Java) + Flyway migrations
+# (SQL/XML under src/main/resources/db/migration). Frontend has no equivalent
 # packages today; expand the SCAN_PATHS variable when frontend grows a domain
 # layer (post-Epic 6 if Developer Console introduces one).
 #
@@ -23,7 +24,9 @@ SCAN_PATHS=(
   "backend/src/test/java/com/wkspower/platform/domain"
   "backend/src/test/java/com/wkspower/platform/infrastructure/persistence"
   "backend/src/test/java/com/wkspower/platform/audit"
+  "backend/src/main/resources/db/migration"
 )
+INCLUDE_GLOBS=(--include='*.java' --include='*.sql' --include='*.xml')
 
 FORBIDDEN='(tenant_id|tenantId|WHERE[[:space:]]+tenant_id|@TenantId)'
 ALLOWLIST_FILE="backend/.ci/tenant-invariant-allowlist.txt"
@@ -31,9 +34,11 @@ DOC_LINK="docs/zero-tenant-id.md"
 FAIL_SUFFIX="Forbidden by Decision 25 (Zero tenant_id invariant). See ${DOC_LINK} for the rationale and approved alternatives."
 
 # Load allowlist globs (skip blank/# lines). Tolerate missing file.
+# Strip trailing CR so Windows-edited allowlists do not silently fail to match.
 allowlist=()
 if [[ -f "$ALLOWLIST_FILE" ]]; then
   while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
     case "$line" in
       ''|\#*) continue ;;
       *) allowlist+=("$line") ;;
@@ -53,18 +58,27 @@ is_allowlisted() {
   return 1
 }
 
-# Build existing-paths list (silently skip missing — first-run safety).
+# Build existing-paths list. Tolerate individual missing paths (first-run /
+# refactor safety), but FAIL if every configured path is missing — that almost
+# certainly means a rename or refactor moved the protected packages and the
+# scan would otherwise vacuously pass.
 existing=()
 for p in "${SCAN_PATHS[@]}"; do
   [[ -d "$p" ]] && existing+=("$p")
 done
 
+if [[ ${#existing[@]} -eq 0 ]]; then
+  echo "Tenant invariant (D25) FAILED: none of the configured SCAN_PATHS exist." >&2
+  echo "If the protected packages were renamed, update SCAN_PATHS in $0 in the same PR." >&2
+  exit 1
+fi
+
 violations=0
 files_seen=""  # newline-delimited; uniqued at end (bash 3.2 has no assoc arrays)
 
-if [[ ${#existing[@]} -gt 0 ]]; then
-  # grep returns non-zero when no matches — tolerate via || true.
-  while IFS= read -r match; do
+# grep -I skips binary files; --include filters keep migration tree narrow.
+# grep returns non-zero when no matches — tolerate via || true.
+while IFS= read -r match; do
     [[ -z "$match" ]] && continue
     # match format: path:line:content
     path="${match%%:*}"
@@ -92,8 +106,7 @@ if [[ ${#existing[@]} -gt 0 ]]; then
     printf '%s:%s: %s — %s\n' "$path" "$line" "$ident" "$FAIL_SUFFIX"
     violations=$((violations + 1))
     files_seen="${files_seen}${path}"$'\n'
-  done < <(grep -RnE "$FORBIDDEN" "${existing[@]}" || true)
-fi
+done < <(grep -IRnE "${INCLUDE_GLOBS[@]}" "$FORBIDDEN" "${existing[@]}" || true)
 
 if [[ "$violations" -eq 0 ]]; then
   echo "Tenant invariant (D25) OK"

--- a/backend/.ci/tenant-invariant-allowlist.txt
+++ b/backend/.ci/tenant-invariant-allowlist.txt
@@ -1,0 +1,3 @@
+# Allowlist for the Zero tenant_id invariant (Decision 25, Story 3.0).
+# Each entry MUST be preceded by a line: # story-X.Y: <reason>
+# Empty on adoption — verified clean by Story 3.0 AC4.

--- a/docs/zero-tenant-id.md
+++ b/docs/zero-tenant-id.md
@@ -1,0 +1,25 @@
+# Zero `tenant_id` Invariant (Decision 25)
+
+## The invariant
+
+The application code in this repository must contain **zero** `tenant_id` (or `tenantId`, `WHERE tenant_id`, `@TenantId`) references inside the protected packages: `backend/src/main/java/com/wkspower/platform/domain/`, `backend/src/main/java/com/wkspower/platform/infrastructure/persistence/`, and `backend/src/main/java/com/wkspower/platform/audit/`. WKS Platform v2 ships as a per-instance product — every customer runs their own image, database, and license file — so application-layer tenant scoping is structurally redundant and structurally forbidden.
+
+## Why
+
+Per-instance isolation (Decision 25) is the architectural foundation that lets WKS sell as both OSS and per-client managed hosting under the license-per-instance model (Decision 24, cross-referenced). Once `tenant_id` enters a domain row or a persistence query, multi-tenancy semantics leak into the model and the per-instance posture is compromised — the surface stops being equivalent across deployments and SI partners cannot reason about isolation by reading the code. Source of truth for the decision text and rationale: `_bmad-output/planning-artifacts/architecture.md` Decision 25 (planning repo `wks-platform2`).
+
+## Approved alternatives
+
+If you reach for `tenant_id`, use one of these instead:
+
+- **Per-environment deploy** — `wks deploy <client>` provisions a distinct image, database, URL, and license file for each customer. The "tenant" is the running instance.
+- **`LicenseService.licensee`** — the customer name from the boot-time license (Decision 24) surfaces in the admin banner and audit-export header. It is identification only; it does **not** flow into domain rows or queries.
+- **Infrastructure-layer scoping** — file paths, DB connection strings, MinIO buckets are configured per environment, outside application code.
+
+## Escape hatch
+
+If you genuinely need a tenant concept, you are violating D25 — open a PR amending `architecture.md` before touching code.
+
+## CI enforcement
+
+The lint script `backend/.ci/check-tenant-invariant.sh` greps the protected packages for the forbidden identifiers on every PR via the GitHub Actions job `Tenant invariant (D25)` in `.github/workflows/ci.yml`. The script is a single source of truth — invoke it locally before pushing.

--- a/docs/zero-tenant-id.md
+++ b/docs/zero-tenant-id.md
@@ -23,3 +23,5 @@ If you genuinely need a tenant concept, you are violating D25 — open a PR amen
 ## CI enforcement
 
 The lint script `backend/.ci/check-tenant-invariant.sh` greps the protected packages for the forbidden identifiers on every PR via the GitHub Actions job `Tenant invariant (D25)` in `.github/workflows/ci.yml`. The script is a single source of truth — invoke it locally before pushing.
+
+The scan is textual: it flags the forbidden identifiers anywhere in a file under the protected packages — code, comments, Javadoc, and string literals alike. This is intentional. Comments saying "we used to use `tenantId`" or strings containing the word still signal pre-pivot thinking that an SI partner reading the code would see, which D25 forbids. If you genuinely need to reference the term in prose (e.g., explaining the invariant itself), do it from outside the protected packages.


### PR DESCRIPTION
## Summary

- Implements **Decision 25 ZERO `tenant_id` invariant** as a CI lint job (`Tenant invariant (D25)`) hard-failing on any `tenant_id` / `tenantId` / `WHERE tenant_id` / `@TenantId` reference inside `domain/`, `infrastructure/persistence/`, `audit/`, plus Flyway migrations.
- Single source of truth at `backend/.ci/check-tenant-invariant.sh`; `ci.yml` invokes the same script. Locally runnable from any cwd.
- New `docs/zero-tenant-id.md` explains the invariant, approved alternatives (per-environment deploy, `LicenseService.licensee`, infrastructure-layer scoping), and the escape hatch.
- **SPRINT 1 PREREQ** — gates Stories 3.1–3.10 per post-pivot Epic 3.

## Pre-existing scan

Clean (verified 2026-05-05) — backend main/test domain+persistence+audit and frontend src all 0 matches. Migrations under `db/migration/{common,postgresql}` all 0 matches.

## Local CI gauntlet

- `tenant-invariant` script: OK (clean) + verified negative tests on planted `.java`, `.sql`, and `_smoke` fixtures (all flagged correctly with file:line:identifier and the D25 sentence).
- `mvnw -B -ntp verify`: BUILD SUCCESS (60 tests, ArchUnit, Spotless), 1m25s.
- `npm ci && lint && format:check && test && build`: 63 test files / 236 tests, build emitted 4 woff2 in `dist/assets/` (font-count assertion ≥ 4 satisfied).
- `docker buildx build -f docker/Dockerfile`: image built successfully.
- Pre-push hook re-ran the full backend gauntlet on push.

## Code review (post-implementation)

Three-layer adversarial review (Blind Hunter, Edge Case Hunter, Acceptance Auditor) on this branch. Acceptance Auditor reported **no substantive AC violations**. Patches applied as `cdab96247`:

- Fail-fast when every configured `SCAN_PATH` is missing (silent-green refactor footgun closed).
- Strip trailing `\r` after allowlist read (Windows-edit silent-failure footgun closed).
- `grep -I` + `--include='*.java' --include='*.sql' --include='*.xml'` (binary noise + non-Java tree).
- Extended `SCAN_PATHS` to include `backend/src/main/resources/db/migration` so the `WHERE\s+tenant_id` regex alternative mandated by D25 is finally reachable.
- `docs/zero-tenant-id.md`: paragraph clarifying the textual scan covers comments / Javadoc / string literals intentionally.

Deferred: allowlist-glob semantics (empty on adoption — fold into first story that adds a real entry).

## Action for Victor after merge

Add `Tenant invariant (D25)` to `v2-develop` required status checks in branch protection settings (out of scope for this story per AC7 / Sprint 1 Triage Q1).

## Test plan

- [x] CI: confirm `Tenant invariant (D25)` job goes green on this PR.
- [x] CI: confirm runtime < 10s.
- [ ] CI: confirm existing `backend`, `frontend`, `docker-build` jobs still pass.
- [ ] Manual: after merge, plant a `tenantId` reference in `domain/` on a throwaway branch, confirm the lint fails the PR.
- [ ] Manual: toggle the required-status-check on `v2-develop` branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)