### PR TITLE
Story 4.2 — Mapping YAML Schema & Validator

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/AttachmentDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/AttachmentDefinition.java
@@ -1,0 +1,90 @@
+package com.wkspower.platform.domain.config.model;
+
+import com.wkspower.platform.domain.port.BackendSignalKind;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Validated, immutable description of one {@code attachments[]} entry inside a CaseType YAML (Story
+ * 4.2 AC1 / AC4). Pure Java — no Spring, no Jackson, no JPA.
+ *
+ * <p>The single {@code domain/port/} import allowed in this package is {@link BackendSignalKind}
+ * (Story 4.1) — reused by {@link PropertyEmissionRule#emits()} so the property-emission vocabulary
+ * stays unified across the Mapping Layer (validator output) and the Backend Adapter port (router
+ * input).
+ *
+ * <p>{@link #type()} is a {@code String}, NOT an enum — so adding a Phase-1 attachment type (Story
+ * 4.9 introduces {@code state-machine}) does not require an enum migration with downstream switch
+ * statements. The validator (single allow-list constant) is the only enforcement point.
+ *
+ * @param type adapter kind. Phase-0: only {@code bpmn} (validated by {@code MappingValidator})
+ * @param file relative filename of the attached resource (e.g. {@code claim-underwriting.bpmn})
+ * @param scope raw scope string from YAML — {@code "case"} or {@code "stage:<stage-id>"}
+ * @param stageScopeId parsed stage id when {@code scope} is {@code stage:<id>}; empty for
+ *     case-scoped attachments
+ * @param userTaskMappings BPMN userTask id → {@link UserTaskMapping}
+ * @param endEventMapping optional {@code events.endEvent} rule (single per attachment)
+ * @param signalMappings BPMN signal id → {@link SignalMapping}
+ * @param propertyEmissionRules ordered {@code map.properties[]} list
+ */
+public record AttachmentDefinition(
+    String type,
+    String file,
+    String scope,
+    Optional<String> stageScopeId,
+    Map<String, UserTaskMapping> userTaskMappings,
+    Optional<EndEventMapping> endEventMapping,
+    Map<String, SignalMapping> signalMappings,
+    List<PropertyEmissionRule> propertyEmissionRules) {
+
+  public AttachmentDefinition {
+    Objects.requireNonNull(type, "type");
+    Objects.requireNonNull(file, "file");
+    Objects.requireNonNull(scope, "scope");
+    Objects.requireNonNull(stageScopeId, "stageScopeId");
+    Objects.requireNonNull(userTaskMappings, "userTaskMappings");
+    Objects.requireNonNull(endEventMapping, "endEventMapping");
+    Objects.requireNonNull(signalMappings, "signalMappings");
+    Objects.requireNonNull(propertyEmissionRules, "propertyEmissionRules");
+    userTaskMappings = Map.copyOf(userTaskMappings);
+    signalMappings = Map.copyOf(signalMappings);
+    propertyEmissionRules = List.copyOf(propertyEmissionRules);
+  }
+
+  /** YAML {@code map.userTasks.<id>} entry. */
+  public record UserTaskMapping(String wksTask, String form) {
+    public UserTaskMapping {
+      Objects.requireNonNull(wksTask, "wksTask");
+    }
+  }
+
+  /** YAML {@code map.events.endEvent} entry — single per attachment by spec. */
+  public record EndEventMapping(String stageTransition) {
+    public EndEventMapping {
+      Objects.requireNonNull(stageTransition, "stageTransition");
+    }
+  }
+
+  /** YAML {@code map.events.signal.<id>} entry. */
+  public record SignalMapping(String stageTransition) {
+    public SignalMapping {
+      Objects.requireNonNull(stageTransition, "stageTransition");
+    }
+  }
+
+  /**
+   * YAML {@code map.properties[]} entry. {@link #emits()} is a {@link BackendSignalKind} — the sole
+   * {@code domain/port/} import allowed in this package.
+   */
+  public record PropertyEmissionRule(
+      String on, String camundaProperty, BackendSignalKind emits, String emitScope) {
+    public PropertyEmissionRule {
+      Objects.requireNonNull(on, "on");
+      Objects.requireNonNull(camundaProperty, "camundaProperty");
+      Objects.requireNonNull(emits, "emits");
+      Objects.requireNonNull(emitScope, "emitScope");
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/MappingChangeClass.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/MappingChangeClass.java
@@ -1,0 +1,27 @@
+package com.wkspower.platform.domain.config.model;
+
+/**
+ * Classification returned by {@code MappingDiff.classify(prev, next)} (Story 4.2 AC8 / D20). Two
+ * branches:
+ *
+ * <ul>
+ *   <li>{@link #APPEND_CLASS} — only additive mapping changes (new attachment, new userTaskMapping
+ *       under existing attachment, new property emission rule). Safe to deploy without a CaseType
+ *       version bump.
+ *   <li>{@link #MUTATE_CLASS} — at least one existing entry was modified or removed (mapping
+ *       deleted, {@code wksTask} value changed, {@code stageTransition} payload changed, {@code
+ *       scope} changed, {@code file} reference changed). Requires a CaseType version bump per D20.
+ * </ul>
+ *
+ * <p>Story 4.2 ships the helper unwired. Story 3.8's blast-radius validator imports {@code
+ * MappingDiff} and emits {@link com.wkspower.platform.domain.exception.ErrorCode#WKS_CFG_029} when
+ * the result is {@code MUTATE_CLASS} and the deployer did not supply {@code --bump}.
+ */
+public enum MappingChangeClass {
+
+  /** Only additive changes — safe to redeploy without a CaseType version bump. */
+  APPEND_CLASS,
+
+  /** At least one existing entry was modified or removed — requires a version bump (D20). */
+  MUTATE_CLASS
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/MappingDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/MappingDefinition.java
@@ -1,0 +1,36 @@
+package com.wkspower.platform.domain.config.model;
+
+import java.util.List;
+
+/**
+ * Typed, immutable result of {@code MappingValidator.validate(...)} success — the in-memory
+ * representation of a CaseType YAML's {@code attachments: [...]} block (Story 4.2 AC1 / AC4 /
+ * architecture §786–842, Decision 22). Pure Java — no Spring, no Jackson, no JPA. The only {@code
+ * domain/port/} import in this package is {@link
+ * com.wkspower.platform.domain.port.BackendSignalKind} (used by {@link
+ * AttachmentDefinition.PropertyEmissionRule}).
+ *
+ * <p>Story 4.2 produces this value object; Story 4.3's {@code BackendSignalRouter} consumes it. 4.2
+ * has zero coupling to {@code BackendAdapter} / {@code BackendSignalRouter} (the runtime port from
+ * Story 4.1) — the wire shape lives here.
+ *
+ * <p><b>Zero-attachment case types are first-class</b> (D19 stage-less analogue per architecture
+ * §816): every downstream service treats {@link #empty()} identically to a CaseType with no {@code
+ * attachments:} key — no branching on absence.
+ */
+public record MappingDefinition(List<AttachmentDefinition> attachments) {
+
+  private static final MappingDefinition EMPTY = new MappingDefinition(List.of());
+
+  public MappingDefinition {
+    attachments = attachments == null ? List.of() : List.copyOf(attachments);
+  }
+
+  /**
+   * Singleton zero-attachment instance. Used by {@code MappingValidator} when the YAML omits the
+   * {@code attachments} key or declares an empty list — both are legal per AC1.
+   */
+  public static MappingDefinition empty() {
+    return EMPTY;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/package-info.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/package-info.java
@@ -1,7 +1,15 @@
 /**
  * Immutable domain records describing a case-type configuration: fields, statuses, roles, the
- * workflow reference. Pure Java — no Jackson, no SnakeYAML, no Spring. The infrastructure layer
- * maps {@code RawCaseTypeConfig} (nullable transport shape) into these records only after
- * validation succeeds.
+ * workflow reference, and the Mapping Layer (Story 4.2 / D22 — {@link
+ * com.wkspower.platform.domain.config.model.MappingDefinition} + {@link
+ * com.wkspower.platform.domain.config.model.AttachmentDefinition}). Pure Java — no Jackson, no
+ * SnakeYAML, no Spring, no JPA. The infrastructure layer maps {@code RawCaseTypeConfig} (nullable
+ * transport shape) into these records only after validation succeeds.
+ *
+ * <p>The single {@code domain/port/} import allowed in this package is {@link
+ * com.wkspower.platform.domain.port.BackendSignalKind} (Story 4.1) — reused by {@link
+ * com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule#emits()} so
+ * the property-emission vocabulary stays unified across the Mapping Layer (validator output) and
+ * the Backend Adapter port (router input). Architecture D22 cite.
  */
 package com.wkspower.platform.domain.config.model;

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -105,6 +105,29 @@ public enum ErrorCode {
    */
   WKS_CFG_022("WKS-CFG-022"),
   /**
+   * Mapping references a BPMN userTask id that does not exist in the attached BPMN file (Story 4.2
+   * AC2 / architecture §828). Canonical wire code for {@code userTasks.<id>} and {@code
+   * properties[].on=userTask:<id>} cross-reference failures. Distinguishes from {@code
+   * WKS-MAP-001}, which fires on non-userTask element refs (signals, events).
+   */
+  WKS_CFG_027("WKS-CFG-027"),
+  /**
+   * Mapping {@code events.endEvent.stageTransition} (or signal stageTransition) references a stage
+   * adjacency the CaseType does not declare (Story 4.2 AC2 / architecture §832). Canonical wire
+   * code for stage-adjacency failures; {@code WKS-MAP-007} is reserved as an alias-not-emitted to
+   * give Story 4.6's Admin UI a Mapping-namespaced label option without changing the wire string.
+   */
+  WKS_CFG_028("WKS-CFG-028"),
+  /**
+   * Mapping-class change requires a CaseType version bump (Story 4.2 AC2 / architecture §833 / D20
+   * cross-ref). RESERVED in Story 4.2 — emitted by Story 3.8's blast-radius validator when {@link
+   * com.wkspower.platform.infrastructure.config.MappingDiff#classify} returns {@code
+   * MappingChangeClass.MUTATE_CLASS} and the deployer did not supply {@code --bump}. {@code
+   * MappingValidator} does not emit this code; the constant exists here so 3.8 can reference it
+   * without re-allocating.
+   */
+  WKS_CFG_029("WKS-CFG-029"),
+  /**
    * Duplicate stage id within a case-type YAML (Story 3.1 AC1). Deploy-time validator code;
    * surfaces with a {@code stages[i].id} field path.
    */
@@ -122,6 +145,60 @@ public enum ErrorCode {
   WKS_CFG_033("WKS-CFG-033"),
   /** YAML parse error / I/O failure (catastrophic — validator never produces). */
   WKS_CFG_099("WKS-CFG-099"),
+
+  // 422 — Mapping Layer wire codes (Story 4.2 AC2). Epic-namespaced sibling band of the
+  // architecture-document codes WKS-CFG-027/028/029 above. Codes 001..006 are emitted by
+  // MappingValidator; 007 is reserved-and-not-emitted (alias of WKS-CFG-028) to give Story 4.6's
+  // Admin UI a Mapping-namespaced label without changing the wire string.
+  /**
+   * Mapping references a BPMN element id that does not exist in the attached BPMN file (Story 4.2
+   * AC2 / epics.md AC1). Fires for non-userTask references — {@code map.events.signal.<id>} that is
+   * absent in the BPMN, or an {@code endEvent} rule declared on a BPMN with zero {@code
+   * <bpmn:endEvent>}. UserTask references emit {@link #WKS_CFG_027} instead.
+   */
+  WKS_MAP_001("WKS-MAP-001"),
+  /**
+   * Two mappings target the same {@code (stage, status)} from different BPMN events without an
+   * explicit precedence declaration (Story 4.2 AC2 / epics.md AC2). Phase-0 disallows ambiguity;
+   * Phase-1 may relax once a precedence vocabulary lands.
+   */
+  WKS_MAP_002("WKS-MAP-002"),
+  /**
+   * Mapping {@code scope: stage:<id>} (or {@code emits.scope: stage:<id>}) references a stage that
+   * does not exist on the CaseType (Story 4.2 AC2 / epics.md AC3). The validator collects every
+   * dangling reference in one pass.
+   */
+  WKS_MAP_003("WKS-MAP-003"),
+  /**
+   * {@code attachments[].type} is not a known adapter kind (Story 4.2 AC2 / AC6). Phase-0 allows
+   * only {@code bpmn}; future adapter kinds extend the {@link
+   * com.wkspower.platform.infrastructure.config.MappingValidator} allow-list (see Story 4.9 for the
+   * next allow-list addition).
+   */
+  WKS_MAP_004("WKS-MAP-004"),
+  /**
+   * {@code attachments[].file} is missing, unreadable, or fails the BPMN 2.0 sniff when {@code
+   * type: bpmn} (Story 4.2 AC2 / AC3 / AC5). Also fires when the caller did not supply BPMN bytes
+   * for the declared filename — the validator is I/O-free and does not fall back to a filesystem
+   * search path.
+   */
+  WKS_MAP_005("WKS-MAP-005"),
+  /**
+   * Two {@code attachments} declare the same {@code scope} (Story 4.2 AC2). Phase-0 disallows for
+   * clarity (e.g. two {@code scope: case} or two {@code scope: stage:underwriting} entries);
+   * Phase-1 may relax once layered adapters have a precedence vocabulary.
+   */
+  WKS_MAP_006("WKS-MAP-006"),
+  /**
+   * RESERVED-AND-NOT-EMITTED in Story 4.2 (AC2 aliasing rule). Functionally an alias of {@link
+   * #WKS_CFG_028} — the canonical wire code for stage-adjacency failures stays {@code WKS-CFG-028}.
+   * {@code WKS-MAP-007} is reserved so Story 4.6's Admin UI Mapping Inspector can surface a
+   * Mapping-namespaced label for the same rule without changing the wire string emitted by the
+   * backend. The constant is not produced by any validator path. Per {@code
+   * feedback_error_codes_are_wire_contract.md}: a reserved code may never be reused for a different
+   * meaning.
+   */
+  WKS_MAP_007("WKS-MAP-007"),
 
   // 409 / 422 / 404 — Stage lifecycle runtime errors (Story 3.1 AC9). Band: WKS-STG-001..099.
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/port/BpmnElementInspector.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/BpmnElementInspector.java
@@ -1,0 +1,18 @@
+package com.wkspower.platform.domain.port;
+
+import com.wkspower.platform.domain.workflow.BpmnElementSummary;
+
+/**
+ * Outbound port for engine-free BPMN element introspection — reads userTask / endEvent / signal id
+ * sets from BPMN bytes without exposing the embedded engine SDK. The single implementation lives in
+ * {@code engine/} (Story 4.2 AC12 — reuse {@code BpmnParser}, no new BPMN model dep). Callers in
+ * {@code infrastructure/config} (e.g. {@code MappingValidator}) depend on the port, not the parser.
+ */
+public interface BpmnElementInspector {
+
+  /**
+   * Parse {@code bpmnXml} and return the id sets of its userTask / endEvent / signal elements.
+   * Throws an unchecked exception on parse failure — callers translate to {@code WKS-MAP-005}.
+   */
+  BpmnElementSummary summarize(byte[] bpmnXml);
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/workflow/BpmnElementSummary.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/workflow/BpmnElementSummary.java
@@ -1,0 +1,23 @@
+package com.wkspower.platform.domain.workflow;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Engine-free summary of a parsed BPMN file's element id sets. Returned by {@code
+ * BpmnElementInspector.summarize(byte[])}; consumed by {@code MappingValidator} (Story 4.2 AC3) to
+ * cross-reference YAML mapping ids against the BPMN. The record carries plain Java collections so
+ * the {@code org.cibseven..} import stays inside {@code engine/}.
+ */
+public record BpmnElementSummary(
+    Set<String> userTaskIds, Set<String> endEventIds, Set<String> signalIds) {
+
+  public BpmnElementSummary {
+    Objects.requireNonNull(userTaskIds, "userTaskIds");
+    Objects.requireNonNull(endEventIds, "endEventIds");
+    Objects.requireNonNull(signalIds, "signalIds");
+    userTaskIds = Set.copyOf(userTaskIds);
+    endEventIds = Set.copyOf(endEventIds);
+    signalIds = Set.copyOf(signalIds);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/engine/BpmnParser.java
+++ b/backend/src/main/java/com/wkspower/platform/engine/BpmnParser.java
@@ -1,17 +1,30 @@
 package com.wkspower.platform.engine;
 
+import com.wkspower.platform.domain.port.BpmnElementInspector;
+import com.wkspower.platform.domain.workflow.BpmnElementSummary;
 import java.io.ByteArrayInputStream;
+import java.util.HashSet;
+import java.util.Set;
 import org.cibseven.bpm.model.bpmn.Bpmn;
 import org.cibseven.bpm.model.bpmn.BpmnModelInstance;
+import org.cibseven.bpm.model.bpmn.instance.EndEvent;
+import org.cibseven.bpm.model.bpmn.instance.Signal;
+import org.cibseven.bpm.model.bpmn.instance.UserTask;
 import org.springframework.stereotype.Component;
 
 /**
  * Parse-without-deploy wrapper over CIB seven's BPMN model API. Uses {@link
  * Bpmn#readModelFromStream(java.io.InputStream)} — model-API parsing does not touch the engine, so
  * this is safe to invoke from validation.
+ *
+ * <p>Story 4.2 added the {@link BpmnElementInspector} implementation — engine-free element id
+ * enumeration consumed by {@code MappingValidator} for cross-reference checks (AC3). Returning a
+ * domain-shaped {@link BpmnElementSummary} keeps the {@code org.cibseven..} import confined to
+ * {@code engine/} (architecture invariant — see {@code ArchitectureTest.onlyEngineAdapter
+ * ImportsTheBpmnEngineSdk}).
  */
 @Component
-public class BpmnParser {
+public class BpmnParser implements BpmnElementInspector {
 
   /**
    * Parse BPMN bytes into a model instance. Throws {@link BpmnParseException} on any failure (empty
@@ -27,5 +40,37 @@ public class BpmnParser {
     } catch (RuntimeException ex) {
       throw new BpmnParseException("BPMN parse failed: " + ex.getMessage(), ex);
     }
+  }
+
+  /**
+   * Story 4.2 AC3 / AC12 — parse BPMN bytes and return a CIB-seven-free summary of the userTask /
+   * endEvent / signal id sets the mapping validator cross-references. Returning {@link
+   * BpmnElementSummary} (rather than {@link BpmnModelInstance}) keeps the {@code org.cibseven..}
+   * import confined to {@code engine/}, satisfying {@code ArchitectureTest.onlyEngineAdapter
+   * ImportsTheBpmnEngineSdk}. Throws {@link BpmnParseException} on parse failure — callers convert
+   * to {@code WKS-MAP-005}.
+   */
+  @Override
+  public BpmnElementSummary summarize(byte[] bpmnXml) {
+    BpmnModelInstance model = parse(bpmnXml);
+    Set<String> userTasks = new HashSet<>();
+    for (UserTask t : model.getModelElementsByType(UserTask.class)) {
+      if (t.getId() != null) {
+        userTasks.add(t.getId());
+      }
+    }
+    Set<String> endEvents = new HashSet<>();
+    for (EndEvent e : model.getModelElementsByType(EndEvent.class)) {
+      if (e.getId() != null) {
+        endEvents.add(e.getId());
+      }
+    }
+    Set<String> signals = new HashSet<>();
+    for (Signal s : model.getModelElementsByType(Signal.class)) {
+      if (s.getId() != null) {
+        signals.add(s.getId());
+      }
+    }
+    return new BpmnElementSummary(userTasks, endEvents, signals);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeSourceAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeSourceAdapter.java
@@ -2,7 +2,11 @@ package com.wkspower.platform.infrastructure.config;
 
 import com.wkspower.platform.domain.config.ValidationResult;
 import com.wkspower.platform.domain.port.CaseTypeSource;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 /**
@@ -10,9 +14,19 @@ import org.springframework.stereotype.Component;
  * {@link CaseTypeSource} port. Catastrophic parse failures surface as a {@code WKS-CFG-099}-bearing
  * {@link ValidationResult} so callers treat them uniformly with validation errors — no exception
  * path crosses the port.
+ *
+ * <p>Story 4.2 — when the YAML declares {@code attachments[]}, this adapter reads the sibling files
+ * referenced by {@code attachments[].file} from the YAML's parent directory and supplies the bytes
+ * to {@link ConfigValidator#validate(RawCaseTypeConfig, YamlLineIndex, java.util.Map)}. Failure to
+ * read a sibling file is silently dropped here — {@link MappingValidator} surfaces it as {@code
+ * WKS-MAP-005} ("BPMN file not provided"). The byte-supply path for the {@code loadBytes} contract
+ * (multipart admin deploy — Story 4.5) extends this adapter with a caller-supplied byte map.
  */
 @Component
 public class CaseTypeSourceAdapter implements CaseTypeSource {
+
+  /** Hard cap for sibling BPMN reads — matches the MAX_BPMN_BYTES used in CaseTypeStartupLoader. */
+  private static final long MAX_SIBLING_BYTES = 1_048_576L;
 
   private final CaseTypeYamlLoader loader;
   private final ConfigValidator validator;
@@ -28,7 +42,8 @@ public class CaseTypeSourceAdapter implements CaseTypeSource {
     if (!read.isParsed()) {
       return ValidationResult.invalid(read.errors());
     }
-    return validator.validate(read.raw(), read.lines());
+    Map<String, byte[]> bpmnFiles = readSiblingBpmnFiles(file, read.raw());
+    return validator.validate(read.raw(), read.lines(), bpmnFiles);
   }
 
   @Override
@@ -37,6 +52,59 @@ public class CaseTypeSourceAdapter implements CaseTypeSource {
     if (!read.isParsed()) {
       return ValidationResult.invalid(read.errors());
     }
-    return validator.validate(read.raw(), read.lines());
+    // No sibling-file source in the bytes path — Story 4.5 (admin deploy controller) will supply
+    // a multipart byte map and call the overload directly. Today MappingValidator emits
+    // WKS-MAP-005 when files are referenced but not provided.
+    return validator.validate(read.raw(), read.lines(), Map.of());
+  }
+
+  /**
+   * Read sibling BPMN files for any {@code attachments[].file} the YAML declared. Returns an empty
+   * map when the YAML has no attachments. Files outside the YAML's parent directory or absolute
+   * paths are silently dropped — {@link MappingValidator} surfaces them as {@code WKS-MAP-005}.
+   */
+  private Map<String, byte[]> readSiblingBpmnFiles(Path yamlFile, RawCaseTypeConfig raw) {
+    if (raw == null || raw.attachments() == null || raw.attachments().isEmpty()) {
+      return Map.of();
+    }
+    Path parent = yamlFile.toAbsolutePath().getParent();
+    if (parent == null) {
+      return Map.of();
+    }
+    Map<String, byte[]> out = new HashMap<>();
+    for (RawCaseTypeConfig.RawAttachment a : raw.attachments()) {
+      if (a == null || a.file() == null || a.file().isBlank()) {
+        continue;
+      }
+      String name = a.file();
+      if (out.containsKey(name)) {
+        continue;
+      }
+      Path candidate;
+      try {
+        candidate = Path.of(name);
+      } catch (RuntimeException e) {
+        continue;
+      }
+      if (candidate.isAbsolute()) {
+        continue;
+      }
+      Path resolved = parent.resolve(candidate).normalize();
+      if (!resolved.startsWith(parent)) {
+        continue;
+      }
+      if (!Files.isRegularFile(resolved)) {
+        continue;
+      }
+      try {
+        if (Files.size(resolved) > MAX_SIBLING_BYTES) {
+          continue;
+        }
+        out.put(name, Files.readAllBytes(resolved));
+      } catch (IOException e) {
+        // drop — MappingValidator surfaces "BPMN file not provided" via WKS-MAP-005
+      }
+    }
+    return out;
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -42,6 +42,22 @@ import org.springframework.stereotype.Component;
 public class ConfigValidator {
 
   /**
+   * Story 4.2 AC5 — Mapping Layer validator. Constructor-injected so tests can pass {@code null}
+   * via the {@link #ConfigValidator() no-arg constructor} when only stage / field / role rules are
+   * exercised. The {@link #validate(RawCaseTypeConfig, YamlLineIndex, java.util.Map) overload with
+   * BPMN bytes} requires this dependency to be non-null.
+   */
+  private final MappingValidator mappingValidator;
+
+  public ConfigValidator() {
+    this(null);
+  }
+
+  public ConfigValidator(MappingValidator mappingValidator) {
+    this.mappingValidator = mappingValidator;
+  }
+
+  /**
    * Reserved stage ids — Story 3.1 AC1 (Sprint-1 triage Q4: initial set, extend on first conflict).
    * Lives here as a private constant so the validator owns the rule; if a future story needs to
    * extend, the touch-point is one place.
@@ -57,6 +73,17 @@ public class ConfigValidator {
       java.util.regex.Pattern.compile("[a-z][a-z0-9-]{0,62}");
 
   public ValidationResult validate(RawCaseTypeConfig raw, YamlLineIndex lines) {
+    return validate(raw, lines, java.util.Map.of());
+  }
+
+  /**
+   * Story 4.2 AC5 — overload that runs {@link MappingValidator} after stage validation and merges
+   * its findings into the same {@link ValidationResult}. The {@code bpmnFiles} map (filename →
+   * bytes) is supplied by the caller; the validator is I/O-free and never reads the filesystem.
+   * Missing entries for declared {@code attachments[].file} produce {@code WKS-MAP-005}.
+   */
+  public ValidationResult validate(
+      RawCaseTypeConfig raw, YamlLineIndex lines, java.util.Map<String, byte[]> bpmnFiles) {
     if (raw == null) {
       return ValidationResult.invalid(
           List.of(
@@ -95,6 +122,18 @@ public class ConfigValidator {
     List<String> listColumns =
         checkListColumns(raw.listColumns(), fields, raw.fields() != null, eb, errors);
     List<StageDefinition> stages = checkStages(raw.stages(), eb, errors);
+
+    // Story 4.2 AC5 — Mapping Layer validation runs after stage validation, with the stage id set
+    // already known. The validator is collect-all; its findings merge into {@code errors} so a
+    // single ValidationResult surfaces both stage and mapping failures (no parallel call site).
+    if (mappingValidator != null) {
+      Set<String> stageIds = new HashSet<>();
+      for (StageDefinition sd : stages) {
+        stageIds.add(sd.id());
+      }
+      MappingValidator.Result mappingResult = mappingValidator.validate(raw, stageIds, bpmnFiles);
+      errors.addAll(mappingResult.errors());
+    }
 
     if (!errors.isEmpty()) {
       return ValidationResult.invalid(errors);

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/MappingDiff.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/MappingDiff.java
@@ -1,0 +1,136 @@
+package com.wkspower.platform.infrastructure.config;
+
+import com.wkspower.platform.domain.config.model.AttachmentDefinition;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.UserTaskMapping;
+import com.wkspower.platform.domain.config.model.MappingChangeClass;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Story 4.2 AC8 — pure-function blast-radius classifier for the mapping layer (D20). Given the
+ * previous and next {@link MappingDefinition} of a CaseType, returns either {@link
+ * MappingChangeClass#APPEND_CLASS} (only additive changes — safe to redeploy without a CaseType
+ * version bump) or {@link MappingChangeClass#MUTATE_CLASS} (something existing was modified or
+ * removed — version bump required per D20).
+ *
+ * <p><b>NOT WIRED INTO DEPLOY GATING IN THIS STORY.</b> Story 3.8's blast-radius validator imports
+ * this helper and emits {@link com.wkspower.platform.domain.exception.ErrorCode#WKS_CFG_029} when
+ * {@link #classify} returns {@code MUTATE_CLASS} and the deployer did not supply {@code --bump}.
+ * 4.2 ships unit tests only; 3.8 wires the call site.
+ *
+ * <h2>Classification rules</h2>
+ *
+ * <ul>
+ *   <li>{@code APPEND_CLASS} — a new {@code attachments[]} entry was added; or an existing
+ *       attachment gained a new {@code map.userTasks.<id>}; or an existing attachment gained a new
+ *       {@code map.properties[]} rule; or a new signal mapping was added under existing events
+ *       block.
+ *   <li>{@code MUTATE_CLASS} — any existing {@code AttachmentDefinition.scope} / {@code .file} /
+ *       {@code .type} changed; an attachment was removed; an existing {@code wksTask} value
+ *       changed; an existing {@code stageTransition} payload (endEvent or signal) changed; an
+ *       existing property emission rule changed; any {@code map.userTasks} / {@code
+ *       map.events.signal} key was removed.
+ * </ul>
+ *
+ * <p>Attachment identity is anchored by {@code (type, scope)} — pre/post pairs that share the same
+ * {@code (type, scope)} are considered the same attachment for diff purposes (changing {@code file}
+ * on the same {@code (type, scope)} is treated as a mutation of the existing attachment, not a
+ * delete-plus-add).
+ */
+public final class MappingDiff {
+
+  private MappingDiff() {}
+
+  /**
+   * Classify the diff between {@code prev} and {@code next}. Both arguments may be {@link
+   * MappingDefinition#empty()} — empty-to-empty is {@code APPEND_CLASS} (no change is the
+   * non-blocking case).
+   */
+  public static MappingChangeClass classify(MappingDefinition prev, MappingDefinition next) {
+    Objects.requireNonNull(prev, "prev");
+    Objects.requireNonNull(next, "next");
+
+    Map<String, AttachmentDefinition> prevByKey = indexByKey(prev);
+    Map<String, AttachmentDefinition> nextByKey = indexByKey(next);
+
+    // Removal of any attachment is mutate-class.
+    for (String key : prevByKey.keySet()) {
+      if (!nextByKey.containsKey(key)) {
+        return MappingChangeClass.MUTATE_CLASS;
+      }
+    }
+
+    // For every shared (type, scope) attachment, compare the contents.
+    for (var entry : prevByKey.entrySet()) {
+      AttachmentDefinition before = entry.getValue();
+      AttachmentDefinition after = nextByKey.get(entry.getKey());
+      if (after == null) {
+        return MappingChangeClass.MUTATE_CLASS;
+      }
+      // file change is mutate-class (same scope, but the file ref moved)
+      if (!before.file().equals(after.file())) {
+        return MappingChangeClass.MUTATE_CLASS;
+      }
+
+      // userTasks: removed key OR changed value is mutate; new key is append
+      for (var u : before.userTaskMappings().entrySet()) {
+        UserTaskMapping postValue = after.userTaskMappings().get(u.getKey());
+        if (postValue == null) {
+          return MappingChangeClass.MUTATE_CLASS;
+        }
+        if (!Objects.equals(postValue, u.getValue())) {
+          return MappingChangeClass.MUTATE_CLASS;
+        }
+      }
+
+      // signals: removed key OR changed stageTransition is mutate
+      for (var s : before.signalMappings().entrySet()) {
+        var postValue = after.signalMappings().get(s.getKey());
+        if (postValue == null) {
+          return MappingChangeClass.MUTATE_CLASS;
+        }
+        if (!Objects.equals(postValue, s.getValue())) {
+          return MappingChangeClass.MUTATE_CLASS;
+        }
+      }
+
+      // endEvent: presence/value change is mutate (removing or changing the rule)
+      if (before.endEventMapping().isPresent()) {
+        if (!after.endEventMapping().equals(before.endEventMapping())) {
+          return MappingChangeClass.MUTATE_CLASS;
+        }
+      }
+
+      // properties: every prev rule must be present byte-equal in next; new rules at the tail are
+      // append. Use a set of equals-based contains rather than positional indexing.
+      Set<PropertyEmissionRule> nextRules = new HashSet<>(after.propertyEmissionRules());
+      for (PropertyEmissionRule r : before.propertyEmissionRules()) {
+        if (!nextRules.contains(r)) {
+          return MappingChangeClass.MUTATE_CLASS;
+        }
+      }
+    }
+
+    // Anything left in next but not prev (new attachment, new userTask, new signal, new property
+    // rule) is append-class. We've already verified every existing entry survived unchanged.
+    return MappingChangeClass.APPEND_CLASS;
+  }
+
+  private static Map<String, AttachmentDefinition> indexByKey(MappingDefinition def) {
+    Map<String, AttachmentDefinition> out = new HashMap<>();
+    for (AttachmentDefinition a : def.attachments()) {
+      out.put(key(a), a);
+    }
+    return out;
+  }
+
+  /** Attachment identity for diff: {@code (type, scope)} pair. */
+  private static String key(AttachmentDefinition a) {
+    return a.type() + "|" + a.scope();
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/MappingValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/MappingValidator.java
@@ -1,0 +1,452 @@
+package com.wkspower.platform.infrastructure.config;
+
+import com.wkspower.platform.domain.config.model.AttachmentDefinition;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.EndEventMapping;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.SignalMapping;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.UserTaskMapping;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.domain.port.BackendSignalKind;
+import com.wkspower.platform.domain.port.BpmnElementInspector;
+import com.wkspower.platform.domain.workflow.BpmnElementSummary;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+/**
+ * Story 4.2 — collect-all validator for the {@code attachments: [...]} block of a CaseType YAML.
+ * Mirrors the {@link ConfigValidator} idiom: every check accumulates {@link ErrorDetail}s and the
+ * validator never short-circuits on first error (architecture invariant — {@code BpmnValidator}
+ * lines 124–129 reference).
+ *
+ * <p>This validator is I/O-free. Callers ({@link CaseTypeStartupLoader} / future admin deploy
+ * controller) supply BPMN bytes via the {@code bpmnFiles} map; the validator never touches the
+ * filesystem or deploys to the BPMN engine — Story 4.5 owns that lifecycle.
+ *
+ * <h2>Wire codes emitted</h2>
+ *
+ * <ul>
+ *   <li>{@code WKS-MAP-001} — non-userTask BPMN element id missing in attached file
+ *   <li>{@code WKS-MAP-003} — {@code scope: stage:<id>} (or {@code emits.scope}) references unknown
+ *       stage
+ *   <li>{@code WKS-MAP-004} — {@code attachments[].type} not in the {@link
+ *       #SUPPORTED_ATTACHMENT_TYPES} allow-list
+ *   <li>{@code WKS-MAP-005} — {@code attachments[].file} missing, blank, unreadable, or fails BPMN
+ *       sniff
+ *   <li>{@code WKS-MAP-006} — duplicate {@code scope} across attachments
+ *   <li>{@code WKS-CFG-027} — userTask mapping reference missing in BPMN (architecture §828)
+ *   <li>{@code WKS-CFG-028} — {@code stageTransition} adjacency invalid (architecture §832)
+ * </ul>
+ *
+ * <p><b>Reserved-and-not-emitted</b>: {@code WKS-MAP-002} (precedence collisions — Phase-0
+ * disallows two events targeting the same {@code (stage, status)}; the rule wires up in Story 4.4
+ * once the runtime side has the precedence vocabulary), {@code WKS-MAP-007} (alias of {@code
+ * WKS-CFG-028}), {@code WKS-CFG-029} (Story 3.8's blast-radius surface).
+ *
+ * <h2>Phase-0 type allow-list extension point</h2>
+ *
+ * <p>{@link #SUPPORTED_ATTACHMENT_TYPES} is the single enforcement point for Phase-0's BPMN-only
+ * constraint (D22). Phase-1 stories extend this set to introduce additional adapter kinds — see
+ * <b>Story 4.9</b> for the next allow-list addition (in-memory state-machine adapter).
+ */
+@Component
+public class MappingValidator {
+
+  /**
+   * Phase-0 allow-list of {@code attachments[].type} values (AC6). Single enforcement point — see
+   * Story 4.9 for the next allow-list addition (in-memory state-machine adapter).
+   */
+  private static final Set<String> SUPPORTED_ATTACHMENT_TYPES = Set.of("bpmn");
+
+  /** Stage-scope syntax: {@code stage:<id>} where the id obeys the Story 3.1 stage id pattern. */
+  private static final Pattern STAGE_SCOPE = Pattern.compile("stage:([a-z][a-z0-9-]{0,62})");
+
+  /** {@code "<from> -> <to>"} adjacency syntax (the literal arrow is the separator). */
+  private static final Pattern STAGE_TRANSITION =
+      Pattern.compile("\\s*([a-z][a-z0-9-]*)\\s*->\\s*([a-z][a-z0-9-]*|completed|skipped)\\s*");
+
+  /** {@code "userTask:<id>"} prefix on {@code map.properties[].on}. */
+  private static final Pattern USER_TASK_REF = Pattern.compile("userTask:(.+)");
+
+  private final BpmnElementInspector inspector;
+
+  public MappingValidator(BpmnElementInspector inspector) {
+    this.inspector = inspector;
+  }
+
+  /**
+   * Validate the {@code attachments} block of {@code raw} and return a typed {@link
+   * MappingDefinition} alongside the collected error list. {@code stageIds} is the set of stage ids
+   * declared by the CaseType (Story 3.1) — used for {@code WKS-MAP-003} cross-references and {@code
+   * WKS-CFG-028} adjacency checks. {@code bpmnFiles} maps filename → bytes; missing entries for
+   * declared {@code attachments[].file} produce {@code WKS-MAP-005}.
+   */
+  public Result validate(
+      RawCaseTypeConfig raw, Set<String> stageIds, Map<String, byte[]> bpmnFiles) {
+    List<ErrorDetail> errors = new ArrayList<>();
+    if (raw == null || raw.attachments() == null || raw.attachments().isEmpty()) {
+      return new Result(MappingDefinition.empty(), List.copyOf(errors));
+    }
+    Map<String, byte[]> bpmnByName = bpmnFiles == null ? Map.of() : bpmnFiles;
+
+    Set<String> seenScopes = new HashSet<>();
+    List<AttachmentDefinition> definitions = new ArrayList<>();
+    for (int i = 0; i < raw.attachments().size(); i++) {
+      RawCaseTypeConfig.RawAttachment a = raw.attachments().get(i);
+      String base = "/attachments/" + i;
+      if (a == null) {
+        errors.add(
+            ErrorDetail.ofField(ErrorCode.WKS_CFG_001.wire(), "Attachment entry is empty", base));
+        continue;
+      }
+
+      // --- type allow-list (WKS-MAP-004) ---
+      String type = a.type();
+      if (type == null || type.isBlank()) {
+        errors.add(
+            ErrorDetail.ofField(
+                ErrorCode.WKS_CFG_001.wire(),
+                "Attachment requires 'type' (Phase-0 allowed: " + SUPPORTED_ATTACHMENT_TYPES + ")",
+                base + "/type"));
+      } else if (!SUPPORTED_ATTACHMENT_TYPES.contains(type)) {
+        errors.add(
+            ErrorDetail.ofField(
+                ErrorCode.WKS_MAP_004.wire(),
+                "Unsupported attachment type '"
+                    + type
+                    + "' — Phase-0 allowed: "
+                    + SUPPORTED_ATTACHMENT_TYPES,
+                base + "/type"));
+      }
+
+      // --- scope syntax + stage cross-ref (WKS-MAP-003) + duplicate scope (WKS-MAP-006) ---
+      String scope = a.scope();
+      Optional<String> stageScopeId = Optional.empty();
+      if (scope == null || scope.isBlank()) {
+        errors.add(
+            ErrorDetail.ofField(
+                ErrorCode.WKS_CFG_001.wire(),
+                "Attachment requires 'scope' (case | stage:<id>)",
+                base + "/scope"));
+      } else if ("case".equals(scope)) {
+        // legal
+      } else {
+        var m = STAGE_SCOPE.matcher(scope);
+        if (!m.matches()) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_CFG_001.wire(),
+                  "Attachment scope must be 'case' or 'stage:<id>' — got: " + scope,
+                  base + "/scope"));
+        } else {
+          String stageId = m.group(1);
+          stageScopeId = Optional.of(stageId);
+          if (!stageIds.contains(stageId)) {
+            errors.add(
+                ErrorDetail.ofField(
+                    ErrorCode.WKS_MAP_003.wire(),
+                    "Attachment scope references unknown stage '" + stageId + "'",
+                    base + "/scope"));
+          }
+        }
+      }
+      if (scope != null && !scope.isBlank() && !seenScopes.add(scope)) {
+        errors.add(
+            ErrorDetail.ofField(
+                ErrorCode.WKS_MAP_006.wire(),
+                "Duplicate attachment scope: " + scope,
+                base + "/scope"));
+      }
+
+      // --- file presence + BPMN sniff (WKS-MAP-005) ---
+      String file = a.file();
+      BpmnElementSummary summary = null;
+      boolean bpmnTyped = "bpmn".equals(type);
+      if (file == null || file.isBlank()) {
+        errors.add(
+            ErrorDetail.ofField(
+                ErrorCode.WKS_MAP_005.wire(), "Attachment requires 'file'", base + "/file"));
+      } else if (bpmnTyped) {
+        byte[] bytes = bpmnByName.get(file);
+        if (bytes == null) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_MAP_005.wire(), "BPMN file not provided: " + file, base + "/file"));
+        } else {
+          try {
+            summary = inspector.summarize(bytes);
+          } catch (RuntimeException ex) {
+            errors.add(
+                ErrorDetail.ofField(
+                    ErrorCode.WKS_MAP_005.wire(),
+                    "BPMN parse failed for '" + file + "': " + ex.getMessage(),
+                    base + "/file"));
+          }
+        }
+      }
+
+      // --- map.* cross-refs (WKS-CFG-027 / WKS-MAP-001 / WKS-CFG-028 / WKS-MAP-003) ---
+      Map<String, UserTaskMapping> userTasksOut = new LinkedHashMap<>();
+      Optional<EndEventMapping> endEventOut = Optional.empty();
+      Map<String, SignalMapping> signalsOut = new LinkedHashMap<>();
+      List<PropertyEmissionRule> propsOut = new ArrayList<>();
+
+      RawCaseTypeConfig.RawAttachmentMap map = a.map();
+      if (map != null) {
+        // userTasks — emit WKS-CFG-027 when bpmn summary present and id not in BPMN
+        if (map.userTasks() != null) {
+          for (var entry : map.userTasks().entrySet()) {
+            String taskId = entry.getKey();
+            RawCaseTypeConfig.RawUserTaskMapping rut = entry.getValue();
+            String fieldPath = base + "/map/userTasks/" + taskId;
+            if (rut == null || rut.wksTask() == null || rut.wksTask().isBlank()) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_CFG_001.wire(),
+                      "userTask mapping requires 'wksTask'",
+                      fieldPath + "/wksTask"));
+              continue;
+            }
+            if (summary != null && !summary.userTaskIds().contains(taskId)) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_CFG_027.wire(),
+                      "BPMN userTask '"
+                          + taskId
+                          + "' referenced in mapping but not declared in "
+                          + file,
+                      fieldPath));
+            }
+            userTasksOut.put(taskId, new UserTaskMapping(rut.wksTask(), rut.form()));
+          }
+        }
+
+        // events.endEvent + events.signal
+        if (map.events() != null) {
+          // endEvent
+          RawCaseTypeConfig.RawEndEventMapping ree = map.events().endEvent();
+          if (ree != null) {
+            String fieldPath = base + "/map/events/endEvent/stageTransition";
+            // AC3 rule 5: BPMN must declare at least one endEvent if any endEvent rule exists
+            if (summary != null && summary.endEventIds().isEmpty()) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_MAP_001.wire(),
+                      "endEvent rule declared but BPMN has no endEvents",
+                      base + "/map/events/endEvent"));
+            }
+            String transition = ree.stageTransition();
+            if (transition == null || transition.isBlank()) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_CFG_001.wire(),
+                      "endEvent rule requires 'stageTransition'",
+                      fieldPath));
+            } else {
+              if (!checkStageTransition(transition, stageIds, errors, fieldPath)) {
+                // already reported
+              }
+              endEventOut = Optional.of(new EndEventMapping(transition));
+            }
+          }
+
+          // signal mappings
+          if (map.events().signal() != null) {
+            for (var entry : map.events().signal().entrySet()) {
+              String signalId = entry.getKey();
+              RawCaseTypeConfig.RawSignalMapping rsm = entry.getValue();
+              String sigField = base + "/map/events/signal/" + signalId;
+              if (summary != null && !summary.signalIds().contains(signalId)) {
+                errors.add(
+                    ErrorDetail.ofField(
+                        ErrorCode.WKS_MAP_001.wire(),
+                        "BPMN signal '"
+                            + signalId
+                            + "' referenced in mapping but not declared in "
+                            + file,
+                        sigField));
+              }
+              if (rsm == null || rsm.stageTransition() == null || rsm.stageTransition().isBlank()) {
+                errors.add(
+                    ErrorDetail.ofField(
+                        ErrorCode.WKS_CFG_001.wire(),
+                        "signal mapping requires 'stageTransition'",
+                        sigField + "/stageTransition"));
+              } else {
+                checkStageTransition(
+                    rsm.stageTransition(), stageIds, errors, sigField + "/stageTransition");
+                signalsOut.put(signalId, new SignalMapping(rsm.stageTransition()));
+              }
+            }
+          }
+        }
+
+        // properties[]
+        if (map.properties() != null) {
+          for (int j = 0; j < map.properties().size(); j++) {
+            RawCaseTypeConfig.RawPropertyEmissionRule rpr = map.properties().get(j);
+            String pBase = base + "/map/properties/" + j;
+            if (rpr == null) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_CFG_001.wire(), "property rule is empty", pBase));
+              continue;
+            }
+            String on = rpr.on();
+            if (on == null || on.isBlank()) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_CFG_001.wire(),
+                      "property rule requires 'on' (e.g. userTask:<id>)",
+                      pBase + "/on"));
+            } else {
+              var m = USER_TASK_REF.matcher(on);
+              if (m.matches()) {
+                String userTaskId = m.group(1);
+                if (summary != null && !summary.userTaskIds().contains(userTaskId)) {
+                  errors.add(
+                      ErrorDetail.ofField(
+                          ErrorCode.WKS_CFG_027.wire(),
+                          "BPMN userTask '"
+                              + userTaskId
+                              + "' referenced in mapping but not declared in "
+                              + file,
+                          pBase + "/on"));
+                }
+              }
+            }
+            String prop = rpr.camundaProperty();
+            if (prop == null || prop.isBlank()) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_CFG_001.wire(),
+                      "property rule requires 'camunda:property'",
+                      pBase + "/camunda:property"));
+            }
+            BackendSignalKind emitsKind = null;
+            String emitScope = null;
+            RawCaseTypeConfig.RawEmits remits = rpr.emits();
+            if (remits == null) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_CFG_001.wire(),
+                      "property rule requires 'emits' block",
+                      pBase + "/emits"));
+            } else {
+              emitsKind = parseEmitsKind(remits.type(), errors, pBase + "/emits/type");
+              emitScope = remits.scope();
+              if (emitScope != null && !emitScope.isBlank() && !"case".equals(emitScope)) {
+                var sm = STAGE_SCOPE.matcher(emitScope);
+                if (sm.matches() && !stageIds.contains(sm.group(1))) {
+                  errors.add(
+                      ErrorDetail.ofField(
+                          ErrorCode.WKS_MAP_003.wire(),
+                          "emits.scope references unknown stage '" + sm.group(1) + "'",
+                          pBase + "/emits/scope"));
+                }
+              }
+            }
+            if (on != null
+                && prop != null
+                && emitsKind != null
+                && emitScope != null
+                && !on.isBlank()
+                && !prop.isBlank()
+                && !emitScope.isBlank()) {
+              propsOut.add(new PropertyEmissionRule(on, prop, emitsKind, emitScope));
+            }
+          }
+        }
+      }
+
+      // Build the AttachmentDefinition only when type/file/scope are non-blank — otherwise the
+      // record's invariants would throw NPE. We still keep collecting errors for fields that did
+      // pass.
+      if (type != null
+          && !type.isBlank()
+          && file != null
+          && !file.isBlank()
+          && scope != null
+          && !scope.isBlank()) {
+        definitions.add(
+            new AttachmentDefinition(
+                type, file, scope, stageScopeId, userTasksOut, endEventOut, signalsOut, propsOut));
+      }
+    }
+
+    return new Result(new MappingDefinition(definitions), List.copyOf(errors));
+  }
+
+  private boolean checkStageTransition(
+      String transition, Set<String> stageIds, List<ErrorDetail> errors, String fieldPath) {
+    var m = STAGE_TRANSITION.matcher(transition);
+    if (!m.matches()) {
+      errors.add(
+          ErrorDetail.ofField(
+              ErrorCode.WKS_CFG_001.wire(),
+              "stageTransition must be '<from> -> <to>' — got: " + transition,
+              fieldPath));
+      return false;
+    }
+    String from = m.group(1);
+    String to = m.group(2);
+    boolean ok = true;
+    if (!stageIds.contains(from)) {
+      errors.add(
+          ErrorDetail.ofField(
+              ErrorCode.WKS_CFG_028.wire(),
+              "stageTransition '" + transition + "' references unknown 'from' stage: " + from,
+              fieldPath));
+      ok = false;
+    }
+    if (!"completed".equals(to) && !"skipped".equals(to) && !stageIds.contains(to)) {
+      errors.add(
+          ErrorDetail.ofField(
+              ErrorCode.WKS_CFG_028.wire(),
+              "stageTransition '" + transition + "' references unknown 'to' stage: " + to,
+              fieldPath));
+      ok = false;
+    }
+    return ok;
+  }
+
+  private BackendSignalKind parseEmitsKind(
+      String wire, List<ErrorDetail> errors, String fieldPath) {
+    if (wire == null || wire.isBlank()) {
+      errors.add(
+          ErrorDetail.ofField(ErrorCode.WKS_CFG_001.wire(), "emits.type is required", fieldPath));
+      return null;
+    }
+    return switch (wire) {
+      case "status" -> BackendSignalKind.USER_TASK_PROPERTY;
+      case "named-signal" -> BackendSignalKind.NAMED_SIGNAL;
+      case "outcome" -> BackendSignalKind.OUTCOME;
+      case "task-complete" -> BackendSignalKind.USER_TASK_PROPERTY;
+      default -> {
+        errors.add(
+            ErrorDetail.ofField(
+                ErrorCode.WKS_CFG_008.wire(),
+                "Unknown emits.type '"
+                    + wire
+                    + "' — allowed: status|named-signal|outcome|task-complete",
+                fieldPath));
+        yield null;
+      }
+    };
+  }
+
+  /**
+   * Result of {@link #validate(RawCaseTypeConfig, Set, Map)} — the parsed {@link MappingDefinition}
+   * (always non-null; {@link MappingDefinition#empty()} when the YAML has no attachments) and the
+   * collect-all error list.
+   */
+  public record Result(MappingDefinition definition, List<ErrorDetail> errors) {}
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -2,7 +2,9 @@ package com.wkspower.platform.infrastructure.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Transport-shaped mirror of the case-type YAML tree. Every field is a boxed nullable so the
@@ -25,7 +27,38 @@ public record RawCaseTypeConfig(
     List<RawStatus> statuses,
     List<String> listColumns,
     List<RawRole> roles,
-    List<RawStage> stages) {
+    List<RawStage> stages,
+    List<RawAttachment> attachments) {
+
+  /**
+   * Backward-compat constructor for callers (and tests) authored before Story 4.2 introduced the
+   * {@code attachments} slot. Treats absent attachments as the empty list — equivalent to a YAML
+   * with no {@code attachments:} key (AC1).
+   */
+  public RawCaseTypeConfig(
+      String id,
+      String displayName,
+      Integer version,
+      String description,
+      RawWorkflow workflow,
+      List<RawField> fields,
+      List<RawStatus> statuses,
+      List<String> listColumns,
+      List<RawRole> roles,
+      List<RawStage> stages) {
+    this(
+        id,
+        displayName,
+        version,
+        description,
+        workflow,
+        fields,
+        statuses,
+        listColumns,
+        roles,
+        stages,
+        null);
+  }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawWorkflow(String bpmn) {}
@@ -59,20 +92,6 @@ public record RawCaseTypeConfig(
   public record RawRole(String name, List<String> permissions) {}
 
   /**
-   * Story 3.1 — supports both YAML forms:
-   *
-   * <pre>
-   *   stages: [intake, underwriting]            # string-list form (each element parses via fromString)
-   *   stages:
-   *     - id: intake
-   *       displayName: "Intake"                  # rich-object form
-   * </pre>
-   *
-   * Jackson dispatches via {@link JsonCreator} on the matching type — string scalars hit {@link
-   * #fromString} and produce a {@code RawStage(id, null)}; mappings hit {@link #fromObject} via
-   * Jackson's default record deserialization.
-   */
-  /**
    * Story 3.1 — wrapper record that supports BOTH YAML forms in a single list:
    *
    * <pre>
@@ -95,9 +114,54 @@ public record RawCaseTypeConfig(
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public static RawStage fromObject(
-        @com.fasterxml.jackson.annotation.JsonProperty("id") String id,
-        @com.fasterxml.jackson.annotation.JsonProperty("displayName") String displayName) {
+        @JsonProperty("id") String id, @JsonProperty("displayName") String displayName) {
       return new RawStage(id, displayName);
     }
   }
+
+  // ---------------------------------------------------------------------------------------------
+  // Story 4.2 — attachments + mapping (architecture §790–809)
+  // ---------------------------------------------------------------------------------------------
+
+  /** One {@code attachments[]} entry. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RawAttachment(String type, String file, String scope, RawAttachmentMap map) {}
+
+  /** {@code map: { userTasks, events, properties }} block inside an attachment. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RawAttachmentMap(
+      Map<String, RawUserTaskMapping> userTasks,
+      RawEventMappings events,
+      List<RawPropertyEmissionRule> properties) {}
+
+  /** {@code map.userTasks.<id>} entry. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RawUserTaskMapping(String wksTask, String form) {}
+
+  /** {@code map.events: { endEvent, signal }} block. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RawEventMappings(
+      RawEndEventMapping endEvent, Map<String, RawSignalMapping> signal) {}
+
+  /** {@code map.events.endEvent} entry. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RawEndEventMapping(String stageTransition) {}
+
+  /** {@code map.events.signal.<id>} entry. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RawSignalMapping(String stageTransition) {}
+
+  /**
+   * {@code map.properties[]} entry. The YAML key {@code camunda:property} is colon-bearing; Jackson
+   * needs an explicit {@link JsonProperty} alias.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RawPropertyEmissionRule(
+      @JsonProperty("on") String on,
+      @JsonProperty("camunda:property") String camundaProperty,
+      RawEmits emits) {}
+
+  /** {@code emits: { type, scope }} block inside a property emission rule. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RawEmits(String type, String scope) {}
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/package-info.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/package-info.java
@@ -1,2 +1,13 @@
-/** Spring {@code @Configuration} classes — DataSource, web MVC, CORS, etc. */
+/**
+ * Spring {@code @Configuration} classes — DataSource, web MVC, CORS, etc. — plus the case-type YAML
+ * loading and validation pipeline ({@link
+ * com.wkspower.platform.infrastructure.config.CaseTypeYamlLoader}, {@link
+ * com.wkspower.platform.infrastructure.config.ConfigValidator}) and Story 4.2's Mapping Layer
+ * deploy-time validator ({@link com.wkspower.platform.infrastructure.config.MappingValidator}).
+ *
+ * <p>Story 4.2 / D22 — {@code MappingValidator} runs after stage validation as a single pipeline
+ * step inside {@code ConfigValidator}; there is no second invocation site. The validator is
+ * I/O-free; callers (startup loader, future admin deploy controller) supply BPMN bytes as a
+ * caller-controlled {@code Map<String, byte[]>}.
+ */
 package com.wkspower.platform.infrastructure.config;

--- a/backend/src/test/java/com/wkspower/platform/architecture/ArchitectureTest.java
+++ b/backend/src/test/java/com/wkspower/platform/architecture/ArchitectureTest.java
@@ -313,6 +313,36 @@ class ArchitectureTest {
   }
 
   @Test
+  void mappingDomainModelHasNoFrameworkImports() {
+    // Story 4.2 AC10 task 5 / AC4 — the new mapping value-object types (MappingDefinition,
+    // AttachmentDefinition, MappingChangeClass) stay framework-free. Reuse BackendSignalKind
+    // from domain/port; never duplicate the enum.
+    //
+    // Scope is pinned by simple-name on purpose: FieldType / StatusColor (Story 2.1) carry
+    // Jackson annotations as a documented pre-existing exception. Pinning the rule to the
+    // Story-4.2 types keeps the assertion tight without weakening 2.1's posture.
+    noClasses()
+        .that()
+        .haveSimpleName("MappingDefinition")
+        .or()
+        .haveSimpleName("AttachmentDefinition")
+        .or()
+        .haveSimpleName("MappingChangeClass")
+        .should()
+        .dependOnClassesThat()
+        .resideInAnyPackage(
+            "org.springframework..",
+            "com.fasterxml.jackson..",
+            "jakarta.persistence..",
+            "org.cibseven..")
+        .because(
+            "MappingDefinition / AttachmentDefinition / MappingChangeClass stay pure Java —"
+                + " Story 4.2 AC4 / NFR36. Reuse BackendSignalKind from domain/port; never"
+                + " duplicate the enum.")
+        .check(CLASSES);
+  }
+
+  @Test
   void hexagonalLayering() {
     Architectures.layeredArchitecture()
         .consideringAllDependencies()

--- a/backend/src/test/java/com/wkspower/platform/domain/config/model/MappingDefinitionTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/config/model/MappingDefinitionTest.java
@@ -1,0 +1,87 @@
+package com.wkspower.platform.domain.config.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.UserTaskMapping;
+import com.wkspower.platform.domain.port.BackendSignalKind;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Story 4.2 AC10 — value-object surface tests for {@link MappingDefinition}. */
+class MappingDefinitionTest {
+
+  @Test
+  void emptyFactoryReturnsZeroAttachmentInstance() {
+    MappingDefinition empty = MappingDefinition.empty();
+    assertThat(empty.attachments()).isEmpty();
+  }
+
+  @Test
+  void emptyFactoryIsSingleton() {
+    assertThat(MappingDefinition.empty()).isSameAs(MappingDefinition.empty());
+  }
+
+  @Test
+  void equalityHoldsForIdenticalContent() {
+    AttachmentDefinition a =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of("t1", new UserTaskMapping("Review", null)),
+            Optional.empty(),
+            Map.of(),
+            List.of());
+    AttachmentDefinition b =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of("t1", new UserTaskMapping("Review", null)),
+            Optional.empty(),
+            Map.of(),
+            List.of());
+    assertThat(new MappingDefinition(List.of(a))).isEqualTo(new MappingDefinition(List.of(b)));
+  }
+
+  @Test
+  void backendSignalKindIsReusedForPropertyEmission() {
+    PropertyEmissionRule rule =
+        new PropertyEmissionRule(
+            "userTask:t1", "status", BackendSignalKind.USER_TASK_PROPERTY, "stage:underwriting");
+    assertThat(rule.emits()).isEqualTo(BackendSignalKind.USER_TASK_PROPERTY);
+    assertThat(rule.emitScope()).isEqualTo("stage:underwriting");
+  }
+
+  @Test
+  void scopeStageIdIsExposedViaOptional() {
+    AttachmentDefinition stageScoped =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "stage:underwriting",
+            Optional.of("underwriting"),
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            List.of());
+    assertThat(stageScoped.stageScopeId()).contains("underwriting");
+
+    AttachmentDefinition caseScoped =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            List.of());
+    assertThat(caseScoped.stageScopeId()).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorMappingIntegrationTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorMappingIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.engine.BpmnParser;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 4.2 AC10 task 4 — cross-validator integration. Proves {@link ConfigValidator} composes
+ * {@link MappingValidator} after stage validation without short-circuiting: a YAML with both a
+ * stage error (Story 3.1 — {@code WKS-CFG-031}) and a mapping error ({@code WKS-CFG-027}) produces
+ * BOTH error details in one {@code ValidationResult}.
+ */
+class ConfigValidatorMappingIntegrationTest {
+
+  private static final String BPMN =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                        targetNamespace="http://wkspower.test">
+        <bpmn:process id="claim" isExecutable="true">
+          <bpmn:startEvent id="start"/>
+          <bpmn:userTask id="real-task"/>
+          <bpmn:endEvent id="done"/>
+          <bpmn:sequenceFlow id="f1" sourceRef="start" targetRef="real-task"/>
+          <bpmn:sequenceFlow id="f2" sourceRef="real-task" targetRef="done"/>
+        </bpmn:process>
+      </bpmn:definitions>
+      """;
+
+  private final CaseTypeYamlLoader loader = new CaseTypeYamlLoader();
+  private final MappingValidator mappingValidator = new MappingValidator(new BpmnParser());
+  private final ConfigValidator validator = new ConfigValidator(mappingValidator);
+
+  @Test
+  void duplicateStageAndMissingUserTaskBothSurfaceInOnePass() {
+    String yaml =
+        """
+        id: claim
+        displayName: Claim
+        version: 1
+        workflow:
+          bpmn: claim.bpmn
+        fields:
+          - id: applicant
+            displayName: Applicant
+            type: text
+        statuses:
+          - id: open
+            displayName: Open
+        listColumns: [applicant]
+        roles:
+          - name: officer
+            permissions: [view]
+        stages: [intake, intake]
+        attachments:
+          - type: bpmn
+            file: x.bpmn
+            scope: case
+            map:
+              userTasks:
+                ghost-task: { wksTask: "Ghost" }
+        """;
+    var read = loader.readBytes("test", yaml.getBytes(StandardCharsets.UTF_8));
+    assertThat(read.isParsed()).isTrue();
+
+    var result =
+        validator.validate(
+            read.raw(), read.lines(), Map.of("x.bpmn", BPMN.getBytes(StandardCharsets.UTF_8)));
+
+    var codes = result.errors().stream().map(ErrorDetail::code).distinct().toList();
+    assertThat(codes).contains("WKS-CFG-031", "WKS-CFG-027");
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingDiffTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingDiffTest.java
@@ -1,0 +1,228 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.model.AttachmentDefinition;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.EndEventMapping;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.SignalMapping;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.UserTaskMapping;
+import com.wkspower.platform.domain.config.model.MappingChangeClass;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import com.wkspower.platform.domain.port.BackendSignalKind;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 4.2 AC8 / AC10 — branch coverage for the unwired {@link MappingDiff#classify} helper. Story
+ * 3.8 will wire this into deploy gating; here we lock the classification semantics.
+ */
+class MappingDiffTest {
+
+  @Test
+  void emptyToEmptyIsAppendClass() {
+    assertThat(MappingDiff.classify(MappingDefinition.empty(), MappingDefinition.empty()))
+        .isEqualTo(MappingChangeClass.APPEND_CLASS);
+  }
+
+  @Test
+  void appendClass_newAttachmentAdded() {
+    MappingDefinition prev = MappingDefinition.empty();
+    MappingDefinition next =
+        new MappingDefinition(
+            List.of(
+                new AttachmentDefinition(
+                    "bpmn",
+                    "x.bpmn",
+                    "case",
+                    Optional.empty(),
+                    Map.of(),
+                    Optional.empty(),
+                    Map.of(),
+                    List.of())));
+    assertThat(MappingDiff.classify(prev, next)).isEqualTo(MappingChangeClass.APPEND_CLASS);
+  }
+
+  @Test
+  void appendClass_newUserTaskMappingAdded() {
+    AttachmentDefinition before = baseAttachment(Map.of(), List.of());
+    AttachmentDefinition after =
+        baseAttachment(Map.of("t1", new UserTaskMapping("Review", null)), List.of());
+    assertThat(
+            MappingDiff.classify(
+                new MappingDefinition(List.of(before)), new MappingDefinition(List.of(after))))
+        .isEqualTo(MappingChangeClass.APPEND_CLASS);
+  }
+
+  @Test
+  void appendClass_newPropertyRuleAdded() {
+    PropertyEmissionRule rule =
+        new PropertyEmissionRule(
+            "userTask:t1", "status", BackendSignalKind.USER_TASK_PROPERTY, "case");
+    AttachmentDefinition before = baseAttachment(Map.of(), List.of());
+    AttachmentDefinition after = baseAttachment(Map.of(), List.of(rule));
+    assertThat(
+            MappingDiff.classify(
+                new MappingDefinition(List.of(before)), new MappingDefinition(List.of(after))))
+        .isEqualTo(MappingChangeClass.APPEND_CLASS);
+  }
+
+  @Test
+  void mutateClass_attachmentRemoved() {
+    AttachmentDefinition a = baseAttachment(Map.of(), List.of());
+    assertThat(MappingDiff.classify(new MappingDefinition(List.of(a)), MappingDefinition.empty()))
+        .isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  @Test
+  void mutateClass_wksTaskValueChanged() {
+    AttachmentDefinition before =
+        baseAttachment(Map.of("t1", new UserTaskMapping("Old", null)), List.of());
+    AttachmentDefinition after =
+        baseAttachment(Map.of("t1", new UserTaskMapping("New", null)), List.of());
+    assertThat(
+            MappingDiff.classify(
+                new MappingDefinition(List.of(before)), new MappingDefinition(List.of(after))))
+        .isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  @Test
+  void mutateClass_stageTransitionPayloadChanged() {
+    AttachmentDefinition before =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of(),
+            Optional.of(new EndEventMapping("a -> b")),
+            Map.of(),
+            List.of());
+    AttachmentDefinition after =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of(),
+            Optional.of(new EndEventMapping("a -> c")),
+            Map.of(),
+            List.of());
+    assertThat(
+            MappingDiff.classify(
+                new MappingDefinition(List.of(before)), new MappingDefinition(List.of(after))))
+        .isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  @Test
+  void mutateClass_signalMappingChanged() {
+    AttachmentDefinition before =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of(),
+            Optional.empty(),
+            Map.of("escalated", new SignalMapping("a -> b")),
+            List.of());
+    AttachmentDefinition after =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of(),
+            Optional.empty(),
+            Map.of("escalated", new SignalMapping("a -> c")),
+            List.of());
+    assertThat(
+            MappingDiff.classify(
+                new MappingDefinition(List.of(before)), new MappingDefinition(List.of(after))))
+        .isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  @Test
+  void mutateClass_fileReferenceChanged() {
+    AttachmentDefinition before =
+        new AttachmentDefinition(
+            "bpmn",
+            "old.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            List.of());
+    AttachmentDefinition after =
+        new AttachmentDefinition(
+            "bpmn",
+            "new.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            List.of());
+    assertThat(
+            MappingDiff.classify(
+                new MappingDefinition(List.of(before)), new MappingDefinition(List.of(after))))
+        .isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  @Test
+  void mutateClass_scopeChangedRegistersAsRemoveAndAdd() {
+    AttachmentDefinition before =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "case",
+            Optional.empty(),
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            List.of());
+    AttachmentDefinition after =
+        new AttachmentDefinition(
+            "bpmn",
+            "x.bpmn",
+            "stage:intake",
+            Optional.of("intake"),
+            Map.of(),
+            Optional.empty(),
+            Map.of(),
+            List.of());
+    // Scope is part of the identity key — so the diff sees a removal + an addition. Removal is
+    // mutate-class, by definition.
+    assertThat(
+            MappingDiff.classify(
+                new MappingDefinition(List.of(before)), new MappingDefinition(List.of(after))))
+        .isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  @Test
+  void mutateClass_userTaskMappingRemoved() {
+    AttachmentDefinition before =
+        baseAttachment(Map.of("t1", new UserTaskMapping("Review", null)), List.of());
+    AttachmentDefinition after = baseAttachment(Map.of(), List.of());
+    assertThat(
+            MappingDiff.classify(
+                new MappingDefinition(List.of(before)), new MappingDefinition(List.of(after))))
+        .isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  private AttachmentDefinition baseAttachment(
+      Map<String, UserTaskMapping> userTasks, List<PropertyEmissionRule> properties) {
+    return new AttachmentDefinition(
+        "bpmn",
+        "x.bpmn",
+        "case",
+        Optional.empty(),
+        userTasks,
+        Optional.empty(),
+        Map.of(),
+        properties);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingValidatorTest.java
@@ -1,0 +1,396 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.engine.BpmnParser;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 4.2 AC10 — collect-all wire-code coverage for {@link MappingValidator}. Mirrors the {@code
+ * ConfigValidatorStagesTest} idiom: every "wrong YAML" test asserts the error list
+ * <em>contains</em> the expected wire code, never asserts list size unless explicitly testing
+ * collect-all.
+ */
+class MappingValidatorTest {
+
+  private static final String BPMN_WITH_REVIEW_AND_END =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                        targetNamespace="http://wkspower.test">
+        <bpmn:signal id="claim-escalated" name="ClaimEscalated"/>
+        <bpmn:process id="claim" isExecutable="true">
+          <bpmn:startEvent id="start"/>
+          <bpmn:userTask id="review-claim" name="Review Claim"/>
+          <bpmn:endEvent id="done"/>
+          <bpmn:sequenceFlow id="f1" sourceRef="start" targetRef="review-claim"/>
+          <bpmn:sequenceFlow id="f2" sourceRef="review-claim" targetRef="done"/>
+        </bpmn:process>
+      </bpmn:definitions>
+      """;
+
+  private static final String BPMN_NO_END_EVENT =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                        targetNamespace="http://wkspower.test">
+        <bpmn:process id="claim" isExecutable="true">
+          <bpmn:startEvent id="start"/>
+          <bpmn:userTask id="review-claim" name="Review"/>
+        </bpmn:process>
+      </bpmn:definitions>
+      """;
+
+  private final BpmnParser parser = new BpmnParser();
+  private final MappingValidator validator = new MappingValidator(parser);
+
+  // ---- AC1 zero-attachments / null attachments are legal ----
+
+  @Test
+  void emptyAttachmentsListIsLegal() {
+    var raw = parseYaml(GREEN_HEAD + "\nattachments: []\n");
+    var result = validator.validate(raw, Set.of("intake"), Map.of());
+    assertThat(result.errors()).isEmpty();
+    assertThat(result.definition().attachments()).isEmpty();
+  }
+
+  @Test
+  void omittedAttachmentsKeyIsLegal() {
+    var raw = parseYaml(GREEN_HEAD);
+    var result = validator.validate(raw, Set.of("intake"), Map.of());
+    assertThat(result.errors()).isEmpty();
+    assertThat(result.definition().attachments()).isEmpty();
+  }
+
+  // ---- WKS-MAP-004 — type allow-list ----
+
+  @Test
+  void wksMap004_unknownAttachmentType() {
+    var raw = parseYaml(GREEN_HEAD + attach("state-machine", "x.bpmn", "case", null));
+    var result = validator.validate(raw, Set.of("intake"), Map.of());
+    assertCodes(result.errors()).contains("WKS-MAP-004");
+  }
+
+  // ---- WKS-MAP-005 — file missing/unprovided ----
+
+  @Test
+  void wksMap005_fileNotProvided() {
+    var raw = parseYaml(GREEN_HEAD + attach("bpmn", "missing.bpmn", "case", null));
+    var result = validator.validate(raw, Set.of("intake"), Map.of());
+    assertCodes(result.errors()).contains("WKS-MAP-005");
+  }
+
+  @Test
+  void wksMap005_bpmnParseFails() {
+    var raw = parseYaml(GREEN_HEAD + attach("bpmn", "garbage.bpmn", "case", null));
+    Map<String, byte[]> files =
+        Map.of("garbage.bpmn", "this is not bpmn".getBytes(StandardCharsets.UTF_8));
+    var result = validator.validate(raw, Set.of("intake"), files);
+    assertCodes(result.errors()).contains("WKS-MAP-005");
+  }
+
+  // ---- WKS-MAP-003 — unknown stage in scope or emits.scope ----
+
+  @Test
+  void wksMap003_unknownStageInScope() {
+    var raw = parseYaml(GREEN_HEAD + attach("bpmn", "x.bpmn", "stage:nonexistent", null));
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-MAP-003");
+  }
+
+  // ---- WKS-MAP-006 — duplicate scope across attachments ----
+
+  @Test
+  void wksMap006_duplicateScopeAcrossAttachments() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: a.bpmn\n    scope: case\n"
+            + "  - type: bpmn\n    file: b.bpmn\n    scope: case\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw,
+            Set.of("intake"),
+            Map.of(
+                "a.bpmn",
+                BPMN_WITH_REVIEW_AND_END.getBytes(),
+                "b.bpmn",
+                BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-MAP-006");
+  }
+
+  // ---- WKS-CFG-027 — userTask mapping references unknown BPMN userTask ----
+
+  @Test
+  void wksCfg027_userTaskMappingReferencesUnknownTask() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      userTasks:\n        ghost-task: { wksTask: \"Ghost\" }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-CFG-027");
+  }
+
+  @Test
+  void wksCfg027_propertyOnUserTaskReferencesUnknownTask() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      properties:\n"
+            + "        - on: userTask:ghost-task\n"
+            + "          camunda:property: status\n"
+            + "          emits: { type: status, scope: case }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-CFG-027");
+  }
+
+  // ---- WKS-MAP-001 — non-userTask BPMN element refs ----
+
+  @Test
+  void wksMap001_signalReferencesUnknownBpmnSignal() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      events:\n"
+            + "        signal:\n"
+            + "          ghost-signal: { stageTransition: \"intake -> completed\" }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-MAP-001");
+  }
+
+  @Test
+  void wksMap001_endEventRuleOnBpmnWithNoEndEvents() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      events:\n"
+            + "        endEvent: { stageTransition: \"intake -> completed\" }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(raw, Set.of("intake"), Map.of("x.bpmn", BPMN_NO_END_EVENT.getBytes()));
+    assertCodes(result.errors()).contains("WKS-MAP-001");
+  }
+
+  // ---- WKS-CFG-028 — stageTransition adjacency invalid ----
+
+  @Test
+  void wksCfg028_endEventStageTransitionUnknownStage() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      events:\n"
+            + "        endEvent: { stageTransition: \"intake -> nonexistent\" }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-CFG-028");
+  }
+
+  // ---- AC7 — JSON-pointer field paths ----
+
+  @Test
+  void errorDetailsCarryJsonPointerFieldPaths() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      userTasks:\n        ghost: { wksTask: \"G\" }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertThat(result.errors())
+        .anySatisfy(e -> assertThat(e.field()).isEqualTo("/attachments/0/map/userTasks/ghost"));
+  }
+
+  // ---- AC2 — collect-all (multiple errors of different kinds in one pass) ----
+
+  @Test
+  void collectsAllThreeMappingErrorsInOnePass() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: stage:nonexistent\n" // WKS-MAP-003
+            + "    map:\n      userTasks:\n        ghost: { wksTask: \"G\" }\n" // WKS-CFG-027
+            + "      events:\n"
+            + "        endEvent: { stageTransition: \"intake -> nonexistent\" }\n"; // WKS-CFG-028
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    var codes = result.errors().stream().map(ErrorDetail::code).distinct().toList();
+    assertThat(codes).contains("WKS-MAP-003", "WKS-CFG-027", "WKS-CFG-028");
+  }
+
+  // ---- WKS-CFG-028 — signal stageTransition adjacency invalid ----
+
+  @Test
+  void wksCfg028_signalStageTransitionUnknownToStage() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      events:\n"
+            + "        signal:\n"
+            + "          claim-escalated: { stageTransition: \"intake -> ghost\" }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-CFG-028");
+  }
+
+  // ---- WKS-MAP-003 — unknown stage in emits.scope ----
+
+  @Test
+  void wksMap003_unknownStageInEmitsScope() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      properties:\n"
+            + "        - on: userTask:review-claim\n"
+            + "          camunda:property: status\n"
+            + "          emits: { type: status, scope: stage:nonexistent }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-MAP-003");
+  }
+
+  // ---- WKS-CFG-008 — unknown emits.type ----
+
+  @Test
+  void wksCfg008_unknownEmitsType() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      properties:\n"
+            + "        - on: userTask:review-claim\n"
+            + "          camunda:property: status\n"
+            + "          emits: { type: bogus, scope: case }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-CFG-008");
+  }
+
+  // ---- AC6 — Phase-0 type allow-list contains exactly 'bpmn' ----
+
+  @Test
+  void phase0AllowListAcceptsBpmnOnly() {
+    var rawTemporal = parseYaml(GREEN_HEAD + attach("temporal", "x.bpmn", "case", null));
+    var resTemporal = validator.validate(rawTemporal, Set.of("intake"), Map.of());
+    assertCodes(resTemporal.errors()).contains("WKS-MAP-004");
+
+    var rawStateMachine = parseYaml(GREEN_HEAD + attach("state-machine", "x.bpmn", "case", null));
+    var resStateMachine = validator.validate(rawStateMachine, Set.of("intake"), Map.of());
+    assertCodes(resStateMachine.errors()).contains("WKS-MAP-004");
+  }
+
+  // ---- AC9 / AC10 — positive smoke: a fully valid attachment passes ----
+
+  @Test
+  void greenSeedPassesWithZeroErrors() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      userTasks:\n"
+            + "        review-claim: { wksTask: \"Underwriting Review\" }\n"
+            + "      events:\n"
+            + "        endEvent: { stageTransition: \"intake -> completed\" }\n"
+            + "      properties:\n"
+            + "        - on: userTask:review-claim\n"
+            + "          camunda:property: status\n"
+            + "          emits: { type: status, scope: case }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertThat(result.errors()).isEmpty();
+    assertThat(result.definition().attachments()).hasSize(1);
+    var attachment = result.definition().attachments().get(0);
+    assertThat(attachment.type()).isEqualTo("bpmn");
+    assertThat(attachment.scope()).isEqualTo("case");
+    assertThat(attachment.userTaskMappings()).containsKey("review-claim");
+    assertThat(attachment.endEventMapping()).isPresent();
+    assertThat(attachment.propertyEmissionRules()).hasSize(1);
+  }
+
+  // ---- helpers ----
+
+  private static org.assertj.core.api.AbstractListAssert<?, List<? extends String>, String, ?>
+      assertCodes(List<ErrorDetail> errors) {
+    return assertThat(errors.stream().map(ErrorDetail::code).toList());
+  }
+
+  private static String attach(String type, String file, String scope, String mapBlock) {
+    StringBuilder sb = new StringBuilder("\nattachments:\n  - type: ");
+    sb.append(type).append("\n    file: ").append(file).append("\n    scope: ").append(scope);
+    if (mapBlock != null) {
+      sb.append("\n    ").append(mapBlock);
+    }
+    sb.append('\n');
+    return sb.toString();
+  }
+
+  private RawCaseTypeConfig parseYaml(String yaml) {
+    var loader = new CaseTypeYamlLoader();
+    var read = loader.readBytes("test", yaml.getBytes(StandardCharsets.UTF_8));
+    if (!read.isParsed()) {
+      throw new AssertionError(
+          "YAML did not parse: " + read.errors().stream().map(ErrorDetail::message).toList());
+    }
+    return read.raw();
+  }
+
+  private static final String GREEN_HEAD =
+      """
+      id: claim
+      displayName: Claim
+      version: 1
+      workflow:
+        bpmn: claim.bpmn
+      fields:
+        - id: applicant
+          displayName: Applicant
+          type: text
+      statuses:
+        - id: open
+          displayName: Open
+      listColumns: [applicant]
+      roles:
+        - name: officer
+          permissions: [view, create]
+      stages:
+        - id: intake
+          displayName: Intake
+      """;
+}


### PR DESCRIPTION
## Wire codes added (AC2)

| Code | Meaning |
|---|---|
| WKS-MAP-001 | BPMN element id missing in attached file |
| WKS-MAP-002 | Same (stage,status) targeted from two events without precedence (RESERVED — emission lives in Story 4.4) |
| WKS-MAP-003 | scope:stage:<id> references unknown stage |
| WKS-MAP-004 | attachments[].type not 'bpmn' (Phase-0) |
| WKS-MAP-005 | attachments[].file missing/unreadable/not-BPMN |
| WKS-MAP-006 | Duplicate scope across attachments |
| WKS-MAP-007 | RESERVED — not emitted; alias of WKS-CFG-028 |
| WKS-CFG-027 | userTasks.<id> missing in attached BPMN |
| WKS-CFG-028 | endEvent.stageTransition adjacency invalid |
| WKS-CFG-029 | RESERVED — emitted by Story 3.8, not by 4.2 |

## Package layout

```
domain/config/model/MappingDefinition         (new)
domain/config/model/AttachmentDefinition      (new)
domain/config/model/MappingChangeClass        (new)
domain/port/BpmnElementInspector              (new)
domain/workflow/BpmnElementSummary            (new)
infrastructure/config/MappingValidator        (new)
infrastructure/config/MappingDiff             (new)
infrastructure/config/RawCaseTypeConfig       (extended — attachments slot + 8 nested records)
infrastructure/config/ConfigValidator         (extended — validate(raw, lines, bpmnFiles) overload)
infrastructure/config/CaseTypeSourceAdapter   (extended — sibling BPMN reader)
engine/BpmnParser                             (extended — implements BpmnElementInspector)
domain/exception/ErrorCode                    (extended — 10 codes appended)
```

## Dependency-tree diff

\`git diff backend/pom.xml\` empty. Zero new runtime deps. BPMN parsing reuses the existing
\`org.cibseven.bpm.model:cibseven-bpm-model-bpmn\` already on the classpath via \`engine/BpmnParser\`.

## Naming alignment

- \`WKS-MAP-007\` reserved-not-emitted: gives Story 4.6 UI a Mapping-namespaced label for the rule whose wire code is \`WKS-CFG-028\`.
- \`WKS-CFG-029\` reserved-not-emitted: ships the code constant; Story 3.8's blast-radius validator emits it.
- \`WKS-MAP-002\` reserved-not-emitted in this story: precedence enforcement lives with Story 4.4 once the runtime side has the precedence vocabulary.

## Seed fixture

\`seed/j8-bpmn-attached.{yaml,bpmn}\` (in sibling \`wks-platform2\` planning-artifacts repo) — smallest legal BPMN-attached CaseType (2 stages, 1 userTask, 1 endEvent, 1 property rule). Passes \`MappingValidator\` with zero errors.

## Test plan

- [ ] Backend CI green: 36 new tests, 340+ total unit tests pass; Spotless clean; tenant-invariant lint OK.
- [ ] Verify \`grep -rn 'mappingValidator.validate' backend/src\` returns a single call site (inside \`ConfigValidator\`).
- [ ] Hand-test seeding: from \`wks-platform2/seed/\`, run \`./seed.sh\` after this PR merges and confirm \`[J8] BPMN-attached\` deploys.
- [ ] Confirm against the BOM that \`engine/BpmnParser\` remains the canonical entry point for BPMN parsing — no second BPMN model dep introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)