### PR TITLE
Story 4.1: Backend Adapter interface contract

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/domain/port/AttachmentScope.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/AttachmentScope.java
@@ -1,0 +1,46 @@
+package com.wkspower.platform.domain.port;
+
+import java.util.Objects;
+
+/**
+ * Scope of a {@link BackendAdapter} attachment to a CaseType, per architecture §786 (Decision 22):
+ * an adapter is attached either at the case scope (lifecycle of the entire case) or at a stage
+ * scope (lifecycle of a single stage within the case).
+ *
+ * <p>Sealed hierarchy intentionally — the two variants are exhaustive and the router (Story 4.3)
+ * can pattern-match on them.
+ *
+ * <p>Story 3.1 owns the {@code Stage} entity; this port carries only the {@code stageId} string so
+ * Story 4.1 ships in parallel with Story 3.1 without pulling a domain aggregate into the port. A
+ * mechanical rename to {@code Stage stage} is a Story 4.5 follow-up if/when needed.
+ */
+public sealed interface AttachmentScope permits AttachmentScope.Case, AttachmentScope.Stage {
+
+  /** Adapter attached for the lifecycle of the entire case. */
+  record Case() implements AttachmentScope {
+    public static final Case INSTANCE = new Case();
+  }
+
+  /**
+   * Adapter attached for the lifecycle of a single stage. {@code stageId} is the WKS-side stage id
+   * (string, not the {@code Stage} entity — see class Javadoc).
+   */
+  record Stage(String stageId) implements AttachmentScope {
+    public Stage {
+      Objects.requireNonNull(stageId, "stageId");
+      if (stageId.isBlank()) {
+        throw new IllegalArgumentException("stageId must not be blank");
+      }
+    }
+  }
+
+  /** Convenience factory for the case-scope singleton. */
+  static AttachmentScope ofCase() {
+    return Case.INSTANCE;
+  }
+
+  /** Convenience factory for a stage-scope attachment. */
+  static AttachmentScope ofStage(String stageId) {
+    return new Stage(stageId);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/BackendAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/BackendAdapter.java
@@ -1,0 +1,63 @@
+package com.wkspower.platform.domain.port;
+
+/**
+ * Outbound port for any execution backend that WKS may attach to a CaseType — BPMN today (Story 4.4
+ * implements via embedded CIB seven), state-machine / Temporal / AI orchestrator tomorrow.
+ *
+ * <p>Architecture §828 (Decision 22 — BPMN Attachment &amp; Mapping Layer). The Mapping Layer is
+ * the only seam between WKS primitives and any backend; adding a new backend is a new
+ * implementation of this port plus mapping rules.
+ *
+ * <p>The five-method contract is locked. Story 4.9 (in-memory state-machine) will prove it; Story
+ * 4.4 (BPMN refactor) will ship the first production implementation.
+ *
+ * <p>Implementations MUST translate adapter-side failures into {@link
+ * com.wkspower.platform.domain.exception.WksWorkflowEngineException} per the existing engine port
+ * contract.
+ */
+public interface BackendAdapter {
+
+  /**
+   * Register the adapter for a CaseType at the given scope (case or stage — see {@link
+   * AttachmentScope}). Architecture §786 / Decision 22.
+   *
+   * <p>Idempotent on {@code (caseType, scope)} — repeated calls with the same args MUST NOT throw
+   * and MUST NOT register twice (compliance test 7).
+   */
+  void attach(CaseTypeRef caseType, AttachmentScope scope);
+
+  /**
+   * Drop the adapter's registration for {@code caseType}. In-flight cases bound to the prior
+   * mapping continue under their pinned CaseTypeVersion (Story 4.5 surface; this port only declares
+   * the API).
+   */
+  void detach(CaseTypeRef caseType);
+
+  /**
+   * Register a handler that receives {@link BackendSignal}s emitted by the adapter. Returns an
+   * {@link AutoCloseable} subscription handle — closing it MUST stop further deliveries to the
+   * handler.
+   *
+   * <p>Per-instance ordering is preserved (compliance test 5). Cross-instance ordering is
+   * adapter-defined.
+   */
+  BackendSignalSubscription onBackendSignal(BackendSignalHandler handler);
+
+  /**
+   * Start backend execution for {@code caseInstance}. Returns an opaque adapter-specific instance
+   * id (e.g. CIB process instance id) — callers MUST treat the value as identity only.
+   *
+   * <p>Idempotent on {@code caseInstance.id()} — repeated start of an already-running instance MUST
+   * return the existing id and MUST NOT throw (compliance test 3).
+   *
+   * <p>Implementations MUST translate adapter-side failures into {@link
+   * com.wkspower.platform.domain.exception.WksWorkflowEngineException}.
+   */
+  String start(CaseInstanceRef caseInstance);
+
+  /**
+   * Stop backend execution for {@code caseInstance}. Idempotent on a not-running, unknown, or
+   * already-cancelled instance — MUST NOT throw (compliance test 4).
+   */
+  void cancel(CaseInstanceRef caseInstance);
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignal.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignal.java
@@ -1,0 +1,49 @@
+package com.wkspower.platform.domain.port;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable signal emitted by a {@link BackendAdapter} for downstream routing (Story 4.3) into WKS
+ * case-management semantics. Architecture §662 + §810 (Decision 22).
+ *
+ * <p>{@code payload} is a map of scalar values only — concrete shape per {@link BackendSignalKind}
+ * is documented per-handler but not enforced at the type level (Story 4.3 router validates).
+ *
+ * @param kind one of the four declared kinds (precedence: see {@link BackendSignalKind} Javadoc)
+ * @param adapterName adapter identity for FR8 source attribution (e.g. {@code "bpmn"}, {@code
+ *     "state-machine"}, {@code "null"})
+ * @param caseInstance the case instance the signal targets
+ * @param source adapter-internal element id (BPMN element id, state-machine state name, etc.) for
+ *     traceability
+ * @param payload scalar-only payload; concrete shape per kind documented in handler Javadoc
+ */
+public record BackendSignal(
+    BackendSignalKind kind,
+    String adapterName,
+    CaseInstanceRef caseInstance,
+    String source,
+    Map<String, Object> payload) {
+
+  public BackendSignal {
+    Objects.requireNonNull(kind, "kind");
+    Objects.requireNonNull(adapterName, "adapterName");
+    Objects.requireNonNull(caseInstance, "caseInstance");
+    Objects.requireNonNull(source, "source");
+    payload = payload == null ? Map.of() : Map.copyOf(payload);
+  }
+
+  /**
+   * Static factory mirroring the canonical-form constructor with fail-fast null checks. Provided
+   * because AC2 specifies a static-factory construction path; the canonical record constructor
+   * already enforces the same null contract.
+   */
+  public static BackendSignal of(
+      BackendSignalKind kind,
+      String adapterName,
+      CaseInstanceRef caseInstance,
+      String source,
+      Map<String, Object> payload) {
+    return new BackendSignal(kind, adapterName, caseInstance, source, payload);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignalHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignalHandler.java
@@ -1,0 +1,18 @@
+package com.wkspower.platform.domain.port;
+
+/**
+ * Handler invoked by a {@link BackendAdapter} when a {@link BackendSignal} is emitted. Registered
+ * via {@link BackendAdapter#onBackendSignal(BackendSignalHandler)}.
+ *
+ * <p>Per-instance ordering is preserved by the adapter (compliance test 5). Ordering across
+ * instances is adapter-defined.
+ */
+@FunctionalInterface
+public interface BackendSignalHandler {
+
+  /**
+   * Receive a backend signal. Implementations MUST not throw — Story 4.3's router is the only
+   * legitimate handler and it has its own error-translation contract.
+   */
+  void onSignal(BackendSignal signal);
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignalKind.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignalKind.java
@@ -1,0 +1,34 @@
+package com.wkspower.platform.domain.port;
+
+/**
+ * The four kinds of {@link BackendSignal} a {@link BackendAdapter} may emit. Architecture §662 +
+ * §810 (Decision 22).
+ *
+ * <p><b>Precedence ordering — highest to lowest:</b>
+ *
+ * <ol>
+ *   <li>{@link #END_EVENT} — terminal; supersedes all other signals for the same instance.
+ *   <li>{@link #NAMED_SIGNAL} — explicit signal/message correlation emitted by the backend.
+ *   <li>{@link #USER_TASK_PROPERTY} — user-task-scoped property change (e.g. {@code
+ *       <camunda:property>} on task complete).
+ *   <li>{@link #OUTCOME} — backend-internal outcome event.
+ * </ol>
+ *
+ * <p>This generalises the "endEvent wins" rule documented at architecture §810 to all signal kinds.
+ * Story 4.3 ({@code BackendSignalRouter}) is the enforcer; this enum only documents the ordering so
+ * adapters and tests share one source of truth.
+ */
+public enum BackendSignalKind {
+
+  /** Terminal end event — wins over all other signals for the same instance. Highest precedence. */
+  END_EVENT,
+
+  /** Named signal/message correlation emitted by the backend. */
+  NAMED_SIGNAL,
+
+  /** User-task-scoped property change (e.g. status property set on task complete). */
+  USER_TASK_PROPERTY,
+
+  /** Backend-internal outcome event. Lowest precedence. */
+  OUTCOME
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignalSubscription.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignalSubscription.java
@@ -1,0 +1,15 @@
+package com.wkspower.platform.domain.port;
+
+/**
+ * Subscription handle returned by {@link BackendAdapter#onBackendSignal(BackendSignalHandler)}.
+ * Closing the subscription removes the handler — subsequent signals MUST NOT be delivered to a
+ * closed subscription's handler.
+ *
+ * <p>Style note: {@code close()} is declared without checked exception, mirroring the {@link
+ * WorkflowEngine} port style.
+ */
+public interface BackendSignalSubscription extends AutoCloseable {
+
+  @Override
+  void close();
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/CaseInstanceRef.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/CaseInstanceRef.java
@@ -1,0 +1,25 @@
+package com.wkspower.platform.domain.port;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Immutable value reference to a Case instance plus its CaseType binding. Used by {@link
+ * BackendAdapter#start} and {@link BackendAdapter#cancel} so the port never pulls in the {@code
+ * Case} domain aggregate.
+ *
+ * <p>The {@code id} is the WKS-side case instance UUID — adapters MUST treat any backend-side
+ * instance id (e.g. CIB process instance id) as opaque adapter state and only return it as the
+ * result of {@link BackendAdapter#start}.
+ *
+ * @param id the WKS case instance UUID
+ * @param caseType the CaseType + version this instance is bound to (pinned for the life of the
+ *     instance; see Story 4.5)
+ */
+public record CaseInstanceRef(UUID id, CaseTypeRef caseType) {
+
+  public CaseInstanceRef {
+    Objects.requireNonNull(id, "id");
+    Objects.requireNonNull(caseType, "caseType");
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/CaseTypeRef.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/CaseTypeRef.java
@@ -1,0 +1,32 @@
+package com.wkspower.platform.domain.port;
+
+import java.util.Objects;
+
+/**
+ * Immutable value reference to a CaseType plus its pinned version. Used by {@link BackendAdapter}
+ * to identify which CaseType (and version) an attachment, signal, or instance belongs to without
+ * pulling the {@code CaseType} domain aggregate into the port surface.
+ *
+ * <p>Story 3.4 will own the authoritative {@code CaseTypeVersion} registry; this record only
+ * carries the pair as a value object, in line with Decision 22 (BPMN Attachment &amp; Mapping
+ * Layer).
+ *
+ * <p>Both fields are non-null. {@code version} matches {@code CaseTypeVersion} semantics from
+ * Decision 20 — adapters MUST treat it as opaque (do not parse).
+ *
+ * @param caseTypeId the CaseType id (stable across versions, e.g. {@code "loan-application"})
+ * @param version the pinned CaseType version string (opaque, treated as identity)
+ */
+public record CaseTypeRef(String caseTypeId, String version) {
+
+  public CaseTypeRef {
+    Objects.requireNonNull(caseTypeId, "caseTypeId");
+    Objects.requireNonNull(version, "version");
+    if (caseTypeId.isBlank()) {
+      throw new IllegalArgumentException("caseTypeId must not be blank");
+    }
+    if (version.isBlank()) {
+      throw new IllegalArgumentException("version must not be blank");
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/package-info.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/package-info.java
@@ -1,2 +1,13 @@
-/** Outbound ports — interfaces implemented by {@code infrastructure.*} adapters. */
+/**
+ * Outbound ports — interfaces implemented by {@code infrastructure.*} adapters.
+ *
+ * <ul>
+ *   <li>{@link com.wkspower.platform.domain.port.WorkflowEngine} — embedded BPMN engine port
+ *       (Stories 2.2 / 2.3 / 2.4).
+ *   <li>{@link com.wkspower.platform.domain.port.BackendAdapter} — generic execution-backend port
+ *       per architecture Decision 22 (BPMN Attachment &amp; Mapping Layer); BPMN today via Story
+ *       4.4, state-machine / Temporal / AI tomorrow. Story 4.1 introduces this port as
+ *       interface-only scaffolding.
+ * </ul>
+ */
 package com.wkspower.platform.domain.port;

--- a/backend/src/main/java/com/wkspower/platform/domain/service/BackendAdapterBinder.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/BackendAdapterBinder.java
@@ -1,0 +1,76 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.port.BackendAdapter;
+import com.wkspower.platform.domain.port.CaseTypeRef;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Resolves a {@link BackendAdapter} for a {@link CaseTypeRef} via DI. Architecture Decision 22 —
+ * Mapping Layer is the only seam between WKS primitives and any backend.
+ *
+ * <p>Resolution rule (Story 4.1 AC4): if any registered adapter has called {@link
+ * #register(CaseTypeRef, BackendAdapter)}, return the most-recently-registered adapter; else return
+ * the singleton {@link NullAdapter}.
+ *
+ * <p>This binder is the ONLY way domain code obtains a {@link BackendAdapter} instance —
+ * {@code @Autowired BackendAdapter} directly anywhere in {@code domain/} would defeat the rule.
+ * Story 4.1 has zero call sites for this binder; Story 4.4 / 4.5 wire it up to call sites.
+ *
+ * <p>{@link #register(CaseTypeRef, BackendAdapter)} and {@link #unregister(CaseTypeRef)} are
+ * package-private — only an adapter's own {@code attach(...)} / {@code detach(...)} implementation
+ * (which lives in {@code domain/service} or in an engine package that depends on this one) reaches
+ * into them. Domain services only call {@link #resolve(CaseTypeRef)}.
+ *
+ * <p>Pure-Java by design — no Spring annotations on the class itself. Wired into the Spring context
+ * via {@code infrastructure.config.BackendAdapterConfig} to honour the standing rule that {@code
+ * domain/} stays framework-free (NFR36).
+ */
+public class BackendAdapterBinder {
+
+  private final ConcurrentMap<CaseTypeRef, BackendAdapter> registry = new ConcurrentHashMap<>();
+  private final NullAdapter nullAdapter;
+
+  public BackendAdapterBinder(NullAdapter nullAdapter) {
+    this.nullAdapter = Objects.requireNonNull(nullAdapter, "nullAdapter");
+  }
+
+  /**
+   * Resolve the {@link BackendAdapter} for {@code caseType}. Returns the registered adapter or
+   * {@link NullAdapter} if none has been attached.
+   */
+  public BackendAdapter resolve(CaseTypeRef caseType) {
+    Objects.requireNonNull(caseType, "caseType");
+    BackendAdapter resolved = registry.get(caseType);
+    return resolved == null ? nullAdapter : resolved;
+  }
+
+  /**
+   * Register {@code adapter} as the bound adapter for {@code caseType}. Idempotent on the same
+   * {@code (caseType, adapter)} pair; replaces any prior registration with the most-recent adapter
+   * (resolution rule, AC4).
+   *
+   * <p>Adapter-only contract — only an adapter's {@code attach(...)} call site should invoke this.
+   * Surface is {@code public} (not package-private) so adapters living outside {@code
+   * domain/service/} (notably the Story 4.4 BPMN adapter in {@code engine/}) can self-register; the
+   * contract is enforced by convention + code review.
+   */
+  public void register(CaseTypeRef caseType, BackendAdapter adapter) {
+    Objects.requireNonNull(caseType, "caseType");
+    Objects.requireNonNull(adapter, "adapter");
+    registry.put(caseType, adapter);
+  }
+
+  /**
+   * Drop registration for {@code caseType}. Subsequent {@link #resolve(CaseTypeRef)} calls return
+   * {@link NullAdapter}. Idempotent on unknown / already-removed entries.
+   *
+   * <p>Adapter-only contract — only an adapter's {@code detach(...)} call site should invoke this.
+   * Surface is {@code public} (see {@link #register} Javadoc) for the same cross-package reason.
+   */
+  public void unregister(CaseTypeRef caseType) {
+    Objects.requireNonNull(caseType, "caseType");
+    registry.remove(caseType);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/NullAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/NullAdapter.java
@@ -1,0 +1,70 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.port.AttachmentScope;
+import com.wkspower.platform.domain.port.BackendAdapter;
+import com.wkspower.platform.domain.port.BackendSignalHandler;
+import com.wkspower.platform.domain.port.BackendSignalSubscription;
+import com.wkspower.platform.domain.port.CaseInstanceRef;
+import com.wkspower.platform.domain.port.CaseTypeRef;
+import java.util.Objects;
+
+/**
+ * No-op {@link BackendAdapter} bound by default for any CaseType with zero attachments.
+ * Architecture Decision 22 — a CaseType with no attached process Just Works because the binder
+ * resolves to this adapter.
+ *
+ * <p>Story 4.1 AC3:
+ *
+ * <ul>
+ *   <li>{@code attach} / {@code detach} — no-ops, return immediately.
+ *   <li>{@code onBackendSignal} — registers the handler but NEVER invokes it (NullAdapter emits no
+ *       signals, ever); returns a closeable that is itself a no-op on close.
+ *   <li>{@code start} — returns a deterministic synthetic id of the form {@code
+ *       "null:<caseInstance.id()>"} so audit / observability can distinguish a null start from a
+ *       real one without special-casing.
+ *   <li>{@code cancel} — no-op.
+ * </ul>
+ *
+ * <p>Zero external dependencies — no engine imports, no repository, no infrastructure types, not
+ * even Spring. Wired into the Spring context via {@code infrastructure.config.BackendAdapterConfig}
+ * to honour the project-wide rule that {@code domain/} stays framework-free (NFR36, enforced by
+ * {@link com.wkspower.platform.architecture.ArchitectureTest}). The story spec said
+ * {@code @Component}, but the standing architectural rule wins — see Dev Notes.
+ *
+ * <p>Isolation is also enforced by ArchUnit ({@code BackendAdapterPortIsolationTest}).
+ */
+public final class NullAdapter implements BackendAdapter {
+
+  /** Adapter identity reported on any signal — kept as a constant so router tests can match. */
+  public static final String ADAPTER_NAME = "null";
+
+  @Override
+  public void attach(CaseTypeRef caseType, AttachmentScope scope) {
+    // no-op
+  }
+
+  @Override
+  public void detach(CaseTypeRef caseType) {
+    // no-op
+  }
+
+  @Override
+  public BackendSignalSubscription onBackendSignal(BackendSignalHandler handler) {
+    Objects.requireNonNull(handler, "handler");
+    // Handler is intentionally never invoked — NullAdapter emits no signals.
+    return () -> {
+      /* no-op close */
+    };
+  }
+
+  @Override
+  public String start(CaseInstanceRef caseInstance) {
+    Objects.requireNonNull(caseInstance, "caseInstance");
+    return "null:" + caseInstance.id();
+  }
+
+  @Override
+  public void cancel(CaseInstanceRef caseInstance) {
+    // no-op
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/BackendAdapterConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/BackendAdapterConfig.java
@@ -1,0 +1,29 @@
+package com.wkspower.platform.infrastructure.config;
+
+import com.wkspower.platform.domain.service.BackendAdapterBinder;
+import com.wkspower.platform.domain.service.NullAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Story 4.1 — wires the pure-Java {@link NullAdapter} and {@link BackendAdapterBinder} (both in
+ * {@code domain/service}, framework-free per NFR36) as Spring singletons so future call sites
+ * (Story 4.4 / 4.5) can inject {@code BackendAdapterBinder}.
+ *
+ * <p>This config has zero call sites in Story 4.1 — it exists so the beans are present on the
+ * application context and so Story 4.4 can refactor call sites without re-wiring. The
+ * infrastructure boundary is the correct home: {@code domain/} stays Spring-free.
+ */
+@Configuration
+public class BackendAdapterConfig {
+
+  @Bean
+  public NullAdapter nullAdapter() {
+    return new NullAdapter();
+  }
+
+  @Bean
+  public BackendAdapterBinder backendAdapterBinder(NullAdapter nullAdapter) {
+    return new BackendAdapterBinder(nullAdapter);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/architecture/BackendAdapterPortIsolationTest.java
+++ b/backend/src/test/java/com/wkspower/platform/architecture/BackendAdapterPortIsolationTest.java
@@ -1,0 +1,65 @@
+package com.wkspower.platform.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 4.1 AC5 — guardrail that the {@code BackendAdapter} port and the two service-side classes
+ * that ship with it ({@code NullAdapter}, {@code BackendAdapterBinder}) remain backend-agnostic
+ * forever. A code-review reminder is not enough — this rule fails the build the day someone imports
+ * {@code org.cibseven..} or {@code com.wkspower.platform.engine..} into one of these files.
+ *
+ * <p>Pinned as its own ArchUnit class (rather than added to {@code ArchitectureTest}) so a
+ * regression surfaces a Story-4.1-attributable failure message.
+ */
+class BackendAdapterPortIsolationTest {
+
+  private static final JavaClasses CLASSES =
+      new ClassFileImporter()
+          .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+          .importPackages("com.wkspower.platform");
+
+  @Test
+  void backendAdapterPortHasNoEngineOrInfrastructureImports() {
+    noClasses()
+        .that()
+        .resideInAPackage("com.wkspower.platform.domain.port..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAnyPackage(
+            "org.cibseven..",
+            "com.wkspower.platform.engine..",
+            "com.wkspower.platform.infrastructure..")
+        .because(
+            "Story 4.1 AC5: domain.port classes — including BackendAdapter, BackendSignal, "
+                + "AttachmentScope, CaseTypeRef, CaseInstanceRef, BackendSignalKind, "
+                + "BackendSignalHandler, BackendSignalSubscription — must remain backend-agnostic "
+                + "and infrastructure-agnostic. Adding any such import here would break the "
+                + "Mapping Layer (Decision 22) by leaking backend choice into domain.")
+        .check(CLASSES);
+  }
+
+  @Test
+  void nullAdapterAndBinderHaveNoEngineImports() {
+    // NullAdapter and BackendAdapterBinder live in domain.service alongside CaseService etc., so
+    // we cannot use a package-wide rule. Pin by simple name — these two classes ship with the
+    // port and must remain backend-agnostic forever.
+    noClasses()
+        .that()
+        .haveSimpleName("NullAdapter")
+        .or()
+        .haveSimpleName("BackendAdapterBinder")
+        .should()
+        .dependOnClassesThat()
+        .resideInAnyPackage("org.cibseven..", "com.wkspower.platform.engine..")
+        .because(
+            "Story 4.1 AC5: NullAdapter (the zero-attachment fallback) and BackendAdapterBinder "
+                + "(the resolve seam) must never depend on a specific backend SDK. Spring "
+                + "@Component is allowed; engine SDK and engine package imports are not.")
+        .check(CLASSES);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/port/BackendAdapterComplianceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/port/BackendAdapterComplianceTest.java
@@ -1,0 +1,181 @@
+package com.wkspower.platform.domain.port;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.wkspower.platform.domain.service.BackendAdapterBinder;
+import com.wkspower.platform.domain.service.NullAdapter;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 4.1 AC6 — abstract compliance contract. Any {@link BackendAdapter} implementation MUST pass
+ * these seven test methods. Story 4.4 (BPMN adapter) and Story 4.9 (in-memory state machine) extend
+ * this class by overriding {@link #newAdapterUnderTest(BackendAdapterBinder)}.
+ *
+ * <p>Tests 1–4, 7 exercise real behaviour. Tests 5–6 are vacuously satisfied by adapters that emit
+ * no signals (e.g. {@link NullAdapter}); the {@link FakeRecordingAdapter} subclass exercises them
+ * non-trivially.
+ */
+public abstract class BackendAdapterComplianceTest {
+
+  protected NullAdapter nullAdapter;
+  protected BackendAdapterBinder binder;
+  protected BackendAdapter adapter;
+
+  /**
+   * Subclasses build a fresh adapter under test for each compliance run. The binder is provided so
+   * the adapter can self-register from inside {@code attach(...)}.
+   */
+  protected abstract BackendAdapter newAdapterUnderTest(BackendAdapterBinder binder);
+
+  /**
+   * Whether the adapter under test ever emits signals. {@link NullAdapter} returns {@code false};
+   * {@link FakeRecordingAdapter} returns {@code true}. Tests 5 and 6 are skipped (vacuously
+   * passing) when this returns {@code false}, and they receive a non-null fake-emit hook when this
+   * returns {@code true}.
+   */
+  protected boolean adapterEmitsSignals() {
+    return false;
+  }
+
+  /**
+   * For signal-emitting adapters: emit a synthetic signal to every subscribed handler. Default
+   * throws — adapters that emit signals MUST override.
+   */
+  protected void emitSignal(BackendSignal signal) {
+    throw new UnsupportedOperationException(
+        "Adapter under test does not support test-side signal emission");
+  }
+
+  @BeforeEach
+  void setUp() {
+    nullAdapter = new NullAdapter();
+    binder = new BackendAdapterBinder(nullAdapter);
+    adapter = newAdapterUnderTest(binder);
+  }
+
+  // ---------- Test 1 ----------
+  @Test
+  void attach_then_resolve_returns_this_adapter() {
+    CaseTypeRef ref = new CaseTypeRef("ct-1", "1.0.0");
+
+    adapter.attach(ref, AttachmentScope.ofCase());
+
+    // NullAdapter is the binder's fallback; for it, resolve returns nullAdapter (which IS the
+    // adapter under test). For other adapters, the adapter's attach must self-register.
+    BackendAdapter resolved = binder.resolve(ref);
+    if (adapter instanceof NullAdapter) {
+      assertThat(resolved).isSameAs(nullAdapter);
+    } else {
+      assertThat(resolved).isSameAs(adapter);
+    }
+  }
+
+  // ---------- Test 2 ----------
+  @Test
+  void detach_falls_back_to_null_adapter() {
+    CaseTypeRef ref = new CaseTypeRef("ct-1", "1.0.0");
+    adapter.attach(ref, AttachmentScope.ofCase());
+
+    adapter.detach(ref);
+
+    assertThat(binder.resolve(ref)).isSameAs(nullAdapter);
+  }
+
+  // ---------- Test 3 ----------
+  @Test
+  void start_is_idempotent_on_same_case_instance() {
+    CaseInstanceRef ci = new CaseInstanceRef(UUID.randomUUID(), new CaseTypeRef("ct-1", "1.0.0"));
+
+    String first = adapter.start(ci);
+    String second = adapter.start(ci);
+
+    assertThat(second).isEqualTo(first);
+  }
+
+  // ---------- Test 4 ----------
+  @Test
+  void cancel_unknown_instance_is_no_op() {
+    CaseInstanceRef ci = new CaseInstanceRef(UUID.randomUUID(), new CaseTypeRef("ct-1", "1.0.0"));
+
+    assertThatCode(() -> adapter.cancel(ci)).doesNotThrowAnyException();
+    // Calling a second time on an already-cancelled / unknown instance also must not throw.
+    assertThatCode(() -> adapter.cancel(ci)).doesNotThrowAnyException();
+  }
+
+  // ---------- Test 5 ----------
+  @Test
+  void signal_handler_receives_emitted_signals() {
+    if (!adapterEmitsSignals()) {
+      // Vacuously satisfied — NullAdapter and other zero-emit adapters declare no obligation here.
+      return;
+    }
+    List<BackendSignal> received = new CopyOnWriteArrayList<>();
+    BackendSignalSubscription sub = adapter.onBackendSignal(received::add);
+
+    CaseInstanceRef ci = new CaseInstanceRef(UUID.randomUUID(), new CaseTypeRef("ct-1", "1.0.0"));
+    BackendSignal s1 =
+        BackendSignal.of(
+            BackendSignalKind.NAMED_SIGNAL, "fake-recording", ci, "elem-A", java.util.Map.of());
+    BackendSignal s2 =
+        BackendSignal.of(
+            BackendSignalKind.OUTCOME, "fake-recording", ci, "elem-B", java.util.Map.of());
+    BackendSignal s3 =
+        BackendSignal.of(
+            BackendSignalKind.END_EVENT, "fake-recording", ci, "elem-C", java.util.Map.of());
+
+    emitSignal(s1);
+    emitSignal(s2);
+    emitSignal(s3);
+
+    // After close, no further deliveries.
+    sub.close();
+    emitSignal(s1);
+
+    assertThat(received).containsExactly(s1, s2, s3);
+  }
+
+  // ---------- Test 6 ----------
+  @Test
+  void signal_kind_field_is_one_of_four_declared_values() {
+    if (!adapterEmitsSignals()) {
+      return; // vacuous for NullAdapter
+    }
+    List<BackendSignalKind> kinds = new ArrayList<>();
+    BackendSignalSubscription sub = adapter.onBackendSignal(s -> kinds.add(s.kind()));
+
+    CaseInstanceRef ci = new CaseInstanceRef(UUID.randomUUID(), new CaseTypeRef("ct-1", "1.0.0"));
+    for (BackendSignalKind k : BackendSignalKind.values()) {
+      emitSignal(BackendSignal.of(k, "fake-recording", ci, "elem-" + k.name(), java.util.Map.of()));
+    }
+    sub.close();
+
+    EnumSet<BackendSignalKind> declared =
+        EnumSet.of(
+            BackendSignalKind.END_EVENT,
+            BackendSignalKind.NAMED_SIGNAL,
+            BackendSignalKind.USER_TASK_PROPERTY,
+            BackendSignalKind.OUTCOME);
+    assertThat(kinds).allMatch(declared::contains);
+  }
+
+  // ---------- Test 7 ----------
+  @Test
+  void attach_is_idempotent() {
+    CaseTypeRef ref = new CaseTypeRef("ct-1", "1.0.0");
+    AttachmentScope scope = AttachmentScope.ofCase();
+
+    adapter.attach(ref, scope);
+    adapter.attach(ref, scope);
+
+    // Detach must remove the binding cleanly — verifying no double-registration leak.
+    adapter.detach(ref);
+    assertThat(binder.resolve(ref)).isSameAs(nullAdapter);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/port/FakeRecordingAdapter.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/port/FakeRecordingAdapter.java
@@ -1,0 +1,95 @@
+package com.wkspower.platform.domain.port;
+
+import com.wkspower.platform.domain.service.BackendAdapterBinder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Test-only minimal in-memory {@link BackendAdapter}. Records every call and lets tests push
+ * synthetic {@link BackendSignal}s through to subscribed handlers so compliance tests 5 and 6 are
+ * non-trivial.
+ *
+ * <p>This fake is unrelated to Story 4.9's productionizable in-memory state-machine adapter — it
+ * lives in {@code src/test/java}, is not a Spring component, and has a deliberately trivial scope.
+ */
+public final class FakeRecordingAdapter implements BackendAdapter {
+
+  public static final String ADAPTER_NAME = "fake-recording";
+
+  private final BackendAdapterBinder binder;
+  private final List<BackendSignalHandler> handlers = new CopyOnWriteArrayList<>();
+  private final List<AttachCall> attachCalls = new ArrayList<>();
+  private final List<CaseTypeRef> detachCalls = new ArrayList<>();
+  private final List<CaseInstanceRef> cancelCalls = new ArrayList<>();
+  private final Map<java.util.UUID, String> startedInstances = new HashMap<>();
+
+  public FakeRecordingAdapter(BackendAdapterBinder binder) {
+    this.binder = Objects.requireNonNull(binder, "binder");
+  }
+
+  @Override
+  public synchronized void attach(CaseTypeRef caseType, AttachmentScope scope) {
+    Objects.requireNonNull(caseType, "caseType");
+    Objects.requireNonNull(scope, "scope");
+    AttachCall call = new AttachCall(caseType, scope);
+    if (!attachCalls.contains(call)) {
+      attachCalls.add(call);
+    }
+    binder.register(caseType, this);
+  }
+
+  @Override
+  public synchronized void detach(CaseTypeRef caseType) {
+    Objects.requireNonNull(caseType, "caseType");
+    detachCalls.add(caseType);
+    binder.unregister(caseType);
+  }
+
+  @Override
+  public BackendSignalSubscription onBackendSignal(BackendSignalHandler handler) {
+    Objects.requireNonNull(handler, "handler");
+    handlers.add(handler);
+    return () -> handlers.remove(handler);
+  }
+
+  @Override
+  public synchronized String start(CaseInstanceRef caseInstance) {
+    Objects.requireNonNull(caseInstance, "caseInstance");
+    return startedInstances.computeIfAbsent(caseInstance.id(), id -> "fake:" + id);
+  }
+
+  @Override
+  public synchronized void cancel(CaseInstanceRef caseInstance) {
+    Objects.requireNonNull(caseInstance, "caseInstance");
+    cancelCalls.add(caseInstance);
+    startedInstances.remove(caseInstance.id());
+  }
+
+  // --- test-side push API ---
+
+  /** Push a signal to every currently-subscribed handler, preserving subscription order. */
+  public void emit(BackendSignal signal) {
+    Objects.requireNonNull(signal, "signal");
+    for (BackendSignalHandler h : handlers) {
+      h.onSignal(signal);
+    }
+  }
+
+  public List<AttachCall> attachCalls() {
+    return List.copyOf(attachCalls);
+  }
+
+  public List<CaseTypeRef> detachCalls() {
+    return List.copyOf(detachCalls);
+  }
+
+  public List<CaseInstanceRef> cancelCalls() {
+    return List.copyOf(cancelCalls);
+  }
+
+  public record AttachCall(CaseTypeRef caseType, AttachmentScope scope) {}
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/port/FakeRecordingAdapterComplianceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/port/FakeRecordingAdapterComplianceTest.java
@@ -1,0 +1,29 @@
+package com.wkspower.platform.domain.port;
+
+import com.wkspower.platform.domain.service.BackendAdapterBinder;
+
+/**
+ * Story 4.1 AC6 — proves {@link FakeRecordingAdapter} passes the compliance contract. Exercises
+ * tests 5 and 6 non-trivially (signal emission + kind validation) so the harness itself is proven
+ * against a non-NullAdapter implementation.
+ */
+class FakeRecordingAdapterComplianceTest extends BackendAdapterComplianceTest {
+
+  private FakeRecordingAdapter fake;
+
+  @Override
+  protected BackendAdapter newAdapterUnderTest(BackendAdapterBinder binder) {
+    this.fake = new FakeRecordingAdapter(binder);
+    return fake;
+  }
+
+  @Override
+  protected boolean adapterEmitsSignals() {
+    return true;
+  }
+
+  @Override
+  protected void emitSignal(BackendSignal signal) {
+    fake.emit(signal);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/port/NullAdapterComplianceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/port/NullAdapterComplianceTest.java
@@ -1,0 +1,15 @@
+package com.wkspower.platform.domain.port;
+
+import com.wkspower.platform.domain.service.BackendAdapterBinder;
+
+/**
+ * Story 4.1 AC6 — proves {@link com.wkspower.platform.domain.service.NullAdapter} passes the
+ * compliance contract. Tests 5 / 6 are vacuously satisfied because NullAdapter emits no signals.
+ */
+class NullAdapterComplianceTest extends BackendAdapterComplianceTest {
+
+  @Override
+  protected BackendAdapter newAdapterUnderTest(BackendAdapterBinder binder) {
+    return nullAdapter;
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/service/BackendAdapterBinderTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/BackendAdapterBinderTest.java
@@ -1,0 +1,123 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.port.AttachmentScope;
+import com.wkspower.platform.domain.port.BackendAdapter;
+import com.wkspower.platform.domain.port.BackendSignalHandler;
+import com.wkspower.platform.domain.port.BackendSignalSubscription;
+import com.wkspower.platform.domain.port.CaseInstanceRef;
+import com.wkspower.platform.domain.port.CaseTypeRef;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/** Story 4.1 Task 5 — direct unit coverage of {@link BackendAdapterBinder} per AC4. */
+class BackendAdapterBinderTest {
+
+  private final NullAdapter nullAdapter = new NullAdapter();
+  private final BackendAdapterBinder binder = new BackendAdapterBinder(nullAdapter);
+
+  @Test
+  void resolve_returnsNullAdapter_whenNothingRegistered() {
+    assertThat(binder.resolve(new CaseTypeRef("ct-1", "1.0.0"))).isSameAs(nullAdapter);
+  }
+
+  @Test
+  void resolve_returnsRegisteredAdapter() {
+    CaseTypeRef ref = new CaseTypeRef("ct-1", "1.0.0");
+    BackendAdapter custom = new RecordingAdapter();
+
+    binder.register(ref, custom);
+
+    assertThat(binder.resolve(ref)).isSameAs(custom);
+  }
+
+  @Test
+  void resolve_returnsMostRecentlyRegisteredAdapter() {
+    CaseTypeRef ref = new CaseTypeRef("ct-1", "1.0.0");
+    BackendAdapter first = new RecordingAdapter();
+    BackendAdapter second = new RecordingAdapter();
+
+    binder.register(ref, first);
+    binder.register(ref, second);
+
+    assertThat(binder.resolve(ref)).isSameAs(second);
+  }
+
+  @Test
+  void unregister_fallsBackToNullAdapter() {
+    CaseTypeRef ref = new CaseTypeRef("ct-1", "1.0.0");
+    binder.register(ref, new RecordingAdapter());
+
+    binder.unregister(ref);
+
+    assertThat(binder.resolve(ref)).isSameAs(nullAdapter);
+  }
+
+  @Test
+  void unregister_unknownKey_isNoOp() {
+    binder.unregister(new CaseTypeRef("never-registered", "1.0.0"));
+    assertThat(binder.resolve(new CaseTypeRef("never-registered", "1.0.0"))).isSameAs(nullAdapter);
+  }
+
+  @Test
+  void concurrentRegisterFromTwoThreads_lastWriteWinsAndDoesNotThrow() throws Exception {
+    CaseTypeRef ref = new CaseTypeRef("ct-1", "1.0.0");
+    BackendAdapter a = new RecordingAdapter();
+    BackendAdapter b = new RecordingAdapter();
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService es = Executors.newFixedThreadPool(2);
+
+    try {
+      es.submit(
+          () -> {
+            start.await();
+            for (int i = 0; i < 1000; i++) {
+              binder.register(ref, a);
+            }
+            return null;
+          });
+      es.submit(
+          () -> {
+            start.await();
+            for (int i = 0; i < 1000; i++) {
+              binder.register(ref, b);
+            }
+            return null;
+          });
+      start.countDown();
+      es.shutdown();
+      assertThat(es.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      es.shutdownNow();
+    }
+
+    BackendAdapter resolved = binder.resolve(ref);
+    assertThat(resolved).isIn(a, b);
+  }
+
+  /** Bare-bones adapter for binder tests — no signal/recording behaviour needed here. */
+  private static final class RecordingAdapter implements BackendAdapter {
+    @Override
+    public void attach(CaseTypeRef caseType, AttachmentScope scope) {}
+
+    @Override
+    public void detach(CaseTypeRef caseType) {}
+
+    @Override
+    public BackendSignalSubscription onBackendSignal(BackendSignalHandler handler) {
+      return () -> {};
+    }
+
+    @Override
+    public String start(CaseInstanceRef caseInstance) {
+      return "rec:" + caseInstance.id();
+    }
+
+    @Override
+    public void cancel(CaseInstanceRef caseInstance) {}
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/service/NullAdapterTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/NullAdapterTest.java
@@ -1,0 +1,73 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.wkspower.platform.domain.port.AttachmentScope;
+import com.wkspower.platform.domain.port.BackendSignalSubscription;
+import com.wkspower.platform.domain.port.CaseInstanceRef;
+import com.wkspower.platform.domain.port.CaseTypeRef;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/** Story 4.1 Task 4 — direct unit coverage of {@link NullAdapter} contract per AC3. */
+class NullAdapterTest {
+
+  private final NullAdapter adapter = new NullAdapter();
+
+  @Test
+  void attach_isNoOp() {
+    assertThatCode(() -> adapter.attach(new CaseTypeRef("ct-1", "1.0.0"), AttachmentScope.ofCase()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void detach_isNoOp() {
+    assertThatCode(() -> adapter.detach(new CaseTypeRef("ct-1", "1.0.0")))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void start_returnsDeterministicSyntheticId() {
+    UUID caseId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    CaseInstanceRef ref = new CaseInstanceRef(caseId, new CaseTypeRef("ct-1", "1.0.0"));
+
+    String id = adapter.start(ref);
+
+    assertThat(id).isEqualTo("null:11111111-1111-1111-1111-111111111111");
+  }
+
+  @Test
+  void start_isStableAcrossInvocations() {
+    CaseInstanceRef ref = new CaseInstanceRef(UUID.randomUUID(), new CaseTypeRef("ct-1", "1.0.0"));
+    assertThat(adapter.start(ref)).isEqualTo(adapter.start(ref));
+  }
+
+  @Test
+  void cancel_isNoOp() {
+    CaseInstanceRef ref = new CaseInstanceRef(UUID.randomUUID(), new CaseTypeRef("ct-1", "1.0.0"));
+    assertThatCode(() -> adapter.cancel(ref)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void onBackendSignal_neverInvokesHandler() {
+    AtomicInteger invocations = new AtomicInteger(0);
+
+    BackendSignalSubscription sub =
+        adapter.onBackendSignal(signal -> invocations.incrementAndGet());
+
+    // No way to push a signal through NullAdapter — verify the handler was registered without
+    // invocation, then close. The adapter emits no signals, ever.
+    assertThat(invocations.get()).isZero();
+    assertThatCode(sub::close).doesNotThrowAnyException();
+    assertThat(invocations.get()).isZero();
+  }
+
+  @Test
+  void closingSubscription_isIdempotent() {
+    BackendSignalSubscription sub = adapter.onBackendSignal(s -> {});
+    sub.close();
+    assertThatCode(sub::close).doesNotThrowAnyException();
+  }
+}


### PR DESCRIPTION
## Summary
- 8 new domain ports + NullAdapter + BackendAdapterBinder + abstract compliance test
- Interface-only scaffolding; no runtime call sites yet (Stories 4.3 / 4.4 / 4.9 will wire it)
- Two accepted deviations: `@Bean` over `@Component` (NFR36); `public register/unregister` (Story 4.4 cross-package access)
- Code review verdict: APPROVE — see paired strategy-repo PR for spec + Dev Agent Record

## Test plan
- [x] `mvn verify` — 60 IT + 27 new unit tests, 0 failures
- [x] `backend/.ci/check-tenant-invariant.sh` — OK
- [x] ArchUnit 17/17 (domain framework-free, NFR36)
- [x] No new `pom.xml` deps; no new error codes
- [ ] CI green on PR
- [ ] Reviewer confirms both intentional deviations match the accept reasoning in the spec's Dev Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)