### PR TITLE
Story 3.3: Stage Timeline UI in Case Detail

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
@@ -110,13 +110,20 @@ public class CaseController {
         .body(ApiResponse.success(CaseDtoMapper.toDto(created, caseType)));
   }
 
+  /**
+   * Story 3.3 AC3 — the read-model surface that drives the Stage Timeline UI. Loads the case-stage
+   * history (one row per declared stage on the bound CaseType@version, including SKIPPED rows at
+   * their declared ordinal) and passes it to the mapper so the wire {@link CaseDto#stages()} array
+   * is populated in a single round-trip. Zero-stage CaseTypes return {@code stages: []}.
+   */
   @GetMapping("/{id}")
   public ApiResponse<CaseDto> get(
       @PathVariable("id") UUID id, @AuthenticationPrincipal WksUserPrincipal actor) {
     Case found = caseService.findById(id);
     requireVerb(actor, found.caseTypeId(), "view");
     CaseTypeConfig caseType = caseService.requireCaseType(found.caseTypeId());
-    return ApiResponse.success(CaseDtoMapper.toDto(found, caseType));
+    List<Stage> history = stageRepository.loadHistory(id);
+    return ApiResponse.success(CaseDtoMapper.toDto(found, caseType, history));
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseDto.java
@@ -1,6 +1,7 @@
 package com.wkspower.platform.api.dto.response;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -18,10 +19,10 @@ import java.util.UUID;
  *       {@code null}.
  * </ul>
  *
- * Future consumer: Story 3.3 (StageTimeline frontend component) reads both fields to highlight the
- * active stage. Story 3.3 ALSO ships a {@code stages: List<StageView>} array field on this DTO (the
- * timeline payload); the two scalars and the array are additive, not redundant — scalars give O(1)
- * "which stage am I on?" without iterating the array.
+ * <p>Story 3.3 — appended {@code stages: List<StageView>} (always non-null; empty for zero-stage
+ * CaseTypes). The two scalar denormalised cache fields above are owned by Story 3.2; the array is
+ * owned by Story 3.3 per the locked Sprint 2 coordination split. Scalars give O(1) "which stage am
+ * I on?" without iterating the array.
  */
 public record CaseDto(
     UUID id,
@@ -38,4 +39,14 @@ public record CaseDto(
     long version,
     CaseTypeViewDto caseType,
     String currentStageId,
-    Integer currentStageOrdinal) {}
+    Integer currentStageOrdinal,
+    List<StageView> stages) {
+
+  /**
+   * Compact constructor — defensive-copy {@code stages} so the wire shape is immutable end-to-end
+   * (mirrors {@code CaseTypeConfig}'s {@code List.copyOf} discipline).
+   */
+  public CaseDto {
+    stages = stages == null ? List.of() : List.copyOf(stages);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
@@ -24,7 +24,23 @@ public record CaseTypeViewDto(
     int version,
     List<FieldView> fields,
     List<StatusDefinition> statuses,
-    List<String> listColumns) {
+    List<String> listColumns,
+    List<StageDefinitionView> stages) {
+
+  /**
+   * Compact constructor — defensive-copy {@code stages} so the wire shape is immutable end-to-end.
+   * Story 3.3 — added {@code stages} for the timeline UI; declared in YAML order, never reordered.
+   */
+  public CaseTypeViewDto {
+    stages = stages == null ? List.of() : List.copyOf(stages);
+  }
+
+  /**
+   * Wire-shape projection of {@code StageDefinition} for the case-type detail endpoint and the
+   * embedded {@link CaseDto#caseType()} sub-object. Mirrors the YAML grammar 1:1 so the timeline
+   * has the declared display name + ordinal without a second round-trip. Story 3.3.
+   */
+  public record StageDefinitionView(String id, String displayName, int ordinal) {}
 
   /**
    * Wire-shape projection of {@code FieldDefinition} for the case-type detail endpoint. Every

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/StageView.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/StageView.java
@@ -1,0 +1,43 @@
+package com.wkspower.platform.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.Instant;
+
+/**
+ * Wire shape for a single stage row exposed by {@link CaseDto#stages()} (Story 3.3 AC3 / AC4).
+ *
+ * <p>The {@code state} field carries the uppercase enum string of {@link
+ * com.wkspower.platform.domain.model.StageState} (e.g. {@code "PENDING"}, {@code "ACTIVE"}, {@code
+ * "COMPLETED"}, {@code "SKIPPED"}). The frontend maps to a lowercase CSS class name client-side.
+ * Renaming any of these enum strings is a multi-PR cascade — they are a wire contract per memory
+ * note {@code feedback_error_codes_are_wire_contract.md}.
+ *
+ * <p>Skipped stages appear in the list at their declared ordinal — the timeline never omits them.
+ * The list is always ordered by {@code ordinal} ASC; for zero-stage CaseTypes the list is empty.
+ *
+ * <p>{@code source} is one of {@code "wks-auto-rule"}, {@code "manual"}, {@code "backend-signal"}
+ * (Decision 1) — nullable on initial {@code PENDING} rows before the first transition. {@code
+ * sourceRef} is a free-form correlation string and never includes PII.
+ *
+ * @param stageId YAML-declared stage id (e.g. {@code "intake"})
+ * @param displayName human-readable label from the bound CaseType@version (Title-cased fallback per
+ *     Story 3.1 AC1)
+ * @param ordinal 0-based position in the declared stage list
+ * @param state {@link com.wkspower.platform.domain.model.StageState} as wire string
+ * @param enteredAt timestamp the row entered {@code ACTIVE}; {@code null} for {@code PENDING} and
+ *     {@code SKIPPED} rows that never went active
+ * @param exitedAt timestamp the row left {@code ACTIVE}; {@code null} while {@code PENDING} or
+ *     {@code ACTIVE}
+ * @param source attribution; {@code null} on initial {@code PENDING}
+ * @param sourceRef free-form correlation; never PII
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public record StageView(
+    String stageId,
+    String displayName,
+    int ordinal,
+    String state,
+    Instant enteredAt,
+    Instant exitedAt,
+    String source,
+    String sourceRef) {}

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -5,11 +5,17 @@ import com.wkspower.platform.api.dto.response.CaseSummaryDto;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.FieldView;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.OptionView;
+import com.wkspower.platform.api.dto.response.CaseTypeViewDto.StageDefinitionView;
+import com.wkspower.platform.api.dto.response.StageView;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
 import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.model.Stage;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Domain-model → wire-DTO mapping for the case CRUD endpoints. Manual mapping (no MapStruct) per
@@ -21,7 +27,38 @@ public final class CaseDtoMapper {
     // utility
   }
 
+  /**
+   * Story 2.3 entry point — kept for callers (e.g. write-paths and tests) that don't yet have the
+   * stage history loaded. Projects an empty stage list, which is correct for zero-stage CaseTypes
+   * and a safe default for write-paths that re-fetch the case immediately afterward. New read-paths
+   * (Story 3.3 onwards) should use {@link #toDto(Case, CaseTypeConfig, List)} so the timeline
+   * renders without a second round-trip.
+   */
   public static CaseDto toDto(Case domain, CaseTypeConfig caseType) {
+    return toDto(domain, caseType, List.of());
+  }
+
+  /**
+   * Story 3.3 — full read-model projection. {@code history} is the output of {@code
+   * StageRepository.loadHistory(caseId)}; the mapper joins each row to its declared {@code
+   * StageDefinition} (via {@code stageId}) so the wire {@link StageView} carries the bound
+   * CaseType@version display name + ordinal. Skipped stages stay in the list at their declared
+   * ordinal; the list is sorted ASC by ordinal — the timeline never omits or reorders stages.
+   *
+   * <p>Zero-row history (zero-stage CaseType) maps to {@code stages = []} — no {@code if
+   * (history.isEmpty())} branch is needed, the empty-list mapping is the empty-stage path (Decision
+   * 19's "stage-less paths must remain unbranched in code").
+   */
+  public static CaseDto toDto(Case domain, CaseTypeConfig caseType, List<Stage> history) {
+    Map<String, StageDefinition> defsById = new HashMap<>();
+    for (StageDefinition def : caseType.stages()) {
+      defsById.put(def.id(), def);
+    }
+    List<StageView> stageViews =
+        history.stream()
+            .sorted((a, b) -> Integer.compare(a.ordinal(), b.ordinal()))
+            .map(s -> toStageView(s, defsById.get(s.stageId())))
+            .toList();
     return new CaseDto(
         domain.id(),
         domain.caseTypeId(),
@@ -39,7 +76,43 @@ public final class CaseDtoMapper {
         // Story 3.2 AC5 — null on zero-stage CaseTypes; populated from the cases table cache cols
         // (Story 3.1) for staged cases.
         domain.currentStageId(),
-        domain.currentStageOrdinal());
+        domain.currentStageOrdinal(),
+        // Story 3.3 — full stage history projection (empty list for zero-stage CaseTypes).
+        stageViews);
+  }
+
+  static StageView toStageView(Stage stage, StageDefinition def) {
+    // The history row's stageId must always match a declared stage on the bound CaseType@version.
+    // A null def here would mean schema drift between the case and its bound CaseType — a defensive
+    // fallback (Title-cased stageId) is safer than throwing inside a read-only projection.
+    String displayName = def != null ? def.displayName() : titleCase(stage.stageId());
+    return new StageView(
+        stage.stageId(),
+        displayName,
+        stage.ordinal(),
+        stage.state().name(),
+        stage.enteredAt(),
+        stage.exitedAt(),
+        stage.source(),
+        stage.sourceRef());
+  }
+
+  private static String titleCase(String id) {
+    if (id == null || id.isBlank()) return id;
+    StringBuilder sb = new StringBuilder(id.length());
+    boolean upper = true;
+    for (char c : id.toCharArray()) {
+      if (c == '-' || c == '_') {
+        sb.append(' ');
+        upper = true;
+      } else if (upper) {
+        sb.append(Character.toUpperCase(c));
+        upper = false;
+      } else {
+        sb.append(c);
+      }
+    }
+    return sb.toString();
   }
 
   public static CaseSummaryDto toSummaryDto(CaseSummary summary) {
@@ -54,13 +127,18 @@ public final class CaseDtoMapper {
   }
 
   public static CaseTypeViewDto toCaseTypeView(CaseTypeConfig caseType) {
+    List<StageDefinitionView> stages =
+        caseType.stages().stream()
+            .map(s -> new StageDefinitionView(s.id(), s.displayName(), s.ordinal()))
+            .toList();
     return new CaseTypeViewDto(
         caseType.id(),
         caseType.displayName(),
         caseType.version(),
         caseType.fields().stream().map(CaseDtoMapper::toFieldView).toList(),
         caseType.statuses(),
-        caseType.listColumns());
+        caseType.listColumns(),
+        stages);
   }
 
   static FieldView toFieldView(FieldDefinition f) {

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
@@ -154,6 +154,73 @@ class CaseControllerTest {
         .andExpect(jsonPath("$.data.caseType.statuses[0].id").value("open"));
   }
 
+  // ---- Story 3.3 AC3 — stage timeline projection on GET /api/cases/{id} -------
+
+  @Test
+  void getReturnsStageTimelineForMultiStageCase() throws Exception {
+    Case sample = sampleCase();
+    when(caseService.findById(sample.id())).thenReturn(sample);
+    when(caseService.requireCaseType("loan-application")).thenReturn(threeStageLoanType());
+    when(caseTypePermissionEvaluator.hasVerb(any(), eq("loan-application"), eq("view")))
+        .thenReturn(true);
+    when(stageRepository.loadHistory(sample.id())).thenReturn(threeStageHistory(sample.id()));
+
+    mockMvc
+        .perform(get("/api/cases/" + sample.id()).with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.stages.length()").value(3))
+        // Ordered by ordinal ASC: intake (COMPLETED) → underwriting (ACTIVE) → decision (PENDING).
+        .andExpect(jsonPath("$.data.stages[0].stageId").value("intake"))
+        .andExpect(jsonPath("$.data.stages[0].ordinal").value(0))
+        .andExpect(jsonPath("$.data.stages[0].state").value("COMPLETED"))
+        .andExpect(jsonPath("$.data.stages[0].displayName").value("Intake"))
+        .andExpect(jsonPath("$.data.stages[1].stageId").value("underwriting"))
+        .andExpect(jsonPath("$.data.stages[1].state").value("ACTIVE"))
+        .andExpect(jsonPath("$.data.stages[2].stageId").value("decision"))
+        .andExpect(jsonPath("$.data.stages[2].state").value("PENDING"))
+        // CaseTypeViewDto also exposes the declared stages for the timeline schema.
+        .andExpect(jsonPath("$.data.caseType.stages.length()").value(3))
+        .andExpect(jsonPath("$.data.caseType.stages[0].id").value("intake"))
+        .andExpect(jsonPath("$.data.caseType.stages[0].ordinal").value(0));
+  }
+
+  @Test
+  void getReturnsEmptyStageTimelineForZeroStageCase() throws Exception {
+    Case sample = sampleCase();
+    when(caseService.findById(sample.id())).thenReturn(sample);
+    when(caseService.requireCaseType("loan-application")).thenReturn(loanType());
+    when(caseTypePermissionEvaluator.hasVerb(any(), eq("loan-application"), eq("view")))
+        .thenReturn(true);
+    when(stageRepository.loadHistory(sample.id())).thenReturn(List.of());
+
+    mockMvc
+        .perform(get("/api/cases/" + sample.id()).with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.stages.length()").value(0))
+        .andExpect(jsonPath("$.data.caseType.stages.length()").value(0));
+  }
+
+  @Test
+  void getReturnsSkippedStageInOrdinalPositionForBypassedCase() throws Exception {
+    // AC3 — skipped stages stay in the list at their declared ordinal; the timeline never omits.
+    Case sample = sampleCase();
+    when(caseService.findById(sample.id())).thenReturn(sample);
+    when(caseService.requireCaseType("loan-application")).thenReturn(threeStageLoanType());
+    when(caseTypePermissionEvaluator.hasVerb(any(), eq("loan-application"), eq("view")))
+        .thenReturn(true);
+    when(stageRepository.loadHistory(sample.id()))
+        .thenReturn(threeStageHistoryWithSkip(sample.id()));
+
+    mockMvc
+        .perform(get("/api/cases/" + sample.id()).with(officerAuth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.stages.length()").value(3))
+        .andExpect(jsonPath("$.data.stages[0].state").value("COMPLETED"))
+        .andExpect(jsonPath("$.data.stages[1].stageId").value("underwriting"))
+        .andExpect(jsonPath("$.data.stages[1].state").value("SKIPPED"))
+        .andExpect(jsonPath("$.data.stages[2].state").value("ACTIVE"));
+  }
+
   @Test
   void getReturns404WhenServiceThrows() throws Exception {
     UUID id = UUID.randomUUID();
@@ -409,6 +476,101 @@ class CaseControllerTest {
         List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
         List.of("name"),
         List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))));
+  }
+
+  /** Story 3.3 — three-stage CaseType fixture (intake → underwriting → decision). */
+  private static CaseTypeConfig threeStageLoanType() {
+    return new CaseTypeConfig(
+        "loan-application",
+        "Loan Application",
+        1,
+        null,
+        new WorkflowRef("loan-application.bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("name"),
+        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))),
+        List.of(
+            new com.wkspower.platform.domain.config.model.StageDefinition("intake", "Intake", 0),
+            new com.wkspower.platform.domain.config.model.StageDefinition(
+                "underwriting", "Underwriting", 1),
+            new com.wkspower.platform.domain.config.model.StageDefinition(
+                "decision", "Decision", 2)));
+  }
+
+  /** Story 3.3 — happy path: stage 0 COMPLETED, stage 1 ACTIVE, stage 2 PENDING. */
+  private static List<com.wkspower.platform.domain.model.Stage> threeStageHistory(UUID caseId) {
+    Instant t0 = NOW;
+    Instant t1 = NOW.plusSeconds(60);
+    return List.of(
+        new com.wkspower.platform.domain.model.Stage(
+            UUID.randomUUID(),
+            caseId,
+            "intake",
+            0,
+            com.wkspower.platform.domain.model.StageState.COMPLETED,
+            t0,
+            t1,
+            "manual",
+            null),
+        new com.wkspower.platform.domain.model.Stage(
+            UUID.randomUUID(),
+            caseId,
+            "underwriting",
+            1,
+            com.wkspower.platform.domain.model.StageState.ACTIVE,
+            t1,
+            null,
+            "manual",
+            null),
+        new com.wkspower.platform.domain.model.Stage(
+            UUID.randomUUID(),
+            caseId,
+            "decision",
+            2,
+            com.wkspower.platform.domain.model.StageState.PENDING,
+            null,
+            null,
+            null,
+            null));
+  }
+
+  /** Story 3.3 — bypass case: stage 0 COMPLETED, stage 1 SKIPPED, stage 2 ACTIVE. */
+  private static List<com.wkspower.platform.domain.model.Stage> threeStageHistoryWithSkip(
+      UUID caseId) {
+    Instant t0 = NOW;
+    Instant t1 = NOW.plusSeconds(60);
+    return List.of(
+        new com.wkspower.platform.domain.model.Stage(
+            UUID.randomUUID(),
+            caseId,
+            "intake",
+            0,
+            com.wkspower.platform.domain.model.StageState.COMPLETED,
+            t0,
+            t1,
+            "manual",
+            null),
+        new com.wkspower.platform.domain.model.Stage(
+            UUID.randomUUID(),
+            caseId,
+            "underwriting",
+            1,
+            com.wkspower.platform.domain.model.StageState.SKIPPED,
+            null,
+            t1,
+            "manual",
+            null),
+        new com.wkspower.platform.domain.model.Stage(
+            UUID.randomUUID(),
+            caseId,
+            "decision",
+            2,
+            com.wkspower.platform.domain.model.StageState.ACTIVE,
+            t1,
+            null,
+            "manual",
+            null));
   }
 
   /** Authenticated post-processor with a valid {@link AuthenticatedUser} principal. */

--- a/frontend/src/components/workspace/CaseDetailPanel.routing.test.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.routing.test.tsx
@@ -32,6 +32,7 @@ const dto: CaseDto = {
     statuses: [],
     listColumns: [],
   },
+  stages: [],
 };
 
 function HostedDetail() {

--- a/frontend/src/components/workspace/CaseDetailPanel.stageTimeline.test.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.stageTimeline.test.tsx
@@ -1,0 +1,117 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import { server } from '@/test/server';
+import type { CaseDto } from '@/types/case';
+
+import { CaseDetailPanel } from './CaseDetailPanel';
+
+const ID = '11111111-2222-3333-4444-555555555555';
+
+function baseDto(over: Partial<CaseDto> = {}): CaseDto {
+  return {
+    id: ID,
+    caseTypeId: 'loan',
+    caseTypeVersion: 1,
+    status: 'open',
+    assignee: null,
+    data: {},
+    processInstanceId: null,
+    documentCount: 0,
+    createdAt: '2026-04-01T00:00:00Z',
+    createdBy: null,
+    updatedAt: '2026-04-02T00:00:00Z',
+    version: 1,
+    caseType: {
+      id: 'loan',
+      displayName: 'Loan',
+      version: 1,
+      fields: [],
+      statuses: [],
+      listColumns: [],
+      stages: [],
+    },
+    stages: [],
+    ...over,
+  };
+}
+
+function wrap(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>
+        <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('CaseDetailPanel × StageTimeline integration (AC2, AC5, AC11.5)', () => {
+  it('does NOT mount StageTimeline for a zero-stage CaseType', async () => {
+    server.use(
+      http.get(`/api/cases/${ID}`, () => HttpResponse.json({ data: baseDto(), meta: {} })),
+    );
+    const { container } = wrap(<CaseDetailPanel caseId={ID} onClose={() => undefined} />);
+    // Wait for the case to load (heading appears).
+    await screen.findByRole('heading', { level: 1 });
+    expect(container.querySelector('nav.wks-stage-timeline')).toBeNull();
+  });
+
+  it('mounts StageTimeline above the tab list for a multi-stage case', async () => {
+    const dto = baseDto({
+      caseType: {
+        id: 'loan',
+        displayName: 'Loan',
+        version: 1,
+        fields: [],
+        statuses: [],
+        listColumns: [],
+        stages: [
+          { id: 'intake', displayName: 'Intake', ordinal: 0 },
+          { id: 'decision', displayName: 'Decision', ordinal: 1 },
+        ],
+      },
+      stages: [
+        {
+          stageId: 'intake',
+          displayName: 'Intake',
+          ordinal: 0,
+          state: 'COMPLETED',
+          enteredAt: '2026-04-01T09:00:00Z',
+          exitedAt: '2026-04-02T13:00:00Z',
+          source: 'manual',
+          sourceRef: null,
+        },
+        {
+          stageId: 'decision',
+          displayName: 'Decision',
+          ordinal: 1,
+          state: 'ACTIVE',
+          enteredAt: '2026-04-02T13:00:00Z',
+          exitedAt: null,
+          source: 'manual',
+          sourceRef: null,
+        },
+      ],
+    });
+    server.use(http.get(`/api/cases/${ID}`, () => HttpResponse.json({ data: dto, meta: {} })));
+    const { container } = wrap(<CaseDetailPanel caseId={ID} onClose={() => undefined} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('nav.wks-stage-timeline')).not.toBeNull();
+    });
+    // The timeline appears inside the <header>, which sits before the <CaseActionBar> + <Tabs>.
+    const header = container.querySelector('header');
+    expect(header?.querySelector('nav.wks-stage-timeline')).not.toBeNull();
+
+    // Both stage labels render.
+    expect(screen.getByText('Intake')).toBeInTheDocument();
+    expect(screen.getByText('Decision')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/workspace/CaseDetailPanel.tabs.test.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.tabs.test.tsx
@@ -34,6 +34,7 @@ const dto: CaseDto = {
     statuses: [],
     listColumns: [],
   },
+  stages: [],
 };
 
 function wrap(ui: ReactNode) {

--- a/frontend/src/components/workspace/CaseDetailPanel.test.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.test.tsx
@@ -44,6 +44,7 @@ const dto: CaseDto = {
     statuses: [],
     listColumns: [],
   },
+  stages: [],
 };
 
 function wrap(ui: ReactNode) {

--- a/frontend/src/components/workspace/CaseDetailPanel.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.tsx
@@ -13,6 +13,7 @@ import { CaseActionBar } from './CaseActionBar';
 import { CaseBreadcrumbs } from './CaseBreadcrumbs';
 import { DocumentsTabPlaceholder } from './DocumentsTabPlaceholder';
 import { PropertiesTab } from './PropertiesTab';
+import { StageTimeline } from './StageTimeline';
 import { StatusBadge } from './StatusBadge';
 
 const HEADING_ID = 'case-detail-heading';
@@ -213,6 +214,16 @@ export function CaseDetailPanel({ caseId, onClose }: CaseDetailPanelProps) {
           </HeadingFocusable>
           <StatusBadge status={caseDto.status} caseType={caseDto.caseType} />
         </div>
+        {/*
+          Story 3.3 — Stage timeline. Single truthy-length gate (AC2 / Decision 19): the absence
+          of stages is the empty list, no `else` branch. `caseType.stages` is optional in TS for
+          backward-compat with pre-3.3 fixtures; the runtime read is wire-driven.
+        */}
+        {(caseDto.caseType.stages?.length ?? 0) > 0 && caseDto.stages.length > 0 && (
+          <div className="mt-3">
+            <StageTimeline stages={caseDto.stages} caseTypeStageDefs={caseDto.caseType.stages} />
+          </div>
+        )}
         <span className="sr-only" aria-live="polite">
           {t('case.detail.announcement', { idShort })}
         </span>

--- a/frontend/src/components/workspace/PropertiesTab.test.tsx
+++ b/frontend/src/components/workspace/PropertiesTab.test.tsx
@@ -62,6 +62,7 @@ function caseDto(data: Record<string, unknown>): CaseDto {
     updatedAt: '2026-04-02T00:00:00Z',
     version: 1,
     caseType: ctView(),
+    stages: [],
   };
 }
 

--- a/frontend/src/components/workspace/StageTimeline.a11y.test.tsx
+++ b/frontend/src/components/workspace/StageTimeline.a11y.test.tsx
@@ -1,0 +1,86 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import type { StageView } from '@/types/case';
+
+import { StageTimeline } from './StageTimeline';
+
+function wrap(ui: React.ReactNode) {
+  return render(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
+}
+
+describe('StageTimeline — accessibility (AC8, AC11.4)', () => {
+  it('renders <nav aria-label> > <ol> with aria-current="step" on the active stage', () => {
+    const stages: StageView[] = [
+      {
+        stageId: 's0',
+        displayName: 'Intake',
+        ordinal: 0,
+        state: 'COMPLETED',
+        enteredAt: '2026-04-01T00:00:00Z',
+        exitedAt: '2026-04-02T00:00:00Z',
+        source: 'manual',
+        sourceRef: null,
+      },
+      {
+        stageId: 's1',
+        displayName: 'Decision',
+        ordinal: 1,
+        state: 'ACTIVE',
+        enteredAt: '2026-04-02T00:00:00Z',
+        exitedAt: null,
+        source: 'manual',
+        sourceRef: null,
+      },
+    ];
+    const { container } = wrap(<StageTimeline stages={stages} />);
+
+    const nav = container.querySelector('nav.wks-stage-timeline');
+    expect(nav).not.toBeNull();
+    expect(nav?.getAttribute('aria-label')).toBe('Stage timeline');
+
+    const list = nav?.querySelector('ol');
+    expect(list).not.toBeNull();
+
+    const items = list?.querySelectorAll('li[data-stage-state]');
+    expect(items?.length).toBe(2);
+    // Only the ACTIVE stage carries aria-current="step".
+    expect(items?.[0]?.getAttribute('aria-current')).toBeNull();
+    expect(items?.[1]?.getAttribute('aria-current')).toBe('step');
+  });
+
+  it('renders an aria-live="polite" region announcing the full stage list on mount', () => {
+    const stages: StageView[] = [
+      {
+        stageId: 's0',
+        displayName: 'Intake',
+        ordinal: 0,
+        state: 'COMPLETED',
+        enteredAt: '2026-04-01T00:00:00Z',
+        exitedAt: '2026-04-02T00:00:00Z',
+        source: 'manual',
+        sourceRef: null,
+      },
+      {
+        stageId: 's1',
+        displayName: 'Decision',
+        ordinal: 1,
+        state: 'ACTIVE',
+        enteredAt: '2026-04-02T00:00:00Z',
+        exitedAt: null,
+        source: 'manual',
+        sourceRef: null,
+      },
+    ];
+    const { container } = wrap(<StageTimeline stages={stages} />);
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live).not.toBeNull();
+    // The announcement names the count and surfaces each stage's display name + state label.
+    expect(live?.textContent).toContain('2 stages');
+    expect(live?.textContent).toContain('Intake');
+    expect(live?.textContent).toContain('Completed');
+    expect(live?.textContent).toContain('Decision');
+    expect(live?.textContent).toContain('Current');
+  });
+});

--- a/frontend/src/components/workspace/StageTimeline.keyboard.test.tsx
+++ b/frontend/src/components/workspace/StageTimeline.keyboard.test.tsx
@@ -1,0 +1,83 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import type { StageView } from '@/types/case';
+
+import { StageTimeline } from './StageTimeline';
+
+function makeStages(count: number): StageView[] {
+  return Array.from({ length: count }, (_, i) => ({
+    stageId: `s${i}`,
+    displayName: `Stage ${i}`,
+    ordinal: i,
+    state: i === 0 ? 'COMPLETED' : i === 1 ? 'ACTIVE' : 'PENDING',
+    enteredAt: i <= 1 ? '2026-04-01T00:00:00Z' : null,
+    exitedAt: i === 0 ? '2026-04-02T00:00:00Z' : null,
+    source: i <= 1 ? 'manual' : null,
+    sourceRef: null,
+  }));
+}
+
+function wrap(ui: React.ReactNode) {
+  return render(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
+}
+
+describe('StageTimeline — keyboard navigation (AC7, AC11.2)', () => {
+  it('initial focus targets the ACTIVE stage; ArrowRight steps forward; ArrowLeft back', async () => {
+    const user = userEvent.setup();
+    const { container } = wrap(<StageTimeline stages={makeStages(4)} />);
+    const nodes = container.querySelectorAll('button.wks-stage-node');
+    expect(nodes).toHaveLength(4);
+
+    // Roving tabindex: only the active stage (index 1) starts with tabIndex=0.
+    expect(nodes[0]?.getAttribute('tabindex')).toBe('-1');
+    expect(nodes[1]?.getAttribute('tabindex')).toBe('0');
+    expect(nodes[2]?.getAttribute('tabindex')).toBe('-1');
+
+    // Move focus to the active node first (Tab simulation via direct focus is fine — we test
+    // the component's roving behavior, not the browser's tab order).
+    (nodes[1] as HTMLButtonElement).focus();
+    expect(document.activeElement).toBe(nodes[1]);
+
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(nodes[2]);
+
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(nodes[3]);
+
+    // No-wrap: another ArrowRight stays on last node.
+    await user.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(nodes[3]);
+
+    await user.keyboard('{ArrowLeft}');
+    expect(document.activeElement).toBe(nodes[2]);
+  });
+
+  it('Home jumps to first node, End jumps to last (AC7)', async () => {
+    const user = userEvent.setup();
+    const { container } = wrap(<StageTimeline stages={makeStages(5)} />);
+    const nodes = container.querySelectorAll('button.wks-stage-node');
+    (nodes[1] as HTMLButtonElement).focus();
+
+    await user.keyboard('{End}');
+    expect(document.activeElement).toBe(nodes[4]);
+
+    await user.keyboard('{Home}');
+    expect(document.activeElement).toBe(nodes[0]);
+  });
+
+  it('ArrowDown / ArrowUp move focus identically to ArrowRight / ArrowLeft', async () => {
+    const user = userEvent.setup();
+    const { container } = wrap(<StageTimeline stages={makeStages(3)} />);
+    const nodes = container.querySelectorAll('button.wks-stage-node');
+    (nodes[1] as HTMLButtonElement).focus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(nodes[2]);
+
+    await user.keyboard('{ArrowUp}');
+    expect(document.activeElement).toBe(nodes[1]);
+  });
+});

--- a/frontend/src/components/workspace/StageTimeline.popover.test.tsx
+++ b/frontend/src/components/workspace/StageTimeline.popover.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import type { StageView } from '@/types/case';
+
+import { StageTimeline } from './StageTimeline';
+
+function wrap(ui: React.ReactNode) {
+  return render(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
+}
+
+const stages: StageView[] = [
+  {
+    stageId: 'intake',
+    displayName: 'Intake',
+    ordinal: 0,
+    state: 'COMPLETED',
+    enteredAt: '2026-04-01T09:00:00Z',
+    exitedAt: '2026-04-02T13:00:00Z',
+    source: 'manual',
+    sourceRef: null,
+  },
+  {
+    stageId: 'underwriting',
+    displayName: 'Underwriting',
+    ordinal: 1,
+    state: 'SKIPPED',
+    enteredAt: null,
+    exitedAt: '2026-04-02T13:00:00Z',
+    source: 'manual',
+    sourceRef: 'risk-decision-bypass',
+  },
+  {
+    stageId: 'decision',
+    displayName: 'Decision',
+    ordinal: 2,
+    state: 'ACTIVE',
+    enteredAt: '2026-04-02T13:00:00Z',
+    exitedAt: null,
+    source: 'manual',
+    sourceRef: null,
+  },
+];
+
+describe('StageTimeline — popover content per state (AC7, AC11.3)', () => {
+  it('opens sticky popover on Enter activation and shows duration for COMPLETED', async () => {
+    const user = userEvent.setup();
+    const { container } = wrap(<StageTimeline stages={stages} />);
+    const completedNode = container.querySelector(
+      'li[data-stage-id="intake"] button.wks-stage-node',
+    ) as HTMLButtonElement;
+    completedNode.focus();
+
+    await user.click(completedNode);
+    // Radix portals popover content; assert via screen.
+    await waitFor(() => {
+      expect(screen.getAllByText(/In stage for/i).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('shows "Skipped" only (no reason text) for SKIPPED — Q2 default', async () => {
+    const user = userEvent.setup();
+    const { container } = wrap(<StageTimeline stages={stages} />);
+    const skippedNode = container.querySelector(
+      'li[data-stage-id="underwriting"] button.wks-stage-node',
+    ) as HTMLButtonElement;
+    skippedNode.focus();
+
+    await user.click(skippedNode);
+    await waitFor(() => {
+      // The popover surfaces the literal "Skipped" label; the sourceRef ("risk-decision-bypass")
+      // is NEVER rendered into the popover (Q2 lock — backend is sole source of truth, no rich
+      // payload until Epic 4).
+      const skippedLabels = screen.getAllByText(/Skipped/);
+      expect(skippedLabels.length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(/risk-decision-bypass/)).toBeNull();
+  });
+
+  it('shows "Current since" for ACTIVE', async () => {
+    const user = userEvent.setup();
+    const { container } = wrap(<StageTimeline stages={stages} />);
+    const activeNode = container.querySelector(
+      'li[data-stage-id="decision"] button.wks-stage-node',
+    ) as HTMLButtonElement;
+    activeNode.focus();
+
+    await user.click(activeNode);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Current since/i).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/components/workspace/StageTimeline.test.tsx
+++ b/frontend/src/components/workspace/StageTimeline.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import type { StageView } from '@/types/case';
+
+import { StageTimeline } from './StageTimeline';
+
+function wrap(ui: React.ReactNode) {
+  return render(<TooltipProvider delayDuration={0}>{ui}</TooltipProvider>);
+}
+
+function pending(idx: number, name = `Stage ${idx}`): StageView {
+  return {
+    stageId: `s${idx}`,
+    displayName: name,
+    ordinal: idx,
+    state: 'PENDING',
+    enteredAt: null,
+    exitedAt: null,
+    source: null,
+    sourceRef: null,
+  };
+}
+
+describe('StageTimeline — render-state matrix (AC1, AC2, AC11.1)', () => {
+  it('renders three nodes for COMPLETED → ACTIVE → PENDING', () => {
+    const stages: StageView[] = [
+      {
+        stageId: 'intake',
+        displayName: 'Intake',
+        ordinal: 0,
+        state: 'COMPLETED',
+        enteredAt: '2026-04-01T09:00:00Z',
+        exitedAt: '2026-04-02T13:00:00Z',
+        source: 'manual',
+        sourceRef: null,
+      },
+      {
+        stageId: 'underwriting',
+        displayName: 'Underwriting',
+        ordinal: 1,
+        state: 'ACTIVE',
+        enteredAt: '2026-04-02T13:00:00Z',
+        exitedAt: null,
+        source: 'manual',
+        sourceRef: null,
+      },
+      {
+        stageId: 'decision',
+        displayName: 'Decision',
+        ordinal: 2,
+        state: 'PENDING',
+        enteredAt: null,
+        exitedAt: null,
+        source: null,
+        sourceRef: null,
+      },
+    ];
+    const { container } = wrap(<StageTimeline stages={stages} />);
+
+    // Three list items, in declared ordinal order.
+    const items = container.querySelectorAll('li[data-stage-state]');
+    expect(items).toHaveLength(3);
+    expect(items[0]?.getAttribute('data-stage-state')).toBe('completed');
+    expect(items[1]?.getAttribute('data-stage-state')).toBe('active');
+    expect(items[2]?.getAttribute('data-stage-state')).toBe('pending');
+
+    // Active stage carries the WAI-ARIA aria-current="step" treatment (AC8).
+    expect(items[1]?.getAttribute('aria-current')).toBe('step');
+    // Non-active stages do NOT carry aria-current.
+    expect(items[0]?.getAttribute('aria-current')).toBeNull();
+    expect(items[2]?.getAttribute('aria-current')).toBeNull();
+
+    // Display names are visible.
+    expect(screen.getByText('Intake')).toBeInTheDocument();
+    expect(screen.getByText('Underwriting')).toBeInTheDocument();
+    expect(screen.getByText('Decision')).toBeInTheDocument();
+  });
+
+  it('marks the SKIPPED stage at its declared ordinal (AC3 — skipped never omitted)', () => {
+    const stages: StageView[] = [
+      {
+        stageId: 'intake',
+        displayName: 'Intake',
+        ordinal: 0,
+        state: 'COMPLETED',
+        enteredAt: '2026-04-01T09:00:00Z',
+        exitedAt: '2026-04-01T10:00:00Z',
+        source: 'manual',
+        sourceRef: null,
+      },
+      {
+        stageId: 'underwriting',
+        displayName: 'Underwriting',
+        ordinal: 1,
+        state: 'SKIPPED',
+        enteredAt: null,
+        exitedAt: '2026-04-01T10:00:00Z',
+        source: 'manual',
+        sourceRef: null,
+      },
+      {
+        stageId: 'decision',
+        displayName: 'Decision',
+        ordinal: 2,
+        state: 'ACTIVE',
+        enteredAt: '2026-04-01T10:00:00Z',
+        exitedAt: null,
+        source: 'manual',
+        sourceRef: null,
+      },
+    ];
+    const { container } = wrap(<StageTimeline stages={stages} />);
+    const items = container.querySelectorAll('li[data-stage-state]');
+    expect(items[1]?.getAttribute('data-stage-state')).toBe('skipped');
+    // Skipped stage label retains italic-opacity treatment via class hook.
+    const skippedMeta = items[1]?.querySelector('.wks-stage-meta');
+    expect(skippedMeta?.className).toMatch(/italic/);
+  });
+
+  it('returns null on empty stages array (AC2 — no DOM, no skeleton)', () => {
+    const { container } = wrap(<StageTimeline stages={[]} />);
+    expect(container.querySelector('nav')).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('forces vertical-stepper layout when stages.length > 12 (Q1 cap)', () => {
+    const thirteen = Array.from({ length: 13 }, (_, i) => pending(i, `S${i}`));
+    const { container } = wrap(<StageTimeline stages={thirteen} />);
+    const nav = container.querySelector('nav.wks-stage-timeline');
+    expect(nav?.getAttribute('data-layout')).toBe('vertical');
+  });
+
+  it('emits WKS-UI-2001 console.warn for two ACTIVE stages (AC10 — defensive)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const stages: StageView[] = [
+      {
+        stageId: 's0',
+        displayName: 'A',
+        ordinal: 0,
+        state: 'ACTIVE',
+        enteredAt: '2026-04-01T00:00:00Z',
+        exitedAt: null,
+        source: 'manual',
+        sourceRef: null,
+      },
+      {
+        stageId: 's1',
+        displayName: 'B',
+        ordinal: 1,
+        state: 'ACTIVE',
+        enteredAt: '2026-04-01T01:00:00Z',
+        exitedAt: null,
+        source: 'manual',
+        sourceRef: null,
+      },
+    ];
+    wrap(<StageTimeline stages={stages} />);
+    expect(warn).toHaveBeenCalled();
+    const msg = warn.mock.calls[0]?.[0] as string;
+    expect(msg).toMatch(/WKS-UI-2001/);
+    warn.mockRestore();
+  });
+});

--- a/frontend/src/components/workspace/StageTimeline.tsx
+++ b/frontend/src/components/workspace/StageTimeline.tsx
@@ -1,0 +1,599 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover';
+import { t } from '@/i18n';
+import { cn } from '@/lib/cn';
+import { formatDate, formatDateTime } from '@/lib/formatDate';
+import type { StageState, StageView } from '@/types/case';
+import type { StageDefinitionView } from '@/types/caseType';
+
+/**
+ * Story 3.3 — Stage Timeline component.
+ *
+ * Pure presentational. Backend is the sole source of truth for `state` (AC1 / D1 invariant). The
+ * component never infers `ACTIVE` / `SKIPPED` from any other field; it does not call `useCase`,
+ * does not subscribe to SSE, does not mutate.
+ *
+ * Layout: horizontal at >= 960px pane width; vertical stepper below 960px AND for any case with
+ * `stages.length > MAX_HORIZONTAL_STAGES` (Q1 default = 12). Pane width is observed via
+ * `ResizeObserver` — never `window.innerWidth` (split-pane width !== viewport width).
+ *
+ * Animation: NONE in Phase 0. The `experimental_animate` prop is exposed for Story 4.3 to flip on
+ * later when the SSE bridge lands. `prefers-reduced-motion: reduce` suppresses the active-node
+ * pulse class.
+ */
+
+/** Q1 default — locked 2026-05-05. Backend `WKS-CFG-034` validator parked as Story 3.8. */
+export const MAX_HORIZONTAL_STAGES = 12;
+
+/** Pane-width breakpoint between horizontal layout and vertical stepper. */
+export const HORIZONTAL_LAYOUT_MIN_WIDTH = 960;
+
+/** Hover delay before the popover opens (AC7). */
+const HOVER_DELAY_MS = 200;
+
+export interface StageTimelineProps {
+  /** Ordered list (by ordinal ASC) — comes from `caseDto.stages` directly. */
+  stages: StageView[];
+  /**
+   * Optional pass-through for the declared schema. When supplied, used as a fallback for stage
+   * `displayName` resolution (the wire `StageView.displayName` is normally already populated by
+   * the backend mapper).
+   */
+  caseTypeStageDefs?: StageDefinitionView[];
+  /**
+   * Story 4.3 wires this to `true` once the SSE bridge lands, flipping on the cross-fade animation
+   * grammar from `ux-stage-timeline.md` §5. Default `false` in Phase 0 — visual transitions are
+   * instant per Q3 default. Underscore prefix mirrors the spec's `experimental_` notation.
+   */
+  experimental_animate?: boolean;
+}
+
+type LayoutMode = 'horizontal' | 'vertical';
+
+/**
+ * Returns the lowercased CSS-class-name token for a state. Wire is uppercase — class names are
+ * lowercase per `ux-stage-timeline.md` §11.
+ */
+function stateClass(state: StageState): string {
+  return state.toLowerCase();
+}
+
+/**
+ * Format a duration between two ISO-8601 timestamps as a coarse human-readable string. Used for
+ * the completed-stage popover (`In stage for 1d 4h`). Coarse on purpose — exact seconds would feel
+ * busy and the BFSI-style use cases never need sub-minute precision.
+ */
+function formatDuration(fromIso: string, toIso: string): string {
+  const ms = new Date(toIso).getTime() - new Date(fromIso).getTime();
+  if (!Number.isFinite(ms) || ms <= 0) return '0m';
+  const minutes = Math.floor(ms / 60000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  if (days >= 1) {
+    const remHours = hours - days * 24;
+    return remHours > 0 ? `${days}d ${remHours}h` : `${days}d`;
+  }
+  if (hours >= 1) {
+    const remMin = minutes - hours * 60;
+    return remMin > 0 ? `${hours}h ${remMin}m` : `${hours}h`;
+  }
+  return `${Math.max(1, minutes)}m`;
+}
+
+/** Produce the inline timestamp slot for each state. Returns `null` for `pending`. */
+function inlineTimestamp(stage: StageView): string | null {
+  switch (stage.state) {
+    case 'COMPLETED':
+      if (stage.enteredAt && stage.exitedAt) {
+        return t('stageTimeline.timestamp.enteredAndExited', {
+          entered: formatDate(stage.enteredAt),
+          exited: formatDate(stage.exitedAt),
+        });
+      }
+      return stage.exitedAt
+        ? t('stageTimeline.timestamp.exited', { date: formatDate(stage.exitedAt) })
+        : null;
+    case 'ACTIVE':
+      return stage.enteredAt
+        ? t('stageTimeline.timestamp.currentSince', { date: formatDate(stage.enteredAt) })
+        : null;
+    case 'SKIPPED':
+      return stage.exitedAt
+        ? t('stageTimeline.timestamp.skippedOn', { date: formatDate(stage.exitedAt) })
+        : t('stageTimeline.popover.skipped');
+    case 'PENDING':
+    default:
+      return null;
+  }
+}
+
+/** Translate the wire-state to the human-readable label used in aria announcements + popovers. */
+function stateLabel(state: StageState): string {
+  switch (state) {
+    case 'COMPLETED':
+      return t('stageTimeline.state.completed');
+    case 'ACTIVE':
+      return t('stageTimeline.state.active');
+    case 'SKIPPED':
+      return t('stageTimeline.state.skipped');
+    case 'PENDING':
+    default:
+      return t('stageTimeline.state.pending');
+  }
+}
+
+/**
+ * Per-state popover body. `pending` returns nothing — pending stages should feel quiet, not invite
+ * speculation (`ux-stage-timeline.md` §6.1).
+ */
+function popoverExtras(stage: StageView): string | null {
+  switch (stage.state) {
+    case 'COMPLETED':
+      if (stage.enteredAt && stage.exitedAt) {
+        return t('stageTimeline.popover.completed.duration', {
+          duration: formatDuration(stage.enteredAt, stage.exitedAt),
+        });
+      }
+      return null;
+    case 'ACTIVE':
+      return stage.enteredAt
+        ? t('stageTimeline.popover.active.currentSince', {
+            timestamp: formatDateTime(stage.enteredAt),
+          })
+        : null;
+    case 'SKIPPED':
+      // Q2 lock 2026-05-05 — show "Skipped" only. Richer payload deferred to Epic 4.
+      return t('stageTimeline.popover.skipped');
+    case 'PENDING':
+    default:
+      return null;
+  }
+}
+
+/**
+ * ResizeObserver-based pane width hook. Story spec calls for the same idiom as
+ * `lib/layoutBreakpoints.ts` — that file holds constants, not a hook, so we implement the hook
+ * locally and keep the breakpoint constant exported above. Returns `null` until the first
+ * observation lands, so SSR / pre-mount renders don't lock into the wrong layout.
+ */
+function usePaneWidth(): {
+  ref: (node: HTMLElement | null) => void;
+  width: number | null;
+} {
+  const [width, setWidth] = useState<number | null>(null);
+  // `globalThis.ResizeObserver` keeps the ESLint `no-undef` rule happy without adding a global.
+  const RO = (globalThis as { ResizeObserver?: typeof globalThis.ResizeObserver }).ResizeObserver;
+  type ROInstance = InstanceType<NonNullable<typeof RO>>;
+  const observerRef = useRef<ROInstance | null>(null);
+
+  const ref = useCallback(
+    (node: HTMLElement | null) => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+      if (!node) {
+        setWidth(null);
+        return;
+      }
+      if (!RO) {
+        setWidth(node.getBoundingClientRect().width);
+        return;
+      }
+      setWidth(node.getBoundingClientRect().width);
+      const observer = new RO((entries) => {
+        const entry = entries[0];
+        if (entry) setWidth(entry.contentRect.width);
+      });
+      observer.observe(node);
+      observerRef.current = observer;
+    },
+    [RO],
+  );
+
+  useEffect(
+    () => () => {
+      observerRef.current?.disconnect();
+    },
+    [],
+  );
+
+  return { ref, width };
+}
+
+/** Inconsistent-state defensive `console.warn` (AC10 / WKS-UI-2001). */
+function warnIfInconsistent(stages: StageView[]): void {
+  const activeCount = stages.filter((s) => s.state === 'ACTIVE').length;
+  if (activeCount > 1) {
+    // eslint-disable-next-line no-console
+    console.warn(`WKS-UI-2001: inconsistent stage state — ${activeCount} ACTIVE stages for case`);
+  }
+}
+
+interface StageNodeProps {
+  stage: StageView;
+  isFocused: boolean;
+  layout: LayoutMode;
+  onFocus: () => void;
+}
+
+/**
+ * One node + (optional) connector + label. Wraps in a Popover so hover and Enter/Space open the
+ * same popover content. The trigger is a `<button>` for native focus + activation semantics.
+ */
+const StageNode = forwardRef<HTMLButtonElement, StageNodeProps>(function StageNode(
+  { stage, isFocused, layout, onFocus },
+  ref,
+) {
+  const cls = stateClass(stage.state);
+  const inline = inlineTimestamp(stage);
+  const extras = popoverExtras(stage);
+  const ts = stage.enteredAt ?? stage.exitedAt;
+
+  // Hover delay (AC7): Radix Popover doesn't support hover-to-open natively; we manage `open`
+  // ourselves with a delayed timer. Click / Enter / Space toggle the sticky popover.
+  const [open, setOpen] = useState(false);
+  const [sticky, setSticky] = useState(false);
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelHoverTimer = () => {
+    if (hoverTimer.current) {
+      clearTimeout(hoverTimer.current);
+      hoverTimer.current = null;
+    }
+  };
+
+  const onPointerEnter = () => {
+    if (sticky) return;
+    cancelHoverTimer();
+    hoverTimer.current = setTimeout(() => setOpen(true), HOVER_DELAY_MS);
+  };
+  const onPointerLeave = () => {
+    cancelHoverTimer();
+    if (!sticky) setOpen(false);
+  };
+
+  useEffect(() => () => cancelHoverTimer(), []);
+
+  const toggleSticky = () => {
+    setSticky((s) => {
+      const next = !s;
+      setOpen(next);
+      return next;
+    });
+  };
+
+  return (
+    <li
+      role="listitem"
+      aria-current={stage.state === 'ACTIVE' ? 'step' : undefined}
+      data-stage-state={cls}
+      data-stage-id={stage.stageId}
+      className={cn(
+        'wks-stage-item',
+        layout === 'horizontal'
+          ? 'flex flex-col items-center text-center min-w-[120px] max-w-[200px] flex-1'
+          : 'flex flex-row items-start gap-3 py-2',
+      )}
+    >
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) setSticky(false);
+        }}
+      >
+        <PopoverTrigger asChild>
+          <button
+            ref={ref}
+            type="button"
+            tabIndex={isFocused ? 0 : -1}
+            onFocus={onFocus}
+            onPointerEnter={onPointerEnter}
+            onPointerLeave={onPointerLeave}
+            onClick={(e) => {
+              // Block the Radix default (which would open without sticky tracking) so we can
+              // manage open + sticky in one place.
+              e.preventDefault();
+              toggleSticky();
+            }}
+            data-state={cls}
+            aria-label={t('stageTimeline.aria.itemSummary', {
+              ordinal: String(stage.ordinal + 1),
+              name: stage.displayName,
+              state: stateLabel(stage.state),
+            })}
+            className={cn(
+              'wks-stage-node relative inline-flex shrink-0 rounded-full border-2 transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-4',
+              stage.state === 'COMPLETED' && 'size-3 border-[var(--success)] bg-[var(--success)]',
+              stage.state === 'ACTIVE' &&
+                'size-3.5 border-[var(--primary)] bg-[var(--primary)] shadow-[0_0_0_4px_color-mix(in_srgb,var(--primary)_30%,transparent)] motion-safe:animate-pulse',
+              stage.state === 'SKIPPED' && 'size-3 border-[var(--border)] bg-transparent',
+              stage.state === 'PENDING' && 'size-3 border-[var(--border)] bg-transparent',
+            )}
+          />
+        </PopoverTrigger>
+        <PopoverContent className="max-w-xs space-y-1 text-sm" align="center">
+          <div className="font-medium">{stage.displayName}</div>
+          <div className="text-[var(--muted-foreground)]">{stateLabel(stage.state)}</div>
+          {ts && <div className="tabular-nums text-xs">{formatDateTime(ts)}</div>}
+          {extras && <div className="text-xs text-[var(--muted-foreground)]">{extras}</div>}
+        </PopoverContent>
+      </Popover>
+
+      <div
+        className={cn(
+          'wks-stage-meta',
+          layout === 'horizontal' ? 'mt-2 px-1' : 'flex-1',
+          stage.state === 'PENDING' && 'opacity-60',
+          stage.state === 'SKIPPED' && 'italic opacity-70',
+        )}
+      >
+        <div className="text-sm font-medium leading-tight">{stage.displayName}</div>
+        {inline && (
+          <div className="mt-0.5 text-xs tabular-nums text-[var(--muted-foreground)]">{inline}</div>
+        )}
+      </div>
+    </li>
+  );
+});
+
+interface ConnectorProps {
+  /** State of the stage *to the left* of the connector (horizontal) or above it (vertical). */
+  fromState: StageState;
+  /** State of the stage *to the right* of the connector (horizontal) or below it (vertical). */
+  toState: StageState;
+  layout: LayoutMode;
+}
+
+/**
+ * Connector between two stage nodes. Rule (AC1, `ux-stage-timeline.md` §2):
+ * - both completed → solid 2px to next
+ * - skipped boundary → dashed in-edge / solid out-edge — meaning if one of {from, to} is SKIPPED,
+ *   the connector touching the skipped node is dashed; the other half stays solid.
+ * - pending → solid 1.5px neutral
+ *
+ * Implementation: render a single line, but split visually only at skip boundaries. To keep DOM
+ * small we use a 2-cell flex (left half + right half) and toggle dashed-ness per side.
+ */
+function Connector({ fromState, toState, layout }: ConnectorProps) {
+  const fromDashed = fromState === 'SKIPPED';
+  const toDashed = toState === 'SKIPPED';
+  const isPending = fromState === 'PENDING' && toState === 'PENDING';
+  const thickness = isPending ? 'border-[1.5px]' : 'border-2';
+  const color = isPending ? 'border-[var(--border)]' : 'border-[var(--success)]';
+
+  if (layout === 'horizontal') {
+    return (
+      <div aria-hidden className="flex h-0 flex-1 items-center self-start mt-[6px]">
+        <div
+          className={cn(
+            'h-0 w-1/2 border-t',
+            thickness,
+            color,
+            fromDashed && 'border-dashed border-[var(--border)]',
+          )}
+        />
+        <div
+          className={cn(
+            'h-0 w-1/2 border-t',
+            thickness,
+            color,
+            toDashed && 'border-dashed border-[var(--border)]',
+          )}
+        />
+      </div>
+    );
+  }
+
+  // Vertical stepper rail.
+  return (
+    <div aria-hidden className="ml-[5px] flex w-0 flex-col items-stretch self-start">
+      <div
+        className={cn(
+          'h-3 w-0 border-l',
+          thickness,
+          color,
+          fromDashed && 'border-dashed border-[var(--border)]',
+        )}
+      />
+      <div
+        className={cn(
+          'h-3 w-0 border-l',
+          thickness,
+          color,
+          toDashed && 'border-dashed border-[var(--border)]',
+        )}
+      />
+    </div>
+  );
+}
+
+/** Build the announcement text for the live region. */
+function announcement(stages: StageView[]): string {
+  const summary = stages
+    .map((s, i) =>
+      t('stageTimeline.aria.itemSummary', {
+        ordinal: String(i + 1),
+        name: s.displayName,
+        state: stateLabel(s.state),
+      }),
+    )
+    .join('. ');
+  return t('stageTimeline.aria.announcement', {
+    n: String(stages.length),
+    summary,
+  });
+}
+
+export function StageTimeline({
+  stages,
+  caseTypeStageDefs,
+  experimental_animate = false,
+}: StageTimelineProps) {
+  void caseTypeStageDefs; // reserved for fallback; current backend always populates displayName
+  void experimental_animate; // wired by Story 4.3 — Phase 0 keeps animation a no-op
+
+  // Defensive observability — emit before any layout work runs.
+  warnIfInconsistent(stages);
+
+  const { ref: paneRef, width } = usePaneWidth();
+  const safeLength = stages?.length ?? 0;
+  const layout: LayoutMode = useMemo(() => {
+    if (safeLength > MAX_HORIZONTAL_STAGES) return 'vertical';
+    if (width === null) return 'horizontal'; // pre-measure default
+    return width >= HORIZONTAL_LAYOUT_MIN_WIDTH ? 'horizontal' : 'vertical';
+  }, [safeLength, width]);
+
+  // Roving tab-index — single composite-widget tab stop. ArrowKeys / Home / End move focus
+  // between nodes within the timeline; Tab moves focus *out* (because non-focused nodes have
+  // tabIndex=-1). Initial focus index is the active stage if any, else 0.
+  const initialIdx = useMemo(() => {
+    if (!stages) return 0;
+    const activeIdx = stages.findIndex((s) => s.state === 'ACTIVE');
+    return activeIdx >= 0 ? activeIdx : 0;
+  }, [stages]);
+  const [focusIdx, setFocusIdx] = useState(initialIdx);
+  const nodeRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  // Keep focusIdx in sync if stages array length changes (e.g. SSE-driven update from 4.3).
+  useLayoutEffect(() => {
+    if (focusIdx >= safeLength) setFocusIdx(Math.max(0, safeLength - 1));
+  }, [safeLength, focusIdx]);
+
+  const moveFocus = useCallback(
+    (next: number) => {
+      const clamped = Math.max(0, Math.min(safeLength - 1, next));
+      setFocusIdx(clamped);
+      const node = nodeRefs.current[clamped];
+      node?.focus();
+    },
+    [safeLength],
+  );
+
+  const onKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLElement>) => {
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          event.preventDefault();
+          moveFocus(focusIdx + 1);
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          event.preventDefault();
+          moveFocus(focusIdx - 1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          moveFocus(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          moveFocus(safeLength - 1);
+          break;
+        default:
+          break;
+      }
+    },
+    [focusIdx, moveFocus, safeLength],
+  );
+
+  // AC2 / AC11 — empty stages array → component returns null. No DOM, no skeleton, no placeholder.
+  // Placed AFTER hooks so React's hook ordering invariants stay intact across re-renders.
+  if (!stages || stages.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav
+      ref={paneRef}
+      aria-label={t('stageTimeline.aria.label')}
+      data-layout={layout}
+      className={cn('wks-stage-timeline w-full', layout === 'horizontal' ? 'overflow-x-auto' : '')}
+    >
+      <ol
+        role="list"
+        aria-label={t('stageTimeline.aria.list')}
+        onKeyDown={onKeyDown}
+        className={cn(
+          'flex',
+          layout === 'horizontal'
+            ? 'flex-row items-stretch gap-0 px-1 py-2'
+            : 'flex-col gap-0 py-2',
+        )}
+      >
+        {stages.map((stage, i) => (
+          <Slot
+            key={stage.stageId}
+            isLast={i === stages.length - 1}
+            connector={
+              i < stages.length - 1 ? (
+                <Connector fromState={stage.state} toState={stages[i + 1]!.state} layout={layout} />
+              ) : null
+            }
+            layout={layout}
+          >
+            <StageNode
+              ref={(node) => {
+                nodeRefs.current[i] = node;
+              }}
+              stage={stage}
+              isFocused={i === focusIdx}
+              layout={layout}
+              onFocus={() => setFocusIdx(i)}
+            />
+          </Slot>
+        ))}
+      </ol>
+      {/* aria-live region for screen-reader announcement on mount + on stages change. */}
+      <span aria-live="polite" className="sr-only">
+        {announcement(stages)}
+      </span>
+    </nav>
+  );
+}
+
+/**
+ * Layout glue between an item and its trailing connector. Keeps the rendering loop tidy and
+ * makes the `Connector` placement test-friendly (the connector always appears as a sibling of the
+ * stage node in the DOM, not nested inside it).
+ */
+function Slot({
+  children,
+  connector,
+  layout,
+  isLast,
+}: {
+  children: React.ReactNode;
+  connector: React.ReactNode;
+  layout: LayoutMode;
+  isLast: boolean;
+}) {
+  if (layout === 'horizontal') {
+    return (
+      <>
+        {children}
+        {!isLast && connector}
+      </>
+    );
+  }
+  // Vertical: connector renders below the node visually; placed after the <li>.
+  return (
+    <>
+      {children}
+      {!isLast && connector}
+    </>
+  );
+}

--- a/frontend/src/hooks/useCases.test.tsx
+++ b/frontend/src/hooks/useCases.test.tsx
@@ -32,6 +32,7 @@ const fixture: CaseDto = {
     statuses: [],
     listColumns: [],
   },
+  stages: [],
 };
 
 function wrapper({ children }: { children: ReactNode }) {

--- a/frontend/src/hooks/useCreateCase.test.tsx
+++ b/frontend/src/hooks/useCreateCase.test.tsx
@@ -32,6 +32,7 @@ const fixture: CaseDto = {
     statuses: [],
     listColumns: [],
   },
+  stages: [],
 };
 
 function setupClient() {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -168,5 +168,22 @@
   "cases.created.announcement": "Case {idShort} created",
 
   "login.errors.notEmail": "Enter a valid email address",
-  "login.errors.passwordRequired": "Password is required"
+  "login.errors.passwordRequired": "Password is required",
+
+  "stageTimeline.aria.label": "Stage timeline",
+  "stageTimeline.aria.list": "Stages",
+  "stageTimeline.aria.announcement": "Stage timeline. List of {n} stages. {summary}",
+  "stageTimeline.aria.itemSummary": "{ordinal}. {name} — {state}",
+  "stageTimeline.state.completed": "Completed",
+  "stageTimeline.state.active": "Current",
+  "stageTimeline.state.skipped": "Skipped",
+  "stageTimeline.state.pending": "Pending",
+  "stageTimeline.popover.completed.duration": "In stage for {duration}",
+  "stageTimeline.popover.active.currentSince": "Current since {timestamp}",
+  "stageTimeline.popover.skipped": "Skipped",
+  "stageTimeline.timestamp.entered": "Entered {date}",
+  "stageTimeline.timestamp.exited": "Exited {date}",
+  "stageTimeline.timestamp.enteredAndExited": "Entered {entered} · Exited {exited}",
+  "stageTimeline.timestamp.skippedOn": "Skipped {date}",
+  "stageTimeline.timestamp.currentSince": "Current since {date}"
 }

--- a/frontend/src/types/case.ts
+++ b/frontend/src/types/case.ts
@@ -21,6 +21,33 @@ export interface CaseSummary {
 
 import type { CaseTypeView } from './caseType';
 
+/**
+ * Story 3.3 — wire enum for `StageView.state`. UPPERCASE strings, mirroring how `Status` is
+ * serialised today via `StatusDefinition.id`. Frontend maps to a lowercase CSS-class-name
+ * client-side. Renaming any of these is a multi-PR cascade — they are a wire contract per
+ * `feedback_error_codes_are_wire_contract.md`.
+ */
+export type StageState = 'PENDING' | 'ACTIVE' | 'COMPLETED' | 'SKIPPED';
+
+/**
+ * Story 3.3 — one entry per stage declared on the bound CaseType@version. Skipped stages stay in
+ * the list at their declared ordinal; the list is always ordered by `ordinal` ASC. Backend is the
+ * sole source of truth for `state` — the frontend never infers `ACTIVE` or `SKIPPED` from any
+ * other field.
+ */
+export interface StageView {
+  stageId: string;
+  displayName: string;
+  ordinal: number;
+  state: StageState;
+  /** ISO-8601 wire format. `null` for `PENDING`, and for `SKIPPED` rows that never went active. */
+  enteredAt: string | null;
+  /** ISO-8601 wire format. `null` while `PENDING` or `ACTIVE`. */
+  exitedAt: string | null;
+  source: 'wks-auto-rule' | 'manual' | 'backend-signal' | null;
+  sourceRef: string | null;
+}
+
 export interface CaseDto {
   id: string;
   caseTypeId: string;
@@ -35,6 +62,12 @@ export interface CaseDto {
   updatedAt: string;
   version: number;
   caseType: CaseTypeView;
+  /**
+   * Story 3.3 — full stage history for the timeline UI. Empty for zero-stage CaseTypes; never
+   * null. Owned by Story 3.3. The two scalar fields `currentStageId` / `currentStageOrdinal` are
+   * owned by Story 3.2 and added under that PR per the locked Sprint 2 split.
+   */
+  stages: StageView[];
 }
 
 export interface CaseRow extends CaseSummary {

--- a/frontend/src/types/caseType.ts
+++ b/frontend/src/types/caseType.ts
@@ -62,6 +62,18 @@ export interface CaseTypeSummary {
   permissions?: string[];
 }
 
+/**
+ * Story 3.3 — one entry per stage declared in the YAML, in declared order. The frontend reads
+ * `stages.length` to gate the `StageTimeline` component (zero-stage CaseTypes do not render the
+ * timeline at all per AC2 / Decision 19). `displayName` mirrors the YAML — Title-cased fallback
+ * applied server-side per Story 3.1 AC1, so the frontend never derives display names client-side.
+ */
+export interface StageDefinitionView {
+  id: string;
+  displayName: string;
+  ordinal: number;
+}
+
 export interface CaseTypeView {
   id: string;
   displayName: string;
@@ -69,4 +81,10 @@ export interface CaseTypeView {
   fields: FieldDefinition[];
   statuses: StatusDefinition[];
   listColumns: string[];
+  /**
+   * Story 3.3 — the declared stage schema (display names, ordinals). Optional in TS for
+   * backward-compat with pre-3.3 fixtures; the wire shape always includes it. The
+   * `StageTimeline` component treats `undefined` and `[]` identically (component returns null).
+   */
+  stages?: StageDefinitionView[];
 }


### PR DESCRIPTION
## Summary

Phase-0 PLG Gate-2 marquee component — the visible spine of the case-detail surface. The Stage primitive (Story 3.1) was the entity + lifecycle + read model; this story turns it into the user-visible timeline.

- **Backend:** `CaseDto` extended with **only** `stages: List<StageView>` (single field). `StageView` is a new wire record with the locked uppercase enum strings `PENDING|ACTIVE|COMPLETED|SKIPPED`. `CaseTypeViewDto` extended with `stages: List<StageDefinitionView>` so the frontend gates the timeline on the declared schema in one round-trip. `CaseController.get` now loads history via `StageRepository.loadHistory(caseId)` and projects through the new mapper overload.
- **Frontend:** New `StageTimeline` component — pure presentational, four-state visual contract (completed / active / skipped / pending), horizontal layout at >= 960px pane width and vertical stepper below or for cases with > 12 stages, single-tab-stop roving focus, sticky popover via Radix `Popover`, `aria-current="step"` on active, `aria-live="polite"` mount-time announcement. `experimental_animate` prop reserved for Story 4.3. `CaseDetailPanel` mounts it inside the header band gated on `caseDto.caseType.stages.length > 0 && caseDto.stages.length > 0` (single truthy-length check per Decision 19).

## Q4 split with Story 3-2 (CaseDto field ownership)

**This PR adds ONLY `stages: List<StageView>` to `CaseDto`.**

- **Rebase outcome:** `origin/v2-develop` HEAD unchanged from branch start point (`963a97ada` Story 4.1 merge). **Story 3-2 has NOT landed first.** Per the locked Q4 split this PR therefore adds only the array field; when 3-2 lands later, its AC5 becomes a no-op for the array surface — 3-2 still owns the scalar `currentStageId` + `currentStageOrdinal` fields.

## Locked decisions (2026-05-05) flagged in this PR

- **Q1 — max stage cap = 12.** Vertical stepper renders above 12 regardless of viewport. Backend `WKS-CFG-034` deploy-time validator **parked as Story 3.8 follow-up** — flagged for the SM.
- **Q2 — skipped-stage popover** shows "Skipped" only (no reason text). Richer payload deferred to Epic 4 (D1 invariant — backend is sole source of truth, never client-inferred).
- **Q3 — no `EventSource`** opened in this story. Component reactive to TanStack Query cache invalidation only. `experimental_animate` prop ready for Story 4.3 to flip.
- **Q5 — code in `wks-platform/`**, planning repo (`wks-platform2/`) doc-only.

## Parked follow-ups

1. `WKS-CFG-034` backend validator → Story 3.8.
2. Skip-reason popover payload → Epic 4 mapping-layer story.
3. SSE animation grammar (`ux-stage-timeline.md` §5) → Story 4.3.
4. Marketing screenshot pack (Gate 2) → GTM follow-up, not this PR.
5. `CONCEPTS.md` annotated screenshot → Story 6.0 amendment.
6. Storybook stories (Task 8) — Storybook not wired in `v2-develop`; gap noted.

## Test plan

- [ ] Pull the branch and `npm run lint && npm run format:check && npm test && npm run build` in `frontend/` — all green locally (251 tests).
- [ ] `mvn -B verify -DskipITs` in `backend/` — green locally (306 tests, 0 regressions).
- [ ] Open a multi-stage case in the case-detail panel and verify the four states render with the visual contract from `ux-stage-timeline.md` §2.
- [ ] Open a zero-stage case and verify NO timeline DOM is mounted (no skeleton, no placeholder, no empty band).
- [ ] Tab-into the timeline: focus lands on the active stage; ArrowRight / ArrowLeft step through; Tab exits.
- [ ] Hover a node for >= 200ms → popover opens; Esc closes; Enter on a node opens a sticky popover.
- [ ] Resize the case-detail pane below 960px → layout collapses to vertical stepper.
- [ ] Force a 13-stage CaseType → vertical stepper at all viewport widths.
- [ ] Confirm the response of `GET /api/cases/{id}` includes `stages: []` for zero-stage cases and `stages: [...]` for multi-stage.

## Quality gates verified locally (per `feedback_match_ci_locally.md`)

- Frontend: lint ✓, format:check ✓, vitest 251/251 ✓, build ✓.
- Backend: spotless ✓, mvn verify ✓ (306/306).

🤖 Generated with [Claude Code](https://claude.com/claude-code)