### PR TITLE
Story 3.1: Stage entity & lifecycle

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import com.wkspower.platform.domain.exception.WksConfigException;
 import com.wkspower.platform.domain.exception.WksConflictException;
 import com.wkspower.platform.domain.exception.WksException;
 import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.exception.WksStageException;
 import com.wkspower.platform.domain.exception.WksValidationAggregateException;
 import com.wkspower.platform.domain.exception.WksValidationException;
 import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
@@ -174,6 +175,29 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
               ApiResponse.error(
                   ErrorPayload.of(
                       code, "Resource was modified by another transaction; reload and retry")));
+    } finally {
+      MDC.remove(MDC_KEY);
+    }
+  }
+
+  /**
+   * Story 3.1 AC10 — map stage-lifecycle exceptions per AC9: {@code WKS-STG-001} → 409 (already
+   * complete), {@code WKS-STG-002} → 422 (backward skip), {@code WKS-STG-003} → 409 (concurrent
+   * transition; reload and retry), {@code WKS-STG-004} → 404 (unknown caseId).
+   */
+  @ExceptionHandler(WksStageException.class)
+  public ResponseEntity<ApiResponse<Void>> handleStage(WksStageException ex) {
+    MDC.put(MDC_KEY, ex.getCode());
+    try {
+      log.warn("Stage lifecycle error: {}", ex.getCode());
+      HttpStatus status =
+          switch (ex.getCode()) {
+            case "WKS-STG-002" -> HttpStatus.UNPROCESSABLE_ENTITY;
+            case "WKS-STG-004" -> HttpStatus.NOT_FOUND;
+            default -> HttpStatus.CONFLICT; // WKS-STG-001, WKS-STG-003
+          };
+      return ResponseEntity.status(status)
+          .body(ApiResponse.error(ErrorPayload.of(ex.getCode(), ex.getMessage())));
     } finally {
       MDC.remove(MDC_KEY);
     }

--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
@@ -2,10 +2,13 @@ package com.wkspower.platform.api.controller;
 
 import com.wkspower.platform.api.dto.ApiResponse;
 import com.wkspower.platform.api.dto.request.CreateCaseRequest;
+import com.wkspower.platform.api.dto.request.StageAdvanceRequest;
+import com.wkspower.platform.api.dto.request.StageSkipRequest;
 import com.wkspower.platform.api.dto.request.TransitionRequest;
 import com.wkspower.platform.api.dto.request.UpdateCaseRequest;
 import com.wkspower.platform.api.dto.response.CaseDto;
 import com.wkspower.platform.api.dto.response.CaseSummaryDto;
+import com.wkspower.platform.api.dto.response.StageActionResponse;
 import com.wkspower.platform.api.dto.response.TaskDto;
 import com.wkspower.platform.api.mapper.CaseDtoMapper;
 import com.wkspower.platform.api.mapper.TaskDtoMapper;
@@ -14,15 +17,21 @@ import com.wkspower.platform.api.pagination.SortSpec;
 import com.wkspower.platform.api.pagination.SortWhitelist;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.exception.WksStageException;
 import com.wkspower.platform.domain.exception.WksValidationException;
 import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.model.CaseQuery;
 import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.model.Stage;
+import com.wkspower.platform.domain.model.StageState;
 import com.wkspower.platform.domain.page.Page;
 import com.wkspower.platform.domain.page.PageRequest;
 import com.wkspower.platform.domain.page.SortOrder;
+import com.wkspower.platform.domain.port.StageRepository;
 import com.wkspower.platform.domain.service.CaseService;
 import com.wkspower.platform.domain.service.TaskService;
+import com.wkspower.platform.domain.service.WksStageAdvancer;
 import com.wkspower.platform.security.CaseTypePermissionEvaluator;
 import com.wkspower.platform.security.WksUserPrincipal;
 import jakarta.validation.Valid;
@@ -34,6 +43,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,15 +73,32 @@ public class CaseController {
   private final CaseService caseService;
   private final TaskService taskService;
   private final CaseTypePermissionEvaluator evaluator;
+  private final WksStageAdvancer stageAdvancer;
+  private final StageRepository stageRepository;
 
   public CaseController(
-      CaseService caseService, TaskService taskService, CaseTypePermissionEvaluator evaluator) {
+      CaseService caseService,
+      TaskService taskService,
+      CaseTypePermissionEvaluator evaluator,
+      WksStageAdvancer stageAdvancer,
+      StageRepository stageRepository) {
     this.caseService = caseService;
     this.taskService = taskService;
     this.evaluator = evaluator;
+    this.stageAdvancer = stageAdvancer;
+    this.stageRepository = stageRepository;
   }
 
+  /**
+   * AC4 atomicity surface (Story 3.1 code review B1, 2026-05-05): {@code @Transactional} pins the
+   * case insert + stage materialise + first-stage activate to a single Spring-managed transaction.
+   * Any unchecked failure from {@link CaseService#create} or {@link
+   * com.wkspower.platform.domain.service.WksStageAdvancer#bootstrap} rolls back the whole unit; the
+   * after-commit {@code StageEntered} bootstrap event publishes only on a successful commit (see
+   * {@link com.wkspower.platform.infrastructure.events.SpringEventPublisher#publishAfterCommit}).
+   */
   @PostMapping
+  @Transactional
   public ResponseEntity<ApiResponse<CaseDto>> create(
       @Valid @RequestBody CreateCaseRequest request,
       @AuthenticationPrincipal WksUserPrincipal actor) {
@@ -182,6 +209,70 @@ public class CaseController {
     Case updated = caseService.transition(id, request.action(), request.variables(), actor.id());
     CaseTypeConfig caseType = caseService.requireCaseType(updated.caseTypeId());
     return ApiResponse.success(CaseDtoMapper.toDto(updated, caseType));
+  }
+
+  /**
+   * Story 3.1 AC10 — manually advance the active stage. Server fills {@code source = "manual"};
+   * {@code sourceRef} is optional. Permission gate: {@code transition} verb (no new permission
+   * introduced). Error mapping: 404 on unknown caseId ({@code WKS-STG-004} / loaded-first 404), 409
+   * on already-complete ({@code WKS-STG-001}) or concurrent ({@code WKS-STG-003}).
+   */
+  @PostMapping("/{id}/advance-stage")
+  @Transactional
+  public ResponseEntity<ApiResponse<StageActionResponse>> advanceStage(
+      @PathVariable("id") UUID id,
+      @Valid @RequestBody(required = false) StageAdvanceRequest request,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    requireTransitionVerbForStageAction(id, actor);
+    String sourceRef = request == null ? null : request.sourceRef();
+    stageAdvancer.advance(id, "manual", sourceRef);
+    return ResponseEntity.ok(ApiResponse.success(loadStageHead(id)));
+  }
+
+  /**
+   * Story 3.1 AC10 — skip ahead to a future-ordinal stage. Server fills {@code source = "manual"}.
+   * Backward skip is rejected with {@code WKS-STG-002} (422); concurrent transitions surface as
+   * {@code WKS-STG-003} (409).
+   */
+  @PostMapping("/{id}/skip-stage")
+  @Transactional
+  public ResponseEntity<ApiResponse<StageActionResponse>> skipStage(
+      @PathVariable("id") UUID id,
+      @Valid @RequestBody StageSkipRequest request,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    requireTransitionVerbForStageAction(id, actor);
+    stageAdvancer.skipTo(id, request.targetStageId(), "manual", request.sourceRef());
+    return ResponseEntity.ok(ApiResponse.success(loadStageHead(id)));
+  }
+
+  /**
+   * Stage-action authz helper (Story 3.1 code review S2, 2026-05-05). Loads the case to gate the
+   * {@code transition} verb — but translates a missing case to {@code WKS-STG-004} so the wire
+   * contract from AC9 (unknown caseId → STG-004 → 404) holds, instead of leaking the generic
+   * loaded-first {@code WKS-API-404}. Found cases route through the standard verb gate.
+   */
+  private void requireTransitionVerbForStageAction(UUID id, WksUserPrincipal actor) {
+    Case found;
+    try {
+      found = caseService.findById(id);
+    } catch (WksNotFoundException ex) {
+      throw new WksStageException(
+          ErrorCode.WKS_STG_004, "Case " + id + " not found — cannot advance / skip");
+    }
+    requireVerb(actor, found.caseTypeId(), "transition");
+  }
+
+  /**
+   * Read the post-transition active stage from the history table. Returns {@code (id, null, null)}
+   * when no stage is active (last-stage completion or zero-stage case).
+   */
+  private StageActionResponse loadStageHead(UUID caseId) {
+    List<Stage> history = stageRepository.loadHistory(caseId);
+    return history.stream()
+        .filter(s -> s.state() == StageState.ACTIVE)
+        .findFirst()
+        .map(s -> new StageActionResponse(caseId, s.stageId(), s.ordinal()))
+        .orElseGet(() -> new StageActionResponse(caseId, null, null));
   }
 
   private void requireVerb(WksUserPrincipal actor, String caseTypeId, String verb) {

--- a/backend/src/main/java/com/wkspower/platform/api/dto/request/StageAdvanceRequest.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/request/StageAdvanceRequest.java
@@ -1,0 +1,8 @@
+package com.wkspower.platform.api.dto.request;
+
+/**
+ * Body for {@code POST /api/cases/{id}/advance-stage} (Story 3.1 AC10). The server fills {@code
+ * source = "manual"} for HTTP-driven advances; the request only carries an optional correlation
+ * string the caller wants stamped into the audit row (e.g. "approved by reviewer Alice").
+ */
+public record StageAdvanceRequest(String sourceRef) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/request/StageSkipRequest.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/request/StageSkipRequest.java
@@ -1,0 +1,9 @@
+package com.wkspower.platform.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Body for {@code POST /api/cases/{id}/skip-stage} (Story 3.1 AC10). The server fills {@code source
+ * = "manual"}; the request supplies the target stage id and an optional correlation ref.
+ */
+public record StageSkipRequest(@NotBlank String targetStageId, String sourceRef) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/StageActionResponse.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/StageActionResponse.java
@@ -1,0 +1,11 @@
+package com.wkspower.platform.api.dto.response;
+
+import java.util.UUID;
+
+/**
+ * Wire shape for the response of {@code POST /api/cases/{id}/advance-stage} and {@code POST
+ * /api/cases/{id}/skip-stage} (Story 3.1 AC10). {@code currentStageId} and {@code
+ * currentStageOrdinal} are {@code null} after last-stage completion.
+ */
+public record StageActionResponse(
+    UUID caseId, String currentStageId, Integer currentStageOrdinal) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
@@ -7,6 +7,11 @@ import java.util.Optional;
  * Validated, immutable case-type configuration. Every collection is defensively copied so the
  * registry cannot be mutated through a reference leaked to callers. Only {@code description} is
  * optional.
+ *
+ * <p>{@code stages} is the post-pivot foundational primitive (Story 3.1 / Decision 19). When the
+ * YAML omits {@code stages:} or declares an empty list, this field is {@link List#of()} and every
+ * downstream service treats the absence as a no-op (Decision 19: "stage-less paths must remain
+ * unbranched").
  */
 public record CaseTypeConfig(
     String id,
@@ -17,13 +22,42 @@ public record CaseTypeConfig(
     List<FieldDefinition> fields,
     List<StatusDefinition> statuses,
     List<String> listColumns,
-    List<RoleDefinition> roles) {
+    List<RoleDefinition> roles,
+    List<StageDefinition> stages) {
+
+  /**
+   * Backward-compat constructor for callers (and tests) that predate Story 3.1's {@code stages}
+   * slot — defaults to {@link List#of()}.
+   */
+  public CaseTypeConfig(
+      String id,
+      String displayName,
+      int version,
+      String description,
+      WorkflowRef workflow,
+      List<FieldDefinition> fields,
+      List<StatusDefinition> statuses,
+      List<String> listColumns,
+      List<RoleDefinition> roles) {
+    this(
+        id,
+        displayName,
+        version,
+        description,
+        workflow,
+        fields,
+        statuses,
+        listColumns,
+        roles,
+        List.of());
+  }
 
   public CaseTypeConfig {
     fields = List.copyOf(fields);
     statuses = List.copyOf(statuses);
     listColumns = List.copyOf(listColumns);
     roles = List.copyOf(roles);
+    stages = stages == null ? List.of() : List.copyOf(stages);
   }
 
   /** Convenience lookup used by the JSON Schema generator and (future) case-data validation. */

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/StageDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/StageDefinition.java
@@ -1,0 +1,35 @@
+package com.wkspower.platform.domain.config.model;
+
+import java.util.Objects;
+
+/**
+ * A stage declared on a case-type YAML (Story 3.1 AC1). Plain Java — no Spring, no JPA, no Jackson
+ * annotations.
+ *
+ * <p>Two YAML forms parse into this record:
+ *
+ * <pre>
+ *   stages: [intake, underwriting, decision]   # string-list form (ordinal = list index)
+ *   stages:
+ *     - id: intake
+ *       displayName: "Intake"                   # rich form (forward-compat for status-set / archetype slots)
+ * </pre>
+ *
+ * <p>{@code displayName} defaults to a Title-cased {@code id} when the YAML omits it (e.g. {@code
+ * "loan-decision"} → {@code "Loan Decision"}). The {@code ordinal} is the 0-based position in the
+ * declared list — never reordered after parse.
+ *
+ * @param id stage id (matches {@code [a-z][a-z0-9-]{0,62}}, not a reserved word)
+ * @param displayName human-readable label, never blank
+ * @param ordinal 0-based position in the declared {@code stages} list
+ */
+public record StageDefinition(String id, String displayName, int ordinal) {
+
+  public StageDefinition {
+    Objects.requireNonNull(id, "id");
+    Objects.requireNonNull(displayName, "displayName");
+    if (ordinal < 0) {
+      throw new IllegalArgumentException("ordinal must be >= 0");
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/event/StageEntered.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/StageEntered.java
@@ -1,0 +1,37 @@
+package com.wkspower.platform.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Emitted when a stage transitions to {@link com.wkspower.platform.domain.model.StageState#ACTIVE}.
+ * Story 3.1 AC4–AC6 fire this from two triggers:
+ *
+ * <ul>
+ *   <li>{@code WksStageAdvancer.bootstrap} — on case creation, for stage 0 only (Sprint 1 triage Q3
+ *       — stage-0-only events; future {@code StagePending} events are deferred to Epic 9 if a
+ *       consumer needs them).
+ *   <li>{@code WksStageAdvancer.advance} / {@code skipTo} — on the new active stage.
+ * </ul>
+ *
+ * <p>Publication discipline: {@code afterCommit} via the {@link
+ * com.wkspower.platform.domain.port.EventPublisher#publishAfterCommit publishAfterCommit} port
+ * method. Subscribers must never observe an event whose underlying transaction was rolled back.
+ * Mirrors Story 2.4's {@code CaseStatusListener} discipline.
+ *
+ * <p>Future consumers (named, not subscribed in this story):
+ *
+ * <ul>
+ *   <li>Epic 4 audit-feed listener — writes the stage transition into the audit table.
+ *   <li>Story 3.3 stage-timeline SSE pump — pushes timeline updates to the case-detail surface.
+ * </ul>
+ *
+ * @param caseId owning case id
+ * @param stageId YAML-declared stage id (e.g. {@code "intake"})
+ * @param ordinal zero-based ordinal of the stage that just went active
+ * @param source one of {@code wks-auto-rule} / {@code manual} / {@code backend-signal}
+ * @param sourceRef free-form correlation string ({@code null} when not applicable)
+ * @param timestamp commit timestamp from {@link com.wkspower.platform.domain.port.Clock#now}
+ */
+public record StageEntered(
+    UUID caseId, String stageId, int ordinal, String source, String sourceRef, Instant timestamp) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/event/StageExited.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/StageExited.java
@@ -1,0 +1,35 @@
+package com.wkspower.platform.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Emitted when a stage transitions out of {@link
+ * com.wkspower.platform.domain.model.StageState#ACTIVE} — i.e. becomes {@link
+ * com.wkspower.platform.domain.model.StageState#COMPLETED}. Story 3.1 AC5–AC7 fire this from {@code
+ * WksStageAdvancer.advance} and {@code WksStageAdvancer.skipTo}, including the last-stage
+ * completion path (AC7).
+ *
+ * <p>Skipped intermediates do <em>not</em> emit this event in Story 3.1 (AC6) — the audit row is
+ * the audit record; activity-feed handling for skips is Epic 4 work.
+ *
+ * <p>Publication discipline: {@code afterCommit} via the {@link
+ * com.wkspower.platform.domain.port.EventPublisher#publishAfterCommit publishAfterCommit} port
+ * method.
+ *
+ * <p>Future consumers (named, not subscribed in this story):
+ *
+ * <ul>
+ *   <li>Epic 4 audit-feed listener — writes the stage transition into the audit table.
+ *   <li>Story 3.3 stage-timeline SSE pump.
+ * </ul>
+ *
+ * @param caseId owning case id
+ * @param stageId YAML-declared stage id of the stage that just exited active
+ * @param ordinal zero-based ordinal of the exited stage
+ * @param source one of {@code wks-auto-rule} / {@code manual} / {@code backend-signal}
+ * @param sourceRef free-form correlation string ({@code null} when not applicable)
+ * @param timestamp commit timestamp from {@link com.wkspower.platform.domain.port.Clock#now}
+ */
+public record StageExited(
+    UUID caseId, String stageId, int ordinal, String source, String sourceRef, Instant timestamp) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -104,8 +104,40 @@ public enum ErrorCode {
    * isExecutable=true}; any additional executable processes trip this code.
    */
   WKS_CFG_022("WKS-CFG-022"),
+  /**
+   * Duplicate stage id within a case-type YAML (Story 3.1 AC1). Deploy-time validator code;
+   * surfaces with a {@code stages[i].id} field path.
+   */
+  WKS_CFG_031("WKS-CFG-031"),
+  /**
+   * Stage id violates the {@code [a-z][a-z0-9-]{0,62}} pattern (Story 3.1 AC1). Same regex shape as
+   * status / role ids, no underscore variant — stages live on the URL surface (Story 3.3) so they
+   * stay strictly kebab-case.
+   */
+  WKS_CFG_032("WKS-CFG-032"),
+  /**
+   * Stage id collides with a reserved word (Story 3.1 AC1). Initial reserved set: {@code case},
+   * {@code stage}, {@code none}, {@code all}. Extend cautiously — the wire is a contract.
+   */
+  WKS_CFG_033("WKS-CFG-033"),
   /** YAML parse error / I/O failure (catastrophic — validator never produces). */
   WKS_CFG_099("WKS-CFG-099"),
+
+  // 409 / 422 / 404 — Stage lifecycle runtime errors (Story 3.1 AC9). Band: WKS-STG-001..099.
+  /**
+   * advance / skipTo invoked on a case whose stages are already all completed, or on a zero-stage
+   * case (no active stage to advance). HTTP 409.
+   */
+  WKS_STG_001("WKS-STG-001"),
+  /** Skip target is at or below the currently-active stage ordinal (backward skip). HTTP 422. */
+  WKS_STG_002("WKS-STG-002"),
+  /**
+   * Concurrent stage transition — two callers raced and the conditional-update lost the row. The
+   * caller should reload and retry. HTTP 409.
+   */
+  WKS_STG_003("WKS-STG-003"),
+  /** advance / skipTo references an unknown caseId. HTTP 404. */
+  WKS_STG_004("WKS-STG-004"),
 
   // 409 — runtime conflict.
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/WksStageException.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/WksStageException.java
@@ -1,0 +1,25 @@
+package com.wkspower.platform.domain.exception;
+
+/**
+ * Stage lifecycle runtime exception (Story 3.1 AC9). Carries one of {@link ErrorCode#WKS_STG_001},
+ * {@link ErrorCode#WKS_STG_002}, {@link ErrorCode#WKS_STG_003}, {@link ErrorCode#WKS_STG_004}.
+ *
+ * <p>HTTP mapping (lifted by {@code GlobalExceptionHandler}):
+ *
+ * <ul>
+ *   <li>{@code WKS-STG-001} (already complete / zero-stage) — 409
+ *   <li>{@code WKS-STG-002} (backward skip) — 422
+ *   <li>{@code WKS-STG-003} (concurrent transition) — 409
+ *   <li>{@code WKS-STG-004} (unknown caseId) — 404
+ * </ul>
+ */
+public class WksStageException extends WksException {
+
+  public WksStageException(ErrorCode code, String message) {
+    super(code, message);
+  }
+
+  public WksStageException(ErrorCode code, String message, Throwable cause) {
+    super(code, message, cause);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/model/Stage.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/Stage.java
@@ -1,0 +1,53 @@
+package com.wkspower.platform.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Domain record for a single stage row in a case's lifecycle history (Story 3.1 AC2). Plain Java —
+ * no Spring, no JPA, no Jackson annotations. Domain-purity ArchUnit rules treat this package as a
+ * framework-free zone (Decision 4 / NFR36).
+ *
+ * <p>Each {@link Stage} corresponds to one row of {@code case_stage_history}. The history table is
+ * append-only-ish — a row is updated to flip {@link StageState} (e.g. {@code PENDING} → {@code
+ * ACTIVE}, {@code ACTIVE} → {@code COMPLETED}, {@code PENDING} → {@code SKIPPED}) but never
+ * deleted. The denormalised cache lives on {@code cases.current_stage_id} / {@code
+ * current_stage_ordinal}; this record exists for reads and tests.
+ *
+ * @param id row identifier (UUID)
+ * @param caseId owning case id
+ * @param stageId YAML-declared stage id (e.g. {@code "intake"})
+ * @param ordinal zero-based ordinal in the declared stage list
+ * @param state {@link StageState} of this row
+ * @param enteredAt timestamp the row entered {@link StageState#ACTIVE}; {@code null} for rows still
+ *     {@link StageState#PENDING} or rows that were {@link StageState#SKIPPED} without ever going
+ *     active
+ * @param exitedAt timestamp the row left {@link StageState#ACTIVE} (i.e. became {@code COMPLETED}
+ *     or {@code SKIPPED}); {@code null} while a row is still {@code PENDING} or {@code ACTIVE}
+ * @param source one of {@code wks-auto-rule} / {@code manual} / {@code backend-signal} (Decision 1)
+ *     — {@code null} on initial {@code PENDING} rows before the first transition
+ * @param sourceRef free-form correlation string (user id, BPMN process-instance id, etc.); {@code
+ *     null} when not applicable
+ */
+public record Stage(
+    UUID id,
+    UUID caseId,
+    String stageId,
+    int ordinal,
+    StageState state,
+    Instant enteredAt,
+    Instant exitedAt,
+    String source,
+    String sourceRef) {
+
+  public Stage {
+    Objects.requireNonNull(id, "id");
+    Objects.requireNonNull(caseId, "caseId");
+    Objects.requireNonNull(stageId, "stageId");
+    Objects.requireNonNull(state, "state");
+    if (ordinal < 0) {
+      throw new IllegalArgumentException("ordinal must be >= 0");
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/model/StageState.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/StageState.java
@@ -1,0 +1,20 @@
+package com.wkspower.platform.domain.model;
+
+/**
+ * Lifecycle state of a {@link Stage} on a case. Closed enum — Phase-1 deferral on extra states
+ * (e.g. {@code CANCELLED}, {@code ROLLED_BACK}) per Story 3.1 AC2.
+ *
+ * <ul>
+ *   <li>{@link #PENDING} — materialised on case creation, never yet active
+ *   <li>{@link #ACTIVE} — currently the case's head stage
+ *   <li>{@link #COMPLETED} — was active, has been advanced past
+ *   <li>{@link #SKIPPED} — never active, jumped over by {@link
+ *       com.wkspower.platform.domain.service.WksStageAdvancer#skipTo}
+ * </ul>
+ */
+public enum StageState {
+  PENDING,
+  ACTIVE,
+  COMPLETED,
+  SKIPPED
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/EventPublisher.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/EventPublisher.java
@@ -9,6 +9,19 @@ package com.wkspower.platform.domain.port;
  */
 public interface EventPublisher {
 
-  /** Publish a domain event. */
+  /** Publish a domain event synchronously. */
   void publish(Object event);
+
+  /**
+   * Publish a domain event after the current transaction commits (Story 3.1 AC4–AC7 discipline).
+   * Mirrors Story 2.4's {@code CaseStatusListener} idiom — subscribers must not observe state that
+   * the underlying transaction subsequently rolls back.
+   *
+   * <p>Outside an active transaction (test harnesses, background work) the default implementation
+   * delegates to {@link #publish} so unit tests using a simple recording stub keep observing events
+   * synchronously without overriding this method.
+   */
+  default void publishAfterCommit(Object event) {
+    publish(event);
+  }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/port/StageRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/StageRepository.java
@@ -1,0 +1,84 @@
+package com.wkspower.platform.domain.port;
+
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.model.Stage;
+import com.wkspower.platform.domain.model.StageState;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Outbound port for the case stage history (Story 3.1 AC3, AC5, AC8). The infrastructure adapter
+ * persists rows in {@code case_stage_history} and updates the denormalised cache columns on {@code
+ * cases}; the domain only sees the contract here.
+ *
+ * <p>The append-only model: every state change is a row update, never a delete. Concurrency is
+ * serialised via a conditional UPDATE inside {@link #appendTransition} that pivots on the previous
+ * {@link StageState} — rowcount of zero raises {@link
+ * com.wkspower.platform.domain.exception.WksStageException} with code {@code WKS-STG-003} (Story
+ * 3.1 AC8 — preferred over {@code @Version} on {@code cases} because stage transitions own their
+ * own optimistic-lock surface).
+ */
+public interface StageRepository {
+
+  /** Load the full stage history for a case, ordered by ordinal ascending. */
+  List<Stage> loadHistory(UUID caseId);
+
+  /**
+   * Materialise pending rows for every declared stage on a freshly created case (Story 3.1 AC4).
+   * Inserts one {@link StageState#PENDING} row per definition. Caller (e.g. {@code
+   * WksStageAdvancer.bootstrap}) follows up with an {@link #appendTransition} call to flip stage 0
+   * to {@link StageState#ACTIVE}. No-op on an empty list.
+   *
+   * @param caseId owning case id
+   * @param stages immutable list of stage definitions (already validated)
+   * @param createdAt timestamp stamped on every {@code created_at} column
+   */
+  void materialiseStages(UUID caseId, List<StageDefinition> stages, Instant createdAt);
+
+  /**
+   * Apply a single stage-state transition atomically. The adapter performs:
+   *
+   * <ol>
+   *   <li>conditional UPDATE on the {@code from} row: pivots on {@code (case_id, stage_id, state =
+   *       fromState)} — rowcount must equal 1, else throw {@code WKS-STG-003}
+   *   <li>conditional UPDATE on the {@code to} row (when {@code toStageId} is non-null): pivots on
+   *       {@code (case_id, stage_id, state = PENDING)} — rowcount must equal 1
+   *   <li>UPDATE on {@code cases.current_stage_id} / {@code cases.current_stage_ordinal} (caller
+   *       supplies the target values; pass nulls to clear after last-stage completion)
+   * </ol>
+   *
+   * <p>Skipped intermediates are passed via {@link Transition#skipped}: each is updated from {@link
+   * StageState#PENDING} to {@link StageState#SKIPPED} with {@code entered_at = NULL} and {@code
+   * exited_at = clock.now()}. No event is emitted by this port — the caller publishes domain events
+   * at the service layer.
+   *
+   * @param transition fully-described transition; nullable fields are tolerated where documented
+   */
+  void appendTransition(Transition transition);
+
+  /**
+   * Description of a single atomic stage transition. {@code fromStageId} is the previously-active
+   * stage (may be {@code null} on bootstrap). {@code toStageId} is the new active stage (may be
+   * {@code null} on last-stage completion). {@code skipped} carries any intermediates that flip
+   * directly from {@code PENDING} → {@code SKIPPED}.
+   */
+  record Transition(
+      UUID caseId,
+      String fromStageId,
+      Integer fromOrdinal,
+      String toStageId,
+      Integer toOrdinal,
+      List<SkippedStage> skipped,
+      String source,
+      String sourceRef,
+      Instant timestamp) {
+
+    public Transition {
+      skipped = skipped == null ? List.of() : List.copyOf(skipped);
+    }
+  }
+
+  /** A pending stage that the transition skips over. */
+  record SkippedStage(String stageId, int ordinal) {}
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -47,6 +47,7 @@ public class CaseService {
   private final ProcessDefinitionKeyResolver processKeyResolver;
   private final EventPublisher eventPublisher;
   private final Clock clock;
+  private final WksStageAdvancer stageAdvancer;
 
   public CaseService(
       CaseRepository caseRepository,
@@ -55,7 +56,8 @@ public class CaseService {
       WorkflowEngine workflowEngine,
       ProcessDefinitionKeyResolver processKeyResolver,
       EventPublisher eventPublisher,
-      Clock clock) {
+      Clock clock,
+      WksStageAdvancer stageAdvancer) {
     this.caseRepository = Objects.requireNonNull(caseRepository, "caseRepository");
     this.caseTypeReader = Objects.requireNonNull(caseTypeReader, "caseTypeReader");
     this.caseDataValidator = Objects.requireNonNull(caseDataValidator, "caseDataValidator");
@@ -63,6 +65,7 @@ public class CaseService {
     this.processKeyResolver = Objects.requireNonNull(processKeyResolver, "processKeyResolver");
     this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher");
     this.clock = Objects.requireNonNull(clock, "clock");
+    this.stageAdvancer = Objects.requireNonNull(stageAdvancer, "stageAdvancer");
   }
 
   /**
@@ -112,6 +115,11 @@ public class CaseService {
             now,
             0L);
     Case persisted = caseRepository.save(toPersist);
+
+    // Story 3.1 AC4 — materialise stages and flip stage 0 to ACTIVE inside the same transaction
+    // as the case insert. Empty stage list is a no-op (Decision 19: stage-less paths must remain
+    // unbranched — the loop in stageAdvancer.bootstrap is the single source of truth).
+    stageAdvancer.bootstrap(persisted.id(), caseType.stages(), "wks-auto-rule", "case-create");
 
     eventPublisher.publish(
         new CaseCreated(persisted.id(), caseType.id(), caseType.version(), actorId, now));

--- a/backend/src/main/java/com/wkspower/platform/domain/service/WksStageAdvancer.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/WksStageAdvancer.java
@@ -1,0 +1,211 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.event.StageEntered;
+import com.wkspower.platform.domain.event.StageExited;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.WksStageException;
+import com.wkspower.platform.domain.model.Stage;
+import com.wkspower.platform.domain.model.StageState;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.StageRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Domain service for stage lifecycle transitions (Story 3.1 AC4–AC8). Framework-free — no Spring
+ * annotations on this class; the {@code @Transactional} boundary is applied at the wiring layer
+ * ({@code ConfigServiceConfig} or a dedicated {@code WksStageAdvancerProxy}) per Decision 4 /
+ * NFR36.
+ *
+ * <p>Three public entry points:
+ *
+ * <ul>
+ *   <li>{@link #bootstrap} — called from {@code CaseService.create} inside the create transaction;
+ *       materialises pending rows and flips stage 0 to ACTIVE. No-op on empty stage list.
+ *   <li>{@link #advance} — manual advance of one stage (or last-stage completion).
+ *   <li>{@link #skipTo} — jump to a future-ordinal stage; intermediates flip to SKIPPED.
+ * </ul>
+ *
+ * <p>Concurrency: {@link StageRepository#appendTransition} performs a conditional UPDATE that
+ * pivots on the previous state; rowcount-zero raises {@link ErrorCode#WKS_STG_003}. Two parallel
+ * advance calls cannot both succeed.
+ */
+public class WksStageAdvancer {
+
+  /** Allowed values for the {@code source} parameter — Decision 1. */
+  private static final List<String> ALLOWED_SOURCES =
+      List.of("wks-auto-rule", "manual", "backend-signal");
+
+  private final StageRepository stageRepository;
+  private final EventPublisher eventPublisher;
+  private final Clock clock;
+
+  public WksStageAdvancer(
+      StageRepository stageRepository, EventPublisher eventPublisher, Clock clock) {
+    this.stageRepository = Objects.requireNonNull(stageRepository, "stageRepository");
+    this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher");
+    this.clock = Objects.requireNonNull(clock, "clock");
+  }
+
+  /**
+   * Materialise all declared stages as PENDING and flip stage 0 to ACTIVE inside the same
+   * transaction (Story 3.1 AC4). Empty stage list is a no-op — Decision 19's "stage-less paths must
+   * remain unbranched" lives here.
+   */
+  public void bootstrap(
+      UUID caseId, List<StageDefinition> stages, String source, String sourceRef) {
+    Objects.requireNonNull(caseId, "caseId");
+    requireValidSource(source);
+    if (stages == null || stages.isEmpty()) {
+      return;
+    }
+    Instant now = clock.now();
+    stageRepository.materialiseStages(caseId, stages, now);
+    StageDefinition first = stages.get(0);
+    stageRepository.appendTransition(
+        new StageRepository.Transition(
+            caseId, null, null, first.id(), first.ordinal(), List.of(), source, sourceRef, now));
+    eventPublisher.publishAfterCommit(
+        new StageEntered(caseId, first.id(), first.ordinal(), source, sourceRef, now));
+  }
+
+  /**
+   * Advance the active stage to the next ordinal, or — when the active stage is last — complete it
+   * and clear the case head (Story 3.1 AC5, AC7). Emits {@link StageExited} for the previous active
+   * stage and (when not last) {@link StageEntered} for the new active stage. Both events fire
+   * {@code afterCommit}.
+   */
+  public void advance(UUID caseId, String source, String sourceRef) {
+    Objects.requireNonNull(caseId, "caseId");
+    requireValidSource(source);
+    List<Stage> history = requireHistory(caseId);
+    Stage active = findActive(history);
+    Instant now = clock.now();
+
+    Stage next = findByOrdinal(history, active.ordinal() + 1);
+    String toStageId = next == null ? null : next.stageId();
+    Integer toOrdinal = next == null ? null : next.ordinal();
+
+    stageRepository.appendTransition(
+        new StageRepository.Transition(
+            caseId,
+            active.stageId(),
+            active.ordinal(),
+            toStageId,
+            toOrdinal,
+            List.of(),
+            source,
+            sourceRef,
+            now));
+
+    eventPublisher.publishAfterCommit(
+        new StageExited(caseId, active.stageId(), active.ordinal(), source, sourceRef, now));
+    if (next != null) {
+      eventPublisher.publishAfterCommit(
+          new StageEntered(caseId, next.stageId(), next.ordinal(), source, sourceRef, now));
+    }
+  }
+
+  /**
+   * Skip directly to {@code targetStageId}, marking every PENDING intermediate as SKIPPED (Story
+   * 3.1 AC6). Backward skip ({@code targetOrdinal <= activeOrdinal}) is rejected with {@code
+   * WKS-STG-002}. Skipping forward by exactly one is equivalent to {@link #advance}.
+   */
+  public void skipTo(UUID caseId, String targetStageId, String source, String sourceRef) {
+    Objects.requireNonNull(caseId, "caseId");
+    Objects.requireNonNull(targetStageId, "targetStageId");
+    requireValidSource(source);
+    List<Stage> history = requireHistory(caseId);
+    Stage active = findActive(history);
+    Stage target = findByStageId(history, targetStageId);
+    if (target == null) {
+      throw new WksStageException(
+          ErrorCode.WKS_STG_002,
+          "Skip target '" + targetStageId + "' is not a stage on case " + caseId);
+    }
+    if (target.ordinal() <= active.ordinal()) {
+      throw new WksStageException(
+          ErrorCode.WKS_STG_002,
+          "Skip target ordinal "
+              + target.ordinal()
+              + " must be greater than active ordinal "
+              + active.ordinal());
+    }
+    Instant now = clock.now();
+    List<StageRepository.SkippedStage> skipped = new ArrayList<>();
+    for (int o = active.ordinal() + 1; o < target.ordinal(); o++) {
+      Stage intermediate = findByOrdinal(history, o);
+      if (intermediate == null || intermediate.state() != StageState.PENDING) {
+        // Defensive: history is read-then-write; an intermediate not in PENDING means a
+        // concurrent caller mutated the row first. Surface as STG-003.
+        throw new WksStageException(
+            ErrorCode.WKS_STG_003,
+            "Concurrent stage transition on case " + caseId + "; reload and retry");
+      }
+      skipped.add(new StageRepository.SkippedStage(intermediate.stageId(), intermediate.ordinal()));
+    }
+
+    stageRepository.appendTransition(
+        new StageRepository.Transition(
+            caseId,
+            active.stageId(),
+            active.ordinal(),
+            target.stageId(),
+            target.ordinal(),
+            skipped,
+            source,
+            sourceRef,
+            now));
+
+    eventPublisher.publishAfterCommit(
+        new StageExited(caseId, active.stageId(), active.ordinal(), source, sourceRef, now));
+    eventPublisher.publishAfterCommit(
+        new StageEntered(caseId, target.stageId(), target.ordinal(), source, sourceRef, now));
+    // Skipped intermediates emit no events in Story 3.1 (AC6).
+  }
+
+  // ---- helpers ----------------------------------------------------------
+
+  private List<Stage> requireHistory(UUID caseId) {
+    List<Stage> history = stageRepository.loadHistory(caseId);
+    if (history == null || history.isEmpty()) {
+      throw new WksStageException(
+          ErrorCode.WKS_STG_001, "Case " + caseId + " has no stages — cannot advance / skip");
+    }
+    return history;
+  }
+
+  private Stage findActive(List<Stage> history) {
+    return history.stream()
+        .filter(s -> s.state() == StageState.ACTIVE)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new WksStageException(
+                    ErrorCode.WKS_STG_001,
+                    "Case stages are all completed; nothing to advance / skip"));
+  }
+
+  private static Stage findByOrdinal(List<Stage> history, int ordinal) {
+    return history.stream().filter(s -> s.ordinal() == ordinal).findFirst().orElse(null);
+  }
+
+  private static Stage findByStageId(List<Stage> history, String stageId) {
+    return history.stream().filter(s -> s.stageId().equals(stageId)).findFirst().orElse(null);
+  }
+
+  private static void requireValidSource(String source) {
+    if (source == null || source.isBlank()) {
+      throw new IllegalArgumentException("source is required (one of " + ALLOWED_SOURCES + ")");
+    }
+    if (!ALLOWED_SOURCES.contains(source)) {
+      throw new IllegalArgumentException(
+          "source '" + source + "' must be one of " + ALLOWED_SOURCES);
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
@@ -9,10 +9,12 @@ import com.wkspower.platform.domain.port.CaseTypeSource;
 import com.wkspower.platform.domain.port.Clock;
 import com.wkspower.platform.domain.port.EventPublisher;
 import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
+import com.wkspower.platform.domain.port.StageRepository;
 import com.wkspower.platform.domain.port.WorkflowEngine;
 import com.wkspower.platform.domain.service.CaseService;
 import com.wkspower.platform.domain.service.ConfigService;
 import com.wkspower.platform.domain.service.TaskService;
+import com.wkspower.platform.domain.service.WksStageAdvancer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -48,7 +50,8 @@ public class ConfigServiceConfig {
       WorkflowEngine workflowEngine,
       ProcessDefinitionKeyResolver processKeyResolver,
       EventPublisher eventPublisher,
-      Clock clock) {
+      Clock clock,
+      WksStageAdvancer stageAdvancer) {
     return new CaseService(
         caseRepository,
         caseTypeReader,
@@ -56,6 +59,21 @@ public class ConfigServiceConfig {
         workflowEngine,
         processKeyResolver,
         eventPublisher,
-        clock);
+        clock,
+        stageAdvancer);
+  }
+
+  /**
+   * Story 3.1 — wires the framework-free {@link WksStageAdvancer}. The {@code @Transactional}
+   * boundary is applied at this layer (via {@link
+   * org.springframework.transaction.annotation.Transactional} on the calling code paths — {@code
+   * CaseService.create} sits inside Spring's transactional proxy already, and the stage-advance
+   * HTTP endpoints declare {@code @Transactional} on the controller bodies). The domain class
+   * itself stays Spring-free per Decision 4 / NFR36.
+   */
+  @Bean
+  public WksStageAdvancer wksStageAdvancer(
+      StageRepository stageRepository, EventPublisher eventPublisher, Clock clock) {
+    return new WksStageAdvancer(stageRepository, eventPublisher, clock);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -8,6 +8,7 @@ import com.wkspower.platform.domain.config.model.FieldOption;
 import com.wkspower.platform.domain.config.model.FieldType;
 import com.wkspower.platform.domain.config.model.Permission;
 import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
 import com.wkspower.platform.domain.config.model.StatusColor;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.domain.config.model.WorkflowRef;
@@ -39,6 +40,21 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class ConfigValidator {
+
+  /**
+   * Reserved stage ids — Story 3.1 AC1 (Sprint-1 triage Q4: initial set, extend on first conflict).
+   * Lives here as a private constant so the validator owns the rule; if a future story needs to
+   * extend, the touch-point is one place.
+   */
+  private static final Set<String> RESERVED_STAGE_IDS = Set.of("case", "stage", "none", "all");
+
+  /**
+   * Stage id pattern (Story 3.1 AC1) — same kebab-case shape as status / role ids, but allows a
+   * 1-character id (regex {@code [a-z][a-z0-9-]{0,62}}). Stages live on the URL surface (Story 3.3)
+   * so no underscore variant.
+   */
+  private static final java.util.regex.Pattern STAGE_ID_PATTERN =
+      java.util.regex.Pattern.compile("[a-z][a-z0-9-]{0,62}");
 
   public ValidationResult validate(RawCaseTypeConfig raw, YamlLineIndex lines) {
     if (raw == null) {
@@ -78,6 +94,7 @@ public class ConfigValidator {
     List<RoleDefinition> roles = checkRoles(raw.roles(), eb, errors);
     List<String> listColumns =
         checkListColumns(raw.listColumns(), fields, raw.fields() != null, eb, errors);
+    List<StageDefinition> stages = checkStages(raw.stages(), eb, errors);
 
     if (!errors.isEmpty()) {
       return ValidationResult.invalid(errors);
@@ -93,8 +110,92 @@ public class ConfigValidator {
             fields,
             statuses,
             listColumns,
-            roles);
+            roles,
+            stages);
     return ValidationResult.ok(config, warnings);
+  }
+
+  /**
+   * Story 3.1 AC1 — validate the optional {@code stages} list. {@code null} or empty produces an
+   * empty list (legal — no error). Collect-all idiom: every duplicate / pattern / reserved-word
+   * violation is appended; checks never short-circuit on first error.
+   */
+  private List<StageDefinition> checkStages(
+      List<RawCaseTypeConfig.RawStage> raws, ErrorBuilder eb, List<ErrorDetail> errors) {
+    if (raws == null || raws.isEmpty()) {
+      return List.of();
+    }
+    List<StageDefinition> out = new ArrayList<>();
+    Set<String> seen = new HashSet<>();
+    for (int i = 0; i < raws.size(); i++) {
+      RawCaseTypeConfig.RawStage s = raws.get(i);
+      String base = "stages[" + i + "]";
+      if (s == null || s.id() == null || s.id().isBlank()) {
+        errors.add(eb.error(ErrorCode.WKS_CFG_001, "Stage entry requires 'id'", base + ".id"));
+        continue;
+      }
+      String id = s.id();
+      boolean idOk = true;
+      if (!STAGE_ID_PATTERN.matcher(id).matches()) {
+        errors.add(
+            eb.error(
+                ErrorCode.WKS_CFG_032, "Stage id must match [a-z][a-z0-9-]{0,62}", base + ".id"));
+        idOk = false;
+      }
+      if (idOk && RESERVED_STAGE_IDS.contains(id)) {
+        errors.add(
+            eb.error(
+                ErrorCode.WKS_CFG_033,
+                "Stage id '" + id + "' is reserved (reserved: " + RESERVED_STAGE_IDS + ")",
+                base + ".id"));
+        idOk = false;
+      }
+      if (idOk && !seen.add(id)) {
+        errors.add(eb.error(ErrorCode.WKS_CFG_031, "Duplicate stage id: " + id, base + ".id"));
+        idOk = false;
+      }
+      if (idOk) {
+        String displayName =
+            s.displayName() == null || s.displayName().isBlank()
+                ? toTitleCase(id)
+                : s.displayName();
+        // Story 3.1 code review S3 (2026-05-05): stage displayName shares the
+        // MAX_DISPLAY_NAME_CHARS=40 cap with field/status displayName (WKS-CFG-007). Catch the
+        // overflow at validate-time so it never reaches the column.
+        if (displayName.length() > CaseTypeLimits.MAX_DISPLAY_NAME_CHARS) {
+          errors.add(
+              eb.error(
+                  ErrorCode.WKS_CFG_007,
+                  "displayName must be ≤ " + CaseTypeLimits.MAX_DISPLAY_NAME_CHARS + " characters",
+                  base + ".displayName"));
+          continue;
+        }
+        out.add(new StageDefinition(id, displayName, i));
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Title-case a kebab-case stage id (Story 3.1 AC1): {@code "intake"} → {@code "Intake"}, {@code
+   * "loan-decision"} → {@code "Loan Decision"}.
+   */
+  private static String toTitleCase(String kebab) {
+    String[] parts = kebab.split("-");
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      if (parts[i].isEmpty()) {
+        continue;
+      }
+      if (sb.length() > 0) {
+        sb.append(' ');
+      }
+      sb.append(Character.toUpperCase(parts[i].charAt(0)));
+      if (parts[i].length() > 1) {
+        sb.append(parts[i].substring(1));
+      }
+    }
+    return sb.toString();
   }
 
   // ---- per-section checks -------------------------------------------------

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -1,5 +1,6 @@
 package com.wkspower.platform.infrastructure.config;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 
@@ -23,7 +24,8 @@ public record RawCaseTypeConfig(
     List<RawField> fields,
     List<RawStatus> statuses,
     List<String> listColumns,
-    List<RawRole> roles) {
+    List<RawRole> roles,
+    List<RawStage> stages) {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawWorkflow(String bpmn) {}
@@ -55,4 +57,47 @@ public record RawCaseTypeConfig(
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawRole(String name, List<String> permissions) {}
+
+  /**
+   * Story 3.1 — supports both YAML forms:
+   *
+   * <pre>
+   *   stages: [intake, underwriting]            # string-list form (each element parses via fromString)
+   *   stages:
+   *     - id: intake
+   *       displayName: "Intake"                  # rich-object form
+   * </pre>
+   *
+   * Jackson dispatches via {@link JsonCreator} on the matching type — string scalars hit {@link
+   * #fromString} and produce a {@code RawStage(id, null)}; mappings hit {@link #fromObject} via
+   * Jackson's default record deserialization.
+   */
+  /**
+   * Story 3.1 — wrapper record that supports BOTH YAML forms in a single list:
+   *
+   * <pre>
+   *   stages: [intake, underwriting]            # bare-string form
+   *   stages:
+   *     - id: intake
+   *       displayName: "Intake"                  # rich-object form
+   * </pre>
+   *
+   * <p>The string form lands via {@link #fromString} (single-arg DELEGATING creator); the object
+   * form lands via {@link #fromObject} (PROPERTIES creator). Both produce the same record shape so
+   * the validator can iterate uniformly.
+   */
+  public record RawStage(String id, String displayName) {
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static RawStage fromString(String id) {
+      return new RawStage(id, null);
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public static RawStage fromObject(
+        @com.fasterxml.jackson.annotation.JsonProperty("id") String id,
+        @com.fasterxml.jackson.annotation.JsonProperty("displayName") String displayName) {
+      return new RawStage(id, displayName);
+    }
+  }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/events/SpringEventPublisher.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/events/SpringEventPublisher.java
@@ -3,11 +3,17 @@ package com.wkspower.platform.infrastructure.events;
 import com.wkspower.platform.domain.port.EventPublisher;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
- * Spring-backed adapter for {@link EventPublisher}. Delegates to the framework's {@code
- * ApplicationEventPublisher}; in-process {@code @EventListener} beans receive events synchronously
- * by default — the SSE bridge (Story 4.3) attaches such a listener.
+ * Spring-backed adapter for {@link EventPublisher}. {@link #publish} delegates to the framework's
+ * {@code ApplicationEventPublisher}; in-process {@code @EventListener} beans receive events
+ * synchronously by default — the SSE bridge (Story 4.3) attaches such a listener.
+ *
+ * <p>{@link #publishAfterCommit} (Story 3.1) registers a {@link TransactionSynchronization} so the
+ * event lands only after the current transaction commits. Outside an active transaction (test
+ * harnesses, background work) it falls back to synchronous {@link #publish}.
  */
 @Component
 public class SpringEventPublisher implements EventPublisher {
@@ -21,5 +27,20 @@ public class SpringEventPublisher implements EventPublisher {
   @Override
   public void publish(Object event) {
     delegate.publishEvent(event);
+  }
+
+  @Override
+  public void publishAfterCommit(Object event) {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              delegate.publishEvent(event);
+            }
+          });
+    } else {
+      delegate.publishEvent(event);
+    }
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/StageRepositoryAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/StageRepositoryAdapter.java
@@ -1,0 +1,152 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.WksStageException;
+import com.wkspower.platform.domain.model.Stage;
+import com.wkspower.platform.domain.model.StageState;
+import com.wkspower.platform.domain.port.StageRepository;
+import com.wkspower.platform.infrastructure.persistence.entity.CaseStageHistoryEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseEntityRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseStageHistoryJpaRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Adapter for {@link StageRepository} (Story 3.1). Pure JPA — no engine package import (Decision
+ * 19: stage lifecycle is engine-agnostic). The optimistic-lock surface (AC8) is the conditional
+ * UPDATE methods on {@link CaseStageHistoryJpaRepository}; rowcount-zero raises {@code
+ * WKS-STG-003}.
+ */
+@Component
+class StageRepositoryAdapter implements StageRepository {
+
+  private final CaseStageHistoryJpaRepository history;
+  private final CaseEntityRepository cases;
+
+  StageRepositoryAdapter(CaseStageHistoryJpaRepository history, CaseEntityRepository cases) {
+    this.history = history;
+    this.cases = cases;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<Stage> loadHistory(UUID caseId) {
+    List<CaseStageHistoryEntity> rows = history.findByCaseIdOrderByOrdinalAsc(caseId);
+    List<Stage> out = new ArrayList<>(rows.size());
+    for (CaseStageHistoryEntity r : rows) {
+      out.add(toDomain(r));
+    }
+    return out;
+  }
+
+  @Override
+  @Transactional
+  public void materialiseStages(UUID caseId, List<StageDefinition> stages, Instant createdAt) {
+    if (stages == null || stages.isEmpty()) {
+      return;
+    }
+    for (StageDefinition s : stages) {
+      CaseStageHistoryEntity row =
+          new CaseStageHistoryEntity(
+              UUID.randomUUID(),
+              caseId,
+              s.id(),
+              s.ordinal(),
+              StageState.PENDING,
+              null,
+              null,
+              null,
+              null,
+              createdAt);
+      history.save(row);
+    }
+  }
+
+  @Override
+  @Transactional
+  public void appendTransition(Transition t) {
+    // 1) flip skipped intermediates first — keeps the active row visible if any of these miss.
+    for (SkippedStage skipped : t.skipped()) {
+      int rc =
+          history.conditionalUpdateSkip(
+              t.caseId(),
+              skipped.stageId(),
+              StageState.PENDING,
+              StageState.SKIPPED,
+              t.timestamp(),
+              t.source(),
+              t.sourceRef());
+      if (rc == 0) {
+        throw new WksStageException(
+            ErrorCode.WKS_STG_003,
+            "Concurrent stage transition on case "
+                + t.caseId()
+                + " (skipped intermediate '"
+                + skipped.stageId()
+                + "' was not in PENDING)");
+      }
+    }
+
+    // 2) flip the previously-active row to COMPLETED — null fromStageId means bootstrap (no prior
+    //    active row).
+    if (t.fromStageId() != null) {
+      int rc =
+          history.conditionalUpdateStateAndExitedAt(
+              t.caseId(), t.fromStageId(), StageState.ACTIVE, StageState.COMPLETED, t.timestamp());
+      if (rc == 0) {
+        throw new WksStageException(
+            ErrorCode.WKS_STG_003,
+            "Concurrent stage transition on case "
+                + t.caseId()
+                + " (stage '"
+                + t.fromStageId()
+                + "' was not ACTIVE)");
+      }
+    }
+
+    // 3) flip the new active row from PENDING → ACTIVE — null toStageId means last-stage
+    //    completion (no next row to activate).
+    if (t.toStageId() != null) {
+      int rc =
+          history.conditionalUpdateActivate(
+              t.caseId(),
+              t.toStageId(),
+              StageState.PENDING,
+              StageState.ACTIVE,
+              t.timestamp(),
+              t.source(),
+              t.sourceRef());
+      if (rc == 0) {
+        throw new WksStageException(
+            ErrorCode.WKS_STG_003,
+            "Concurrent stage transition on case "
+                + t.caseId()
+                + " (stage '"
+                + t.toStageId()
+                + "' was not PENDING)");
+      }
+    }
+
+    // 4) update the denormalised cache on cases. toStageId == null clears the cache (last stage
+    //    completed) so the case has no further head.
+    cases.updateStageCache(t.caseId(), t.toStageId(), t.toOrdinal());
+  }
+
+  private static Stage toDomain(CaseStageHistoryEntity e) {
+    return new Stage(
+        e.getId(),
+        e.getCaseId(),
+        e.getStageId(),
+        e.getOrdinal(),
+        e.getState(),
+        e.getEnteredAt(),
+        e.getExitedAt(),
+        e.getSource(),
+        e.getSourceRef());
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/CaseEntity.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/CaseEntity.java
@@ -43,6 +43,18 @@ public class CaseEntity extends BaseJpaEntity {
   @Column(name = "process_instance_id", length = 64)
   private String processInstanceId;
 
+  /**
+   * Story 3.1 — denormalised cache of the latest ACTIVE stage. {@code null} on zero-stage cases
+   * (CaseType declares no stages) and after the last stage is completed (Story 3.1 AC7).
+   * Authoritative state lives in {@code case_stage_history}; this column is rebuildable.
+   */
+  @Column(name = "current_stage_id", length = 64)
+  private String currentStageId;
+
+  /** Story 3.1 — convenience companion to {@link #currentStageId} for ordering / fast lookup. */
+  @Column(name = "current_stage_ordinal")
+  private Integer currentStageOrdinal;
+
   @Column(name = "created_by", nullable = false)
   private UUID createdBy;
 
@@ -119,6 +131,22 @@ public class CaseEntity extends BaseJpaEntity {
 
   public void setProcessInstanceId(String processInstanceId) {
     this.processInstanceId = processInstanceId;
+  }
+
+  public String getCurrentStageId() {
+    return currentStageId;
+  }
+
+  public void setCurrentStageId(String currentStageId) {
+    this.currentStageId = currentStageId;
+  }
+
+  public Integer getCurrentStageOrdinal() {
+    return currentStageOrdinal;
+  }
+
+  public void setCurrentStageOrdinal(Integer currentStageOrdinal) {
+    this.currentStageOrdinal = currentStageOrdinal;
   }
 
   public UUID getCreatedBy() {

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/CaseStageHistoryEntity.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/CaseStageHistoryEntity.java
@@ -1,0 +1,128 @@
+package com.wkspower.platform.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * JPA entity for the append-only stage history table (Story 3.1 AC3). Inherits id / version / audit
+ * timestamps from {@link BaseJpaEntity}; owns the case-stage-specific columns.
+ *
+ * <p>The {@link com.wkspower.platform.domain.model.StageState} enum maps via {@link
+ * Enumerated.STRING} so the wire string ({@code PENDING}/{@code ACTIVE}/{@code COMPLETED}/{@code
+ * SKIPPED}) lands as readable VARCHAR rather than an ordinal — keeps post-mortem SQL queries
+ * grep-friendly.
+ */
+@Entity
+@Table(name = "case_stage_history")
+public class CaseStageHistoryEntity extends BaseJpaEntity {
+
+  @Column(name = "case_id", nullable = false)
+  private UUID caseId;
+
+  @Column(name = "stage_id", length = 64, nullable = false)
+  private String stageId;
+
+  @Column(name = "ordinal", nullable = false)
+  private int ordinal;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "state", length = 16, nullable = false)
+  private com.wkspower.platform.domain.model.StageState state;
+
+  @Column(name = "entered_at")
+  private Instant enteredAt;
+
+  @Column(name = "exited_at")
+  private Instant exitedAt;
+
+  @Column(name = "source", length = 32)
+  private String source;
+
+  @Column(name = "source_ref", length = 128)
+  private String sourceRef;
+
+  protected CaseStageHistoryEntity() {
+    // JPA
+  }
+
+  public CaseStageHistoryEntity(
+      UUID id,
+      UUID caseId,
+      String stageId,
+      int ordinal,
+      com.wkspower.platform.domain.model.StageState state,
+      Instant enteredAt,
+      Instant exitedAt,
+      String source,
+      String sourceRef,
+      Instant createdAt) {
+    super(id);
+    this.caseId = caseId;
+    this.stageId = stageId;
+    this.ordinal = ordinal;
+    this.state = state;
+    this.enteredAt = enteredAt;
+    this.exitedAt = exitedAt;
+    this.source = source;
+    this.sourceRef = sourceRef;
+    setCreatedAt(createdAt);
+    setUpdatedAt(createdAt);
+  }
+
+  public UUID getCaseId() {
+    return caseId;
+  }
+
+  public String getStageId() {
+    return stageId;
+  }
+
+  public int getOrdinal() {
+    return ordinal;
+  }
+
+  public com.wkspower.platform.domain.model.StageState getState() {
+    return state;
+  }
+
+  public void setState(com.wkspower.platform.domain.model.StageState state) {
+    this.state = state;
+  }
+
+  public Instant getEnteredAt() {
+    return enteredAt;
+  }
+
+  public void setEnteredAt(Instant enteredAt) {
+    this.enteredAt = enteredAt;
+  }
+
+  public Instant getExitedAt() {
+    return exitedAt;
+  }
+
+  public void setExitedAt(Instant exitedAt) {
+    this.exitedAt = exitedAt;
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  public void setSource(String source) {
+    this.source = source;
+  }
+
+  public String getSourceRef() {
+    return sourceRef;
+  }
+
+  public void setSourceRef(String sourceRef) {
+    this.sourceRef = sourceRef;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseEntityRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseEntityRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -32,4 +33,21 @@ public interface CaseEntityRepository extends JpaRepository<CaseEntity, UUID> {
    */
   @Query("SELECT c FROM CaseEntity c WHERE c.id IN :ids")
   List<CaseEntity> findDataByIds(@Param("ids") Collection<UUID> ids);
+
+  /**
+   * Update the denormalised stage-cache columns on the {@code cases} row (Story 3.1). Bypasses the
+   * {@code @Version} optimistic lock by design — stage transitions own their own concurrency
+   * surface via {@link CaseStageHistoryJpaRepository}'s conditional updates; the {@code cases}
+   * cache is just a follower.
+   */
+  @Modifying
+  @Query(
+      "UPDATE CaseEntity c "
+          + "   SET c.currentStageId = :stageId, "
+          + "       c.currentStageOrdinal = :ordinal "
+          + " WHERE c.id = :caseId")
+  int updateStageCache(
+      @Param("caseId") UUID caseId,
+      @Param("stageId") String stageId,
+      @Param("ordinal") Integer ordinal);
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseStageHistoryJpaRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseStageHistoryJpaRepository.java
@@ -1,0 +1,86 @@
+package com.wkspower.platform.infrastructure.persistence.repository;
+
+import com.wkspower.platform.domain.model.StageState;
+import com.wkspower.platform.infrastructure.persistence.entity.CaseStageHistoryEntity;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Spring Data repository for {@link CaseStageHistoryEntity} (Story 3.1). The conditional UPDATE
+ * methods are the optimistic-lock surface for AC8 — each pivots on a previous {@link StageState} so
+ * concurrent transitions cannot both succeed.
+ */
+public interface CaseStageHistoryJpaRepository extends JpaRepository<CaseStageHistoryEntity, UUID> {
+
+  List<CaseStageHistoryEntity> findByCaseIdOrderByOrdinalAsc(UUID caseId);
+
+  /**
+   * Conditional UPDATE pivoting on the previous state — used to flip ACTIVE → COMPLETED. Returns
+   * the rowcount; the adapter raises {@code WKS-STG-003} when zero.
+   */
+  @Modifying
+  @Query(
+      "UPDATE CaseStageHistoryEntity h "
+          + "   SET h.state = :newState, h.exitedAt = :exitedAt "
+          + " WHERE h.caseId = :caseId "
+          + "   AND h.stageId = :stageId "
+          + "   AND h.state = :expectedState")
+  int conditionalUpdateStateAndExitedAt(
+      @Param("caseId") UUID caseId,
+      @Param("stageId") String stageId,
+      @Param("expectedState") StageState expectedState,
+      @Param("newState") StageState newState,
+      @Param("exitedAt") Instant exitedAt);
+
+  /**
+   * Conditional UPDATE pivoting on PENDING — flips PENDING → ACTIVE while stamping {@code
+   * entered_at}, {@code source}, {@code source_ref}.
+   */
+  @Modifying
+  @Query(
+      "UPDATE CaseStageHistoryEntity h "
+          + "   SET h.state = :newState, "
+          + "       h.enteredAt = :enteredAt, "
+          + "       h.source = :source, "
+          + "       h.sourceRef = :sourceRef "
+          + " WHERE h.caseId = :caseId "
+          + "   AND h.stageId = :stageId "
+          + "   AND h.state = :expectedState")
+  int conditionalUpdateActivate(
+      @Param("caseId") UUID caseId,
+      @Param("stageId") String stageId,
+      @Param("expectedState") StageState expectedState,
+      @Param("newState") StageState newState,
+      @Param("enteredAt") Instant enteredAt,
+      @Param("source") String source,
+      @Param("sourceRef") String sourceRef);
+
+  /**
+   * Conditional UPDATE pivoting on PENDING — flips PENDING → SKIPPED while stamping {@code
+   * exited_at}, {@code source}, {@code source_ref}. {@code entered_at} stays NULL — these rows were
+   * never active.
+   */
+  @Modifying
+  @Query(
+      "UPDATE CaseStageHistoryEntity h "
+          + "   SET h.state = :newState, "
+          + "       h.exitedAt = :exitedAt, "
+          + "       h.source = :source, "
+          + "       h.sourceRef = :sourceRef "
+          + " WHERE h.caseId = :caseId "
+          + "   AND h.stageId = :stageId "
+          + "   AND h.state = :expectedState")
+  int conditionalUpdateSkip(
+      @Param("caseId") UUID caseId,
+      @Param("stageId") String stageId,
+      @Param("expectedState") StageState expectedState,
+      @Param("newState") StageState newState,
+      @Param("exitedAt") Instant exitedAt,
+      @Param("source") String source,
+      @Param("sourceRef") String sourceRef);
+}

--- a/backend/src/main/resources/db/migration/common/V202605050001__case_stage_history.sql
+++ b/backend/src/main/resources/db/migration/common/V202605050001__case_stage_history.sql
@@ -1,0 +1,38 @@
+-- Story 3.1 — Stage Entity & Lifecycle (post-pivot Decision 19).
+-- Append-only stage history table + denormalised cache columns on `cases`. The history table is
+-- authoritative; `cases.current_stage_id` / `current_stage_ordinal` are rebuildable from it at any
+-- time. H2 + Postgres compatible (no JSONB, no Postgres-specific syntax) — sits in
+-- db/migration/common/ per Story 3.1 AC3.
+--
+-- Concurrency: AC8's optimistic-lock surface is a conditional UPDATE on (case_id, stage_id, state)
+-- in StageRepositoryAdapter.appendTransition — no @Version column needed on this table. The
+-- adapter pivots on the previous state; rowcount = 0 raises WKS-STG-003.
+--
+-- Zero-tenant invariant (D25) — Story 3.0 lint scans this file; no per-customer column appears.
+
+CREATE TABLE case_stage_history (
+    id           UUID                     PRIMARY KEY,
+    case_id      UUID                     NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+    stage_id     VARCHAR(64)              NOT NULL,
+    ordinal      INTEGER                  NOT NULL,
+    state        VARCHAR(16)              NOT NULL,
+    entered_at   TIMESTAMP WITH TIME ZONE,
+    exited_at    TIMESTAMP WITH TIME ZONE,
+    source       VARCHAR(32),
+    source_ref   VARCHAR(128),
+    -- BaseJpaEntity contributes id / version / created_at / updated_at — keep the column shape
+    -- in sync so Hibernate schema-validation (run by the IT lane) matches the JPA mapping.
+    version      BIGINT                   NOT NULL DEFAULT 0,
+    created_at   TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at   TIMESTAMP WITH TIME ZONE NOT NULL,
+    -- Natural-key uniqueness — `entered_at` is NULLable for PENDING / SKIPPED rows that never
+    -- went active; the (case_id, stage_id) pair is unique within a case, so the simpler form
+    -- below is sufficient and avoids surprises with NULL semantics across H2 / Postgres.
+    UNIQUE (case_id, stage_id)
+);
+
+CREATE INDEX idx_case_stage_history_case_id    ON case_stage_history (case_id);
+CREATE INDEX idx_case_stage_history_case_state ON case_stage_history (case_id, state);
+
+ALTER TABLE cases ADD COLUMN current_stage_id      VARCHAR(64);
+ALTER TABLE cases ADD COLUMN current_stage_ordinal INTEGER;

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
@@ -72,6 +72,11 @@ class CaseControllerTest {
   @MockitoBean(name = "wksTaskService")
   com.wkspower.platform.domain.service.TaskService taskService;
 
+  @MockitoBean(name = "wksStageAdvancer")
+  com.wkspower.platform.domain.service.WksStageAdvancer stageAdvancer;
+
+  @MockitoBean com.wkspower.platform.domain.port.StageRepository stageRepository;
+
   @MockitoBean(name = "caseTypePermissionEvaluator")
   CaseTypePermissionEvaluator caseTypePermissionEvaluator;
 
@@ -335,6 +340,41 @@ class CaseControllerTest {
                 .content("{\"data\":{\"name\":\"Bob\"},\"version\":99}"))
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.error.code").value("WKS-RTM-409"));
+  }
+
+  // ---- POST /api/cases/{id}/advance-stage & /skip-stage (Story 3.1 AC10) -
+
+  @Test
+  void advanceStageReturns404WithStg004WhenCaseUnknown() throws Exception {
+    // Story 3.1 code review S2 (2026-05-05): unknown caseId on stage endpoints must surface
+    // WKS-STG-004 (the wire-contract code for "advance/skip references unknown caseId"), not the
+    // generic WKS-API-404 from the loaded-first findById precheck.
+    UUID id = UUID.randomUUID();
+    when(caseService.findById(id)).thenThrow(new WksNotFoundException("missing"));
+
+    mockMvc
+        .perform(
+            post("/api/cases/" + id + "/advance-stage")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("WKS-STG-004"));
+  }
+
+  @Test
+  void skipStageReturns404WithStg004WhenCaseUnknown() throws Exception {
+    UUID id = UUID.randomUUID();
+    when(caseService.findById(id)).thenThrow(new WksNotFoundException("missing"));
+
+    mockMvc
+        .perform(
+            post("/api/cases/" + id + "/skip-stage")
+                .with(officerAuth())
+                .contentType("application/json")
+                .content("{\"targetStageId\":\"decision\"}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error.code").value("WKS-STG-004"));
   }
 
   // ---- helpers -----------------------------------------------------------

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
@@ -62,6 +62,11 @@ class CaseTransitionControllerTest {
   @MockitoBean(name = "wksTaskService")
   com.wkspower.platform.domain.service.TaskService taskService;
 
+  @MockitoBean(name = "wksStageAdvancer")
+  com.wkspower.platform.domain.service.WksStageAdvancer stageAdvancer;
+
+  @MockitoBean com.wkspower.platform.domain.port.StageRepository stageRepository;
+
   @MockitoBean(name = "caseTypePermissionEvaluator")
   CaseTypePermissionEvaluator evaluator;
 

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
@@ -8,6 +8,7 @@ import com.wkspower.platform.domain.config.model.FieldDefinition;
 import com.wkspower.platform.domain.config.model.FieldType;
 import com.wkspower.platform.domain.config.model.Permission;
 import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
 import com.wkspower.platform.domain.config.model.StatusColor;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.domain.config.model.WorkflowRef;
@@ -28,6 +29,7 @@ import com.wkspower.platform.domain.port.CaseRepository;
 import com.wkspower.platform.domain.port.CaseTypeReader;
 import com.wkspower.platform.domain.port.EventPublisher;
 import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
+import com.wkspower.platform.domain.port.StageRepository;
 import com.wkspower.platform.domain.port.WorkflowEngine;
 import com.wkspower.platform.domain.workflow.DeploymentInfo;
 import com.wkspower.platform.domain.workflow.DeploymentRequest;
@@ -67,8 +69,10 @@ class CaseServiceTest {
   }
 
   private CaseService svc(CaseTypeConfig config) {
+    WksStageAdvancer advancer =
+        new WksStageAdvancer(new NoopStageRepository(), publisher, () -> FIXED);
     return new CaseService(
-        repo, reader(config), validator, engine, resolver, publisher, () -> FIXED);
+        repo, reader(config), validator, engine, resolver, publisher, () -> FIXED, advancer);
   }
 
   @Test
@@ -332,6 +336,24 @@ class CaseServiceTest {
     public void publish(Object event) {
       events.add(event);
     }
+  }
+
+  /**
+   * Stage repo stub — never persists, returns empty history. CaseService stubs use zero-stage
+   * CaseTypes.
+   */
+  private static final class NoopStageRepository implements StageRepository {
+    @Override
+    public List<com.wkspower.platform.domain.model.Stage> loadHistory(UUID caseId) {
+      return List.of();
+    }
+
+    @Override
+    public void materialiseStages(
+        UUID caseId, List<StageDefinition> stages, java.time.Instant createdAt) {}
+
+    @Override
+    public void appendTransition(Transition transition) {}
   }
 
   private static final class StubResolver implements ProcessDefinitionKeyResolver {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/WksStageAdvancerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/WksStageAdvancerTest.java
@@ -1,0 +1,249 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.event.StageEntered;
+import com.wkspower.platform.domain.event.StageExited;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.WksStageException;
+import com.wkspower.platform.domain.model.Stage;
+import com.wkspower.platform.domain.model.StageState;
+import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.StageRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-Java enumeration of {@link WksStageAdvancer} branches (Story 3.1 AC2/AC4–AC9). Stubs the
+ * {@link StageRepository} port so the test exercises the domain decision logic without JPA. The IT
+ * class covers the SQL conditional-update concurrency surface.
+ */
+class WksStageAdvancerTest {
+
+  private static final UUID CASE = UUID.randomUUID();
+  private static final Instant FIXED = Instant.parse("2026-05-05T12:00:00Z");
+
+  private FakeRepo repo;
+  private RecordingPublisher publisher;
+  private WksStageAdvancer advancer;
+
+  @BeforeEach
+  void resetStubs() {
+    repo = new FakeRepo();
+    publisher = new RecordingPublisher();
+    advancer = new WksStageAdvancer(repo, publisher, () -> FIXED);
+  }
+
+  @Test
+  void bootstrapEmptyStageListIsNoOp() {
+    advancer.bootstrap(CASE, List.of(), "wks-auto-rule", "case-create");
+
+    assertThat(repo.materialised).isEmpty();
+    assertThat(repo.transitions).isEmpty();
+    assertThat(publisher.events).isEmpty();
+  }
+
+  @Test
+  void bootstrapMaterialisesStagesAndActivatesFirst() {
+    var stages = stages3();
+    advancer.bootstrap(CASE, stages, "wks-auto-rule", "case-create");
+
+    assertThat(repo.materialised).hasSize(1);
+    assertThat(repo.materialised.get(0)).isEqualTo(stages);
+    assertThat(repo.transitions).hasSize(1);
+    var t = repo.transitions.get(0);
+    assertThat(t.fromStageId()).isNull();
+    assertThat(t.toStageId()).isEqualTo("intake");
+    assertThat(t.toOrdinal()).isZero();
+    assertThat(publisher.events).hasSize(1);
+    assertThat(publisher.events.get(0)).isInstanceOf(StageEntered.class);
+    StageEntered ev = (StageEntered) publisher.events.get(0);
+    assertThat(ev.stageId()).isEqualTo("intake");
+    assertThat(ev.source()).isEqualTo("wks-auto-rule");
+    assertThat(ev.sourceRef()).isEqualTo("case-create");
+  }
+
+  @Test
+  void advanceMovesToNextStageAndEmitsBothEvents() {
+    repo.history =
+        List.of(
+            stage("intake", 0, StageState.ACTIVE),
+            stage("review", 1, StageState.PENDING),
+            stage("decision", 2, StageState.PENDING));
+
+    advancer.advance(CASE, "manual", "user-1");
+
+    assertThat(repo.transitions).hasSize(1);
+    var t = repo.transitions.get(0);
+    assertThat(t.fromStageId()).isEqualTo("intake");
+    assertThat(t.toStageId()).isEqualTo("review");
+    assertThat(t.toOrdinal()).isEqualTo(1);
+
+    assertThat(publisher.events).hasSize(2);
+    assertThat(publisher.events.get(0)).isInstanceOf(StageExited.class);
+    assertThat(publisher.events.get(1)).isInstanceOf(StageEntered.class);
+    assertThat(((StageExited) publisher.events.get(0)).stageId()).isEqualTo("intake");
+    assertThat(((StageEntered) publisher.events.get(1)).stageId()).isEqualTo("review");
+  }
+
+  @Test
+  void lastStageAdvanceCompletesAndClearsHead() {
+    repo.history =
+        List.of(
+            stage("intake", 0, StageState.COMPLETED),
+            stage("review", 1, StageState.COMPLETED),
+            stage("decision", 2, StageState.ACTIVE));
+
+    advancer.advance(CASE, "manual", null);
+
+    var t = repo.transitions.get(0);
+    assertThat(t.fromStageId()).isEqualTo("decision");
+    assertThat(t.toStageId()).isNull();
+    assertThat(t.toOrdinal()).isNull();
+
+    assertThat(publisher.events).hasSize(1);
+    assertThat(publisher.events.get(0)).isInstanceOf(StageExited.class);
+    assertThat(((StageExited) publisher.events.get(0)).stageId()).isEqualTo("decision");
+  }
+
+  @Test
+  void advanceWhenAllCompletedRaisesStg001() {
+    repo.history =
+        List.of(
+            stage("intake", 0, StageState.COMPLETED), stage("decision", 1, StageState.COMPLETED));
+
+    assertThatThrownBy(() -> advancer.advance(CASE, "manual", null))
+        .isInstanceOf(WksStageException.class)
+        .satisfies(ex -> assertThat(((WksStageException) ex).getCode()).isEqualTo("WKS-STG-001"));
+  }
+
+  @Test
+  void advanceOnZeroStageCaseRaisesStg001() {
+    repo.history = List.of();
+
+    assertThatThrownBy(() -> advancer.advance(CASE, "manual", null))
+        .isInstanceOf(WksStageException.class)
+        .satisfies(ex -> assertThat(((WksStageException) ex).getCode()).isEqualTo("WKS-STG-001"));
+  }
+
+  @Test
+  void skipToFutureMarksIntermediatesSkipped() {
+    repo.history =
+        List.of(
+            stage("intake", 0, StageState.ACTIVE),
+            stage("review", 1, StageState.PENDING),
+            stage("decision", 2, StageState.PENDING));
+
+    advancer.skipTo(CASE, "decision", "manual", null);
+
+    var t = repo.transitions.get(0);
+    assertThat(t.fromStageId()).isEqualTo("intake");
+    assertThat(t.toStageId()).isEqualTo("decision");
+    assertThat(t.skipped()).hasSize(1);
+    assertThat(t.skipped().get(0).stageId()).isEqualTo("review");
+
+    assertThat(publisher.events).hasSize(2);
+    assertThat(publisher.events.get(0)).isInstanceOf(StageExited.class);
+    assertThat(publisher.events.get(1)).isInstanceOf(StageEntered.class);
+    // No StageEntered / StageExited for the skipped intermediate.
+  }
+
+  @Test
+  void backwardSkipRaisesStg002() {
+    repo.history =
+        List.of(
+            stage("intake", 0, StageState.COMPLETED),
+            stage("review", 1, StageState.ACTIVE),
+            stage("decision", 2, StageState.PENDING));
+
+    assertThatThrownBy(() -> advancer.skipTo(CASE, "intake", "manual", null))
+        .isInstanceOf(WksStageException.class)
+        .satisfies(ex -> assertThat(((WksStageException) ex).getCode()).isEqualTo("WKS-STG-002"));
+  }
+
+  @Test
+  void skipToUnknownStageRaisesStg002() {
+    repo.history =
+        List.of(stage("intake", 0, StageState.ACTIVE), stage("review", 1, StageState.PENDING));
+
+    assertThatThrownBy(() -> advancer.skipTo(CASE, "no-such", "manual", null))
+        .isInstanceOf(WksStageException.class)
+        .satisfies(ex -> assertThat(((WksStageException) ex).getCode()).isEqualTo("WKS-STG-002"));
+  }
+
+  @Test
+  void nullSourceRejected() {
+    assertThatThrownBy(() -> advancer.bootstrap(CASE, stages3(), null, "x"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void invalidSourceRejected() {
+    assertThatThrownBy(() -> advancer.bootstrap(CASE, stages3(), "ai", "x"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void concurrentMissPropagatedAsStg003() {
+    repo.failOnAppend = ErrorCode.WKS_STG_003;
+    repo.history =
+        List.of(stage("intake", 0, StageState.ACTIVE), stage("r", 1, StageState.PENDING));
+
+    assertThatThrownBy(() -> advancer.advance(CASE, "manual", null))
+        .isInstanceOf(WksStageException.class)
+        .satisfies(ex -> assertThat(((WksStageException) ex).getCode()).isEqualTo("WKS-STG-003"));
+  }
+
+  // ---- helpers ----
+
+  private static List<StageDefinition> stages3() {
+    return List.of(
+        new StageDefinition("intake", "Intake", 0),
+        new StageDefinition("review", "Review", 1),
+        new StageDefinition("decision", "Decision", 2));
+  }
+
+  private static Stage stage(String id, int ordinal, StageState state) {
+    return new Stage(UUID.randomUUID(), CASE, id, ordinal, state, null, null, null, null);
+  }
+
+  private static final class FakeRepo implements StageRepository {
+    List<Stage> history = new ArrayList<>();
+    final List<List<StageDefinition>> materialised = new ArrayList<>();
+    final List<Transition> transitions = new ArrayList<>();
+    ErrorCode failOnAppend = null;
+
+    @Override
+    public List<Stage> loadHistory(UUID caseId) {
+      return List.copyOf(history);
+    }
+
+    @Override
+    public void materialiseStages(UUID caseId, List<StageDefinition> stages, Instant createdAt) {
+      materialised.add(List.copyOf(stages));
+    }
+
+    @Override
+    public void appendTransition(Transition t) {
+      if (failOnAppend != null) {
+        throw new WksStageException(failOnAppend, "stub concurrent miss");
+      }
+      transitions.add(t);
+    }
+  }
+
+  private static final class RecordingPublisher implements EventPublisher {
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public void publish(Object event) {
+      events.add(event);
+    }
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorStagesTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorStagesTest.java
@@ -1,0 +1,210 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.ValidationResult;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 3.1 — extends {@link ConfigValidatorTest} surface with stage-grammar tests. The original
+ * file has the GREEN_YAML constant; this class stays self-contained to avoid editing the existing
+ * test class structure.
+ */
+class ConfigValidatorStagesTest {
+
+  private final CaseTypeYamlLoader loader = new CaseTypeYamlLoader();
+  private final ConfigValidator validator = new ConfigValidator();
+
+  // ---- legal forms ----
+
+  @Test
+  void omittedStagesProducesEmptyList() {
+    var r = validate(GREEN);
+    assertThat(r.isInvalid()).isFalse();
+    assertThat(r.config().get().stages()).isEmpty();
+  }
+
+  @Test
+  void emptyStagesArrayIsLegal() {
+    var r =
+        validate(
+            GREEN.replace(
+                "listColumns: [applicant_name]", "stages: []\nlistColumns: [applicant_name]"));
+    assertThat(r.isInvalid()).isFalse();
+    assertThat(r.config().get().stages()).isEmpty();
+  }
+
+  @Test
+  void stringListFormParsesWithDefaultDisplayName() {
+    var r =
+        validate(
+            GREEN.replace(
+                "listColumns: [applicant_name]",
+                "stages: [intake, loan-decision]\nlistColumns: [applicant_name]"));
+    assertThat(r.isInvalid()).isFalse();
+    List<StageDefinition> stages = r.config().get().stages();
+    assertThat(stages).hasSize(2);
+    assertThat(stages.get(0).id()).isEqualTo("intake");
+    assertThat(stages.get(0).ordinal()).isEqualTo(0);
+    assertThat(stages.get(0).displayName()).isEqualTo("Intake");
+    assertThat(stages.get(1).id()).isEqualTo("loan-decision");
+    assertThat(stages.get(1).ordinal()).isEqualTo(1);
+    assertThat(stages.get(1).displayName()).isEqualTo("Loan Decision");
+  }
+
+  @Test
+  void richObjectFormPreservesExplicitDisplayName() {
+    String yaml =
+        GREEN.replace(
+            "listColumns: [applicant_name]",
+            "stages:\n"
+                + "  - id: intake\n"
+                + "    displayName: \"Custom Intake\"\n"
+                + "  - id: review\n"
+                + "listColumns: [applicant_name]");
+    var r = validate(yaml);
+    assertThat(r.isInvalid()).isFalse();
+    var stages = r.config().get().stages();
+    assertThat(stages).hasSize(2);
+    assertThat(stages.get(0).displayName()).isEqualTo("Custom Intake");
+    assertThat(stages.get(1).displayName()).isEqualTo("Review");
+  }
+
+  // ---- WKS-CFG-031 duplicate stage id ----
+
+  @Test
+  void wksCfg031_duplicateStageId() {
+    var r =
+        validate(
+            GREEN.replace(
+                "listColumns: [applicant_name]",
+                "stages: [intake, intake]\nlistColumns: [applicant_name]"));
+    assertThat(r.isInvalid()).isTrue();
+    assertThat(r.errors().stream().map(e -> e.code())).contains("WKS-CFG-031");
+  }
+
+  // ---- WKS-CFG-032 invalid pattern ----
+
+  @Test
+  void wksCfg032_invalidStageIdPattern() {
+    var r =
+        validate(
+            GREEN.replace(
+                "listColumns: [applicant_name]",
+                "stages: [\"Intake!\"]\nlistColumns: [applicant_name]"));
+    assertThat(r.isInvalid()).isTrue();
+    assertThat(r.errors().stream().map(e -> e.code())).contains("WKS-CFG-032");
+  }
+
+  // ---- WKS-CFG-033 reserved word ----
+
+  @Test
+  void wksCfg033_reservedWordCase() {
+    var r =
+        validate(
+            GREEN.replace(
+                "listColumns: [applicant_name]", "stages: [case]\nlistColumns: [applicant_name]"));
+    assertThat(r.isInvalid()).isTrue();
+    assertThat(r.errors().stream().map(e -> e.code())).contains("WKS-CFG-033");
+  }
+
+  @Test
+  void wksCfg033_reservedWordStage() {
+    var r =
+        validate(
+            GREEN.replace(
+                "listColumns: [applicant_name]", "stages: [stage]\nlistColumns: [applicant_name]"));
+    assertThat(r.isInvalid()).isTrue();
+    assertThat(r.errors().stream().map(e -> e.code())).contains("WKS-CFG-033");
+  }
+
+  // ---- WKS-CFG-007 stage displayName length (Story 3.1 code review S3) ----
+
+  @Test
+  void wksCfg007_stageDisplayNameOver40Chars() {
+    String tooLong = "X".repeat(41);
+    String yaml =
+        GREEN.replace(
+            "listColumns: [applicant_name]",
+            "stages:\n"
+                + "  - id: intake\n"
+                + "    displayName: \""
+                + tooLong
+                + "\"\n"
+                + "listColumns: [applicant_name]");
+    var r = validate(yaml);
+    assertThat(r.isInvalid()).isTrue();
+    assertThat(r.errors().stream().map(e -> e.code())).contains("WKS-CFG-007");
+    assertThat(r.errors().stream().map(e -> e.field()))
+        .anyMatch(f -> f != null && f.endsWith(".displayName"));
+  }
+
+  @Test
+  void wksCfg007_stageDisplayNameAt40CharsAccepted() {
+    String exact = "Y".repeat(40);
+    String yaml =
+        GREEN.replace(
+            "listColumns: [applicant_name]",
+            "stages:\n"
+                + "  - id: intake\n"
+                + "    displayName: \""
+                + exact
+                + "\"\n"
+                + "listColumns: [applicant_name]");
+    var r = validate(yaml);
+    assertThat(r.isInvalid()).isFalse();
+    assertThat(r.config().get().stages().get(0).displayName()).isEqualTo(exact);
+  }
+
+  // ---- AC12 §9 — collect-all combo ----
+
+  @Test
+  void collectsAllThreeStageErrorsInOnePass() {
+    var r =
+        validate(
+            GREEN.replace(
+                "listColumns: [applicant_name]",
+                "stages:\n"
+                    + "  - id: intake\n"
+                    + "  - id: intake\n" // duplicate -> WKS-CFG-031
+                    + "  - id: \"Bad Stage\"\n" // pattern -> WKS-CFG-032
+                    + "  - id: case\n" // reserved -> WKS-CFG-033
+                    + "listColumns: [applicant_name]"));
+    assertThat(r.isInvalid()).isTrue();
+    var codes = r.errors().stream().map(e -> e.code()).distinct().toList();
+    assertThat(codes).contains("WKS-CFG-031", "WKS-CFG-032", "WKS-CFG-033");
+  }
+
+  // ---- helpers ----
+
+  private ValidationResult validate(String yaml) {
+    var read = loader.readBytes("test", yaml.getBytes(StandardCharsets.UTF_8));
+    if (!read.isParsed()) {
+      return ValidationResult.invalid(read.errors());
+    }
+    return validator.validate(read.raw(), read.lines());
+  }
+
+  private static final String GREEN =
+      """
+      id: loan-application
+      displayName: Loan Application
+      version: 1
+      workflow:
+        bpmn: loan-application.bpmn
+      fields:
+        - id: applicant_name
+          displayName: Applicant name
+          type: text
+      statuses:
+        - id: open
+          displayName: Open
+      listColumns: [applicant_name]
+      roles:
+        - name: officer
+          permissions: [view, create]
+      """;
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/StageRepositoryAdapterIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/StageRepositoryAdapterIT.java
@@ -1,0 +1,227 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.exception.WksStageException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.Stage;
+import com.wkspower.platform.domain.model.StageState;
+import com.wkspower.platform.domain.port.StageRepository;
+import com.wkspower.platform.infrastructure.persistence.entity.RoleEntity;
+import com.wkspower.platform.infrastructure.persistence.entity.UserEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseEntityRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseStageHistoryJpaRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.RoleEntityRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.UserEntityRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * {@code @DataJpaTest} IT for {@link StageRepositoryAdapter} (Story 3.1 AC3, AC5, AC6, AC8). Uses
+ * the H2 dev database the existing CaseRepository IT runs against. Postgres-IT parity is a Phase-1
+ * follow-up — the migration is in {@code db/migration/common/} so both databases will run the same
+ * SQL once the dual-IT lane is wired.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({StageRepositoryAdapter.class, CaseRepositoryAdapter.class})
+@ActiveProfiles("dev")
+class StageRepositoryAdapterIT {
+
+  @Autowired StageRepositoryAdapter adapter;
+  @Autowired CaseRepositoryAdapter caseAdapter;
+  @Autowired CaseStageHistoryJpaRepository historyRepo;
+  @Autowired CaseEntityRepository caseRepo;
+  @Autowired UserEntityRepository userRepo;
+  @Autowired RoleEntityRepository roleRepo;
+  @Autowired EntityManager em;
+
+  private UUID actorId;
+  private static final Instant NOW = Instant.parse("2026-05-05T12:00:00Z");
+
+  private static final List<StageDefinition> THREE =
+      List.of(
+          new StageDefinition("intake", "Intake", 0),
+          new StageDefinition("review", "Review", 1),
+          new StageDefinition("decision", "Decision", 2));
+
+  @BeforeEach
+  void seedUser() {
+    RoleEntity role =
+        roleRepo
+            .findByName("admin")
+            .orElseGet(
+                () ->
+                    roleRepo.save(
+                        new RoleEntity(UUID.randomUUID(), "admin", Instant.now(), Instant.now())));
+    UserEntity u =
+        userRepo.save(
+            new UserEntity(
+                UUID.randomUUID(),
+                "stage-it-" + UUID.randomUUID() + "@x",
+                "x",
+                true,
+                Instant.now(),
+                Instant.now(),
+                new HashSet<>(List.of(role))));
+    actorId = u.getId();
+  }
+
+  @Test
+  void materialiseAndBootstrapTransitionFlipsFirstToActive() {
+    UUID caseId = newCase();
+
+    adapter.materialiseStages(caseId, THREE, NOW);
+    flushClear();
+
+    List<Stage> hist = adapter.loadHistory(caseId);
+    assertThat(hist).hasSize(3);
+    assertThat(hist).allMatch(s -> s.state() == StageState.PENDING);
+
+    adapter.appendTransition(
+        new StageRepository.Transition(
+            caseId, null, null, "intake", 0, List.of(), "wks-auto-rule", "case-create", NOW));
+    flushClear();
+
+    List<Stage> after = adapter.loadHistory(caseId);
+    assertThat(after.get(0).state()).isEqualTo(StageState.ACTIVE);
+    assertThat(after.get(0).enteredAt()).isEqualTo(NOW);
+    assertThat(after.get(1).state()).isEqualTo(StageState.PENDING);
+    assertThat(after.get(2).state()).isEqualTo(StageState.PENDING);
+
+    // current_stage_id cache populated.
+    var cached = caseRepo.findById(caseId).orElseThrow();
+    assertThat(cached.getCurrentStageId()).isEqualTo("intake");
+    assertThat(cached.getCurrentStageOrdinal()).isZero();
+  }
+
+  @Test
+  void linearAdvanceCompletesPriorActivatesNext() {
+    UUID caseId = bootstrapped();
+
+    adapter.appendTransition(
+        new StageRepository.Transition(
+            caseId, "intake", 0, "review", 1, List.of(), "manual", "u1", NOW.plusSeconds(60)));
+    flushClear();
+
+    var hist = adapter.loadHistory(caseId);
+    assertThat(hist.get(0).state()).isEqualTo(StageState.COMPLETED);
+    assertThat(hist.get(0).exitedAt()).isNotNull();
+    assertThat(hist.get(1).state()).isEqualTo(StageState.ACTIVE);
+    assertThat(hist.get(1).enteredAt()).isNotNull();
+  }
+
+  @Test
+  void skipMarksIntermediateAsSkippedWithNullEnteredAt() {
+    UUID caseId = bootstrapped();
+
+    adapter.appendTransition(
+        new StageRepository.Transition(
+            caseId,
+            "intake",
+            0,
+            "decision",
+            2,
+            List.of(new StageRepository.SkippedStage("review", 1)),
+            "manual",
+            "u1",
+            NOW.plusSeconds(60)));
+    flushClear();
+
+    var hist = adapter.loadHistory(caseId);
+    assertThat(hist.get(0).state()).isEqualTo(StageState.COMPLETED);
+    assertThat(hist.get(1).state()).isEqualTo(StageState.SKIPPED);
+    assertThat(hist.get(1).enteredAt()).isNull();
+    assertThat(hist.get(1).exitedAt()).isNotNull();
+    assertThat(hist.get(2).state()).isEqualTo(StageState.ACTIVE);
+  }
+
+  @Test
+  void lastStageCompletionClearsCurrentStageCache() {
+    UUID caseId = bootstrapped();
+    // Walk: intake → review → decision → done.
+    adapter.appendTransition(
+        new StageRepository.Transition(
+            caseId, "intake", 0, "review", 1, List.of(), "manual", null, NOW.plusSeconds(10)));
+    adapter.appendTransition(
+        new StageRepository.Transition(
+            caseId, "review", 1, "decision", 2, List.of(), "manual", null, NOW.plusSeconds(20)));
+    adapter.appendTransition(
+        new StageRepository.Transition(
+            caseId, "decision", 2, null, null, List.of(), "manual", null, NOW.plusSeconds(30)));
+    flushClear();
+
+    var hist = adapter.loadHistory(caseId);
+    assertThat(hist).allMatch(s -> s.state() == StageState.COMPLETED);
+    var c = caseRepo.findById(caseId).orElseThrow();
+    assertThat(c.getCurrentStageId()).isNull();
+    assertThat(c.getCurrentStageOrdinal()).isNull();
+  }
+
+  @Test
+  void concurrentMissRaisesStg003WhenFromStageAlreadyAdvanced() {
+    UUID caseId = bootstrapped();
+    // First caller wins.
+    adapter.appendTransition(
+        new StageRepository.Transition(
+            caseId, "intake", 0, "review", 1, List.of(), "manual", null, NOW.plusSeconds(10)));
+    flushClear();
+
+    // Second caller still thinks intake is ACTIVE — conditional UPDATE returns 0.
+    assertThatThrownBy(
+            () ->
+                adapter.appendTransition(
+                    new StageRepository.Transition(
+                        caseId,
+                        "intake",
+                        0,
+                        "review",
+                        1,
+                        List.of(),
+                        "manual",
+                        null,
+                        NOW.plusSeconds(20))))
+        .isInstanceOf(WksStageException.class)
+        .satisfies(ex -> assertThat(((WksStageException) ex).getCode()).isEqualTo("WKS-STG-003"));
+  }
+
+  // ---- helpers ----
+
+  private UUID bootstrapped() {
+    UUID caseId = newCase();
+    adapter.materialiseStages(caseId, THREE, NOW);
+    adapter.appendTransition(
+        new StageRepository.Transition(
+            caseId, null, null, "intake", 0, List.of(), "wks-auto-rule", "case-create", NOW));
+    flushClear();
+    return caseId;
+  }
+
+  private UUID newCase() {
+    UUID id = UUID.randomUUID();
+    Case c =
+        new Case(
+            id, "loan-application", 1, "open", null, Map.of(), "pi-" + id, NOW, actorId, NOW, 0L);
+    caseAdapter.save(c);
+    flushClear();
+    return id;
+  }
+
+  private void flushClear() {
+    em.flush();
+    em.clear();
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseCreateAtomicityIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseCreateAtomicityIT.java
@@ -1,0 +1,243 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.event.StageEntered;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.StageRepository;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseEntityRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseStageHistoryJpaRepository;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.cibseven.bpm.engine.RepositoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+/**
+ * Story 3.1 code review B1 (2026-05-05) — atomicity proof for {@code POST /api/cases} when the
+ * case-type declares stages. {@code CaseController.create} carries {@code @Transactional}, so a
+ * forced failure inside {@code WksStageAdvancer.bootstrap → StageRepository.appendTransition} must
+ * roll back the case insert AND the {@code case_stage_history} PENDING rows AND must NOT publish
+ * the {@code StageEntered} bootstrap event (which is registered with {@code afterCommit}).
+ *
+ * <p>The {@code CaseCreated} event uses the eager {@code publish} path and is permitted to surface;
+ * the test pins ONLY the after-commit stage event suppression because that is the post-pivot wire
+ * contract for stage lifecycle (Story 3.1 AC11).
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("dev")
+@Import(CaseCreateAtomicityIT.RecorderConfig.class)
+class CaseCreateAtomicityIT {
+
+  private static final String EMAIL = "atomicity-admin@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String CASE_TYPE_ID = "atomicity-staged";
+  private static final String PROCESS_KEY = "atomicity-staged-flow";
+
+  @TempDir static java.nio.file.Path dbDir;
+
+  @DynamicPropertySource
+  static void props(DynamicPropertyRegistry reg) {
+    reg.add(
+        "spring.datasource.url",
+        () -> "jdbc:h2:file:" + dbDir.resolve("atomicity-it") + ";DB_CLOSE_DELAY=-1");
+    reg.add("wks.case-types.dir", () -> "");
+    reg.add("camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+    reg.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+  }
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private RepositoryService repositoryService;
+  @Autowired private CaseEntityRepository caseEntities;
+  @Autowired private CaseStageHistoryJpaRepository historyRepo;
+  @Autowired private ApplicationEventPublisher events;
+  @Autowired private ObjectMapper json;
+  @Autowired private StageEnteredRecorder recorder;
+
+  @MockitoSpyBean private StageRepository stageRepository;
+
+  @BeforeEach
+  void setup() throws Exception {
+    if (users.findByEmail(EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+    registry.register(stagedCaseType());
+    var deployment =
+        repositoryService
+            .createDeployment()
+            .name("atomicity-it-" + PROCESS_KEY)
+            .addInputStream(
+                PROCESS_KEY + ".bpmn",
+                new java.io.ByteArrayInputStream(simpleBpmn().getBytes(StandardCharsets.UTF_8)))
+            .deploy();
+    String processDefinitionId =
+        repositoryService
+            .createProcessDefinitionQuery()
+            .deploymentId(deployment.getId())
+            .singleResult()
+            .getId();
+    events.publishEvent(
+        new com.wkspower.platform.domain.event.ConfigDeployed(
+            CASE_TYPE_ID,
+            1,
+            deployment.getId(),
+            PROCESS_KEY,
+            processDefinitionId,
+            null,
+            Instant.now()));
+    recorder.events.clear();
+  }
+
+  @Test
+  void caseCreateRollsBackWhenStageBootstrapFails() throws Exception {
+    String cookie = login();
+
+    // Force WksStageAdvancer.bootstrap → appendTransition to throw mid-create. The controller's
+    // @Transactional must roll back the case_stage_history materialise rows AND the cases insert.
+    long caseRowsBefore = caseEntities.count();
+    long historyRowsBefore = historyRepo.count();
+
+    doThrow(new RuntimeException("forced bootstrap failure (atomicity B1)"))
+        .when(stageRepository)
+        .appendTransition(any());
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"name\":\"Asha\"}}");
+
+    // Forced unchecked exception — handler maps via WKS-RTM-500 (default). The exact status is
+    // less important than the post-condition: rollback must have happened.
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+
+    // 1) cases table — no new row.
+    assertThat(caseEntities.count()).as("case row must be rolled back").isEqualTo(caseRowsBefore);
+    // 2) case_stage_history — no PENDING rows materialised either.
+    assertThat(historyRepo.count())
+        .as("PENDING stage rows must be rolled back")
+        .isEqualTo(historyRowsBefore);
+    // 3) The after-commit StageEntered bootstrap event MUST NOT have fired (rollback ⇒ no commit
+    //    ⇒ no afterCommit synchronization). This is the SpringEventPublisher.publishAfterCommit
+    //    contract — the test would catch a future regression that publishes stage events eagerly.
+    assertThat(recorder.events).as("bootstrap StageEntered must not publish on rollback").isEmpty();
+  }
+
+  // ---- helpers ----------------------------------------------------------
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(EMAIL, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).isNotNull();
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  private static CaseTypeConfig stagedCaseType() {
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Atomicity Staged Fixture",
+        1,
+        null,
+        new WorkflowRef(PROCESS_KEY + ".bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("name"),
+        List.of(
+            new RoleDefinition(
+                "admin",
+                List.of(
+                    Permission.VIEW, Permission.CREATE, Permission.EDIT, Permission.TRANSITION))),
+        List.of(
+            new StageDefinition("intake", "Intake", 0),
+            new StageDefinition("review", "Review", 1)));
+  }
+
+  private static String simpleBpmn() {
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<bpmn:definitions xmlns:bpmn=\"http://www.omg.org/spec/BPMN/20100524/MODEL\""
+        + " xmlns:camunda=\"http://camunda.org/schema/1.0/bpmn\""
+        + " targetNamespace=\"http://wkspower.com/bpmn/test\">"
+        + "<bpmn:process id=\""
+        + PROCESS_KEY
+        + "\" isExecutable=\"true\" camunda:historyTimeToLive=\"30\">"
+        + "<bpmn:startEvent id=\"start\"/>"
+        + "<bpmn:endEvent id=\"end\"/>"
+        + "<bpmn:sequenceFlow id=\"f1\" sourceRef=\"start\" targetRef=\"end\"/>"
+        + "</bpmn:process>"
+        + "</bpmn:definitions>";
+  }
+
+  /** Captures the bootstrap StageEntered event so we can assert it did NOT fire on rollback. */
+  static class StageEnteredRecorder {
+    final List<StageEntered> events = new CopyOnWriteArrayList<>();
+
+    @EventListener
+    public void on(StageEntered e) {
+      events.add(e);
+    }
+  }
+
+  @TestConfiguration
+  static class RecorderConfig {
+    @Bean
+    StageEnteredRecorder stageEnteredRecorder() {
+      return new StageEnteredRecorder();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Stage as first-class WKS primitive (Decision 19); 18 new domain/infra/api files + Flyway `V202605050001`
- Manual advance/skip endpoints with conditional-UPDATE concurrency (`WKS-STG-003`)
- Bootstrap stage 0 atomic with case create (B1 fix); `WKS-STG-004` reachable on REST (S2 fix)
- Code review applied: see paired strategy-repo PR for AC12 §6 amendment + `WKS-CFG-031` renumber

## Test plan
- [x] `mvn verify` — 270u + 66 IT, 0 failures
- [x] `backend/.ci/check-tenant-invariant.sh` — OK
- [x] ArchUnit 17/17 (domain framework-free, NFR36)
- [x] Spotless applied
- [ ] CI green on PR
- [ ] Reviewer confirms B1 atomicity IT (`CaseCreateAtomicityIT`) actually exercises rollback
- [ ] Reviewer signs off on AC12 §6 amendment (parallel IT deferred per spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)