### PR TITLE
Story 3.2: Zero-Stage CaseType is First-Class

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseDto.java
@@ -7,8 +7,21 @@ import java.util.UUID;
 /**
  * Wire shape for {@code GET /api/cases/{id}} and the result of {@code POST /api/cases} / {@code PUT
  * /api/cases/{id}} (Story 2.3 AC5–AC8). {@code documentCount} is always {@code 0} until Epic 3;
- * {@code caseType} is the embedded type view (sub-object). The field shape is frozen here so Story
- * 3.2 can fill {@code documentCount} without a DTO bump.
+ * {@code caseType} is the embedded type view (sub-object).
+ *
+ * <p>Story 3.2 AC5 — adds two NULLABLE scalar stage-cache fields:
+ *
+ * <ul>
+ *   <li>{@code currentStageId} — the latest ACTIVE stage id; {@code null} on zero-stage CaseTypes
+ *       and after the final stage is completed.
+ *   <li>{@code currentStageOrdinal} — companion ordinal; {@code null} iff {@code currentStageId} is
+ *       {@code null}.
+ * </ul>
+ *
+ * Future consumer: Story 3.3 (StageTimeline frontend component) reads both fields to highlight the
+ * active stage. Story 3.3 ALSO ships a {@code stages: List<StageView>} array field on this DTO (the
+ * timeline payload); the two scalars and the array are additive, not redundant — scalars give O(1)
+ * "which stage am I on?" without iterating the array.
  */
 public record CaseDto(
     UUID id,
@@ -23,4 +36,6 @@ public record CaseDto(
     UUID createdBy,
     Instant updatedAt,
     long version,
-    CaseTypeViewDto caseType) {}
+    CaseTypeViewDto caseType,
+    String currentStageId,
+    Integer currentStageOrdinal) {}

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -35,7 +35,11 @@ public final class CaseDtoMapper {
         domain.createdBy(),
         domain.updatedAt(),
         domain.version(),
-        toCaseTypeView(caseType));
+        toCaseTypeView(caseType),
+        // Story 3.2 AC5 — null on zero-stage CaseTypes; populated from the cases table cache cols
+        // (Story 3.1) for staged cases.
+        domain.currentStageId(),
+        domain.currentStageOrdinal());
   }
 
   public static CaseSummaryDto toSummaryDto(CaseSummary summary) {

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
@@ -12,6 +12,12 @@ import java.util.Optional;
  * YAML omits {@code stages:} or declares an empty list, this field is {@link List#of()} and every
  * downstream service treats the absence as a no-op (Decision 19: "stage-less paths must remain
  * unbranched").
+ *
+ * <p>Story 3.2 — {@code workflow} is now <strong>nullable</strong>. A CaseType may declare no
+ * {@code workflow:} block in YAML; the component is then {@code null} and {@link #workflowOpt()}
+ * returns {@link Optional#empty()}. Process-less paths must remain unbranched in code by the same
+ * rule as stage-less paths (Decision 19 — Story 3.2 extension): {@link #workflowOpt()} is iterated
+ * via {@code Optional.ifPresent(...)}, never via {@code if (caseType.workflow() != null)}.
  */
 public record CaseTypeConfig(
     String id,
@@ -63,5 +69,14 @@ public record CaseTypeConfig(
   /** Convenience lookup used by the JSON Schema generator and (future) case-data validation. */
   public Optional<FieldDefinition> field(String fieldId) {
     return fields.stream().filter(f -> f.id().equals(fieldId)).findFirst();
+  }
+
+  /**
+   * Story 3.2 — {@link Optional} view of the (now nullable) {@link #workflow()} component. Call
+   * sites that need to skip engine work for process-less CaseTypes use {@code
+   * workflowOpt().ifPresent(...)} per Decision 19's unbranched-paths invariant.
+   */
+  public Optional<WorkflowRef> workflowOpt() {
+    return Optional.ofNullable(workflow);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/model/Case.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/Case.java
@@ -27,6 +27,10 @@ import java.util.UUID;
  * @param createdBy user id of the actor who created the case
  * @param updatedAt last-update timestamp
  * @param version optimistic-locking version (from {@code @Version} on the JPA row)
+ * @param currentStageId Story 3.1 / 3.2 — denormalised cache of the latest ACTIVE stage id; {@code
+ *     null} on zero-stage CaseTypes and after the last stage is completed
+ * @param currentStageOrdinal Story 3.1 / 3.2 — companion ordinal to {@code currentStageId}; {@code
+ *     null} when {@code currentStageId} is {@code null}
  */
 public record Case(
     UUID id,
@@ -39,7 +43,41 @@ public record Case(
     Instant createdAt,
     UUID createdBy,
     Instant updatedAt,
-    long version) {
+    long version,
+    String currentStageId,
+    Integer currentStageOrdinal) {
+
+  /**
+   * Story 3.2 — backward-compat constructor for callers (and tests) that predate the stage-cache
+   * fields. Defaults both stage-cache slots to {@code null} (zero-stage shape).
+   */
+  public Case(
+      UUID id,
+      String caseTypeId,
+      int caseTypeVersion,
+      String status,
+      UUID assignee,
+      Map<String, Object> data,
+      String processInstanceId,
+      Instant createdAt,
+      UUID createdBy,
+      Instant updatedAt,
+      long version) {
+    this(
+        id,
+        caseTypeId,
+        caseTypeVersion,
+        status,
+        assignee,
+        data,
+        processInstanceId,
+        createdAt,
+        createdBy,
+        updatedAt,
+        version,
+        null,
+        null);
+  }
 
   public Case {
     Objects.requireNonNull(id, "id");

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -87,18 +87,29 @@ public class CaseService {
     UUID caseId = UUID.randomUUID();
     String initialStatus = initialStatus(caseType);
 
-    String processDefinitionKey =
-        processKeyResolver
-            .resolve(caseType.id())
-            .orElseThrow(
-                () ->
-                    new WksWorkflowEngineException(
-                        "No deployed BPMN process definition for case type "
-                            + caseType.id()
-                            + " — case create requires a deployed workflow"));
-    String processInstanceId =
-        workflowEngine.startProcessInstance(
-            processDefinitionKey, Map.of("caseId", caseId.toString(), "caseTypeId", caseType.id()));
+    // Story 3.2 AC2 — engine call is OPTIONAL. Process-less CaseTypes (workflow: omitted) skip the
+    // resolver + start call entirely. Decision 19 / 3.2 unbranched-paths invariant: do not branch
+    // on caseType.hasWorkflow() — iterate via Optional.ifPresent and let absence be the no-op.
+    String[] processInstanceIdHolder = new String[] {null};
+    caseType
+        .workflowOpt()
+        .ifPresent(
+            wf -> {
+              String processDefinitionKey =
+                  processKeyResolver
+                      .resolve(caseType.id())
+                      .orElseThrow(
+                          () ->
+                              new WksWorkflowEngineException(
+                                  "No deployed BPMN process definition for case type "
+                                      + caseType.id()
+                                      + " — case create requires a deployed workflow"));
+              processInstanceIdHolder[0] =
+                  workflowEngine.startProcessInstance(
+                      processDefinitionKey,
+                      Map.of("caseId", caseId.toString(), "caseTypeId", caseType.id()));
+            });
+    String processInstanceId = processInstanceIdHolder[0];
 
     Instant now = clock.now();
     Case toPersist =

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -106,7 +106,7 @@ public class ConfigValidator {
             raw.displayName(),
             raw.version(),
             raw.description(),
-            new WorkflowRef(raw.workflow().bpmn()),
+            toWorkflowRef(raw.workflow()),
             fields,
             statuses,
             listColumns,
@@ -218,16 +218,28 @@ public class ConfigValidator {
     }
   }
 
+  /**
+   * Story 3.2 AC1 — {@code workflow:} is now an OPTIONAL slot. Omitted or blank ⇒ no error
+   * (Decision 19 / 3.2: process-less paths must remain unbranched; zero-process is the trivial
+   * shape, not an alarm). The downstream mapper at {@link #toWorkflowRef} returns {@code null} for
+   * those cases. WKS-CFG-001 is preserved for the slots that ARE still required (id, displayName,
+   * version, fields, statuses, listColumns, roles).
+   */
   private void checkWorkflow(
       RawCaseTypeConfig.RawWorkflow wf, ErrorBuilder eb, List<ErrorDetail> errors) {
-    if (wf == null) {
-      errors.add(eb.error(ErrorCode.WKS_CFG_001, "Required key missing: workflow", "workflow"));
-      return;
+    // Intentionally empty — workflow is optional. BpmnValidator surfaces missing-file errors at
+    // deploy time when a workflow IS declared.
+  }
+
+  /**
+   * Story 3.2 AC1 — null-safe builder for the domain {@link WorkflowRef}. Returns {@code null} when
+   * the YAML omits the slot or supplies a blank {@code bpmn} value.
+   */
+  private static WorkflowRef toWorkflowRef(RawCaseTypeConfig.RawWorkflow wf) {
+    if (wf == null || wf.bpmn() == null || wf.bpmn().isBlank()) {
+      return null;
     }
-    if (wf.bpmn() == null || wf.bpmn().isBlank()) {
-      errors.add(
-          eb.error(ErrorCode.WKS_CFG_001, "Required key missing: workflow.bpmn", "workflow.bpmn"));
-    }
+    return new WorkflowRef(wf.bpmn());
   }
 
   private List<FieldDefinition> checkFields(
@@ -403,11 +415,23 @@ public class ConfigValidator {
     return out;
   }
 
+  /**
+   * Story 3.2 AC8 — canonical two-element default applied when YAML omits or empties {@code
+   * statuses:}. Two elements are the minimum viable contract — a single-status default has no
+   * transition target and traps the case at create. Single-source-of-truth at parse time;
+   * downstream services treat {@link CaseTypeConfig#statuses()} as authoritative without a presence
+   * check.
+   */
+  private static final List<StatusDefinition> DEFAULT_STATUSES =
+      List.of(
+          new StatusDefinition("open", "Open", StatusColor.BLUE),
+          new StatusDefinition("closed", "Closed", StatusColor.ZINC));
+
   private List<StatusDefinition> checkStatuses(
       List<RawCaseTypeConfig.RawStatus> raws, ErrorBuilder eb, List<ErrorDetail> errors) {
     if (raws == null || raws.isEmpty()) {
-      errors.add(eb.error(ErrorCode.WKS_CFG_001, "Required key missing: statuses", "statuses"));
-      return List.of();
+      // Story 3.2 AC8 — apply canonical default; do NOT raise WKS-CFG-001.
+      return DEFAULT_STATUSES;
     }
     if (raws.size() > CaseTypeLimits.MAX_STATUSES) {
       errors.add(

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/mapper/CaseMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/mapper/CaseMapper.java
@@ -25,7 +25,11 @@ public final class CaseMapper {
         entity.getCreatedAt(),
         entity.getCreatedBy(),
         entity.getUpdatedAt(),
-        entity.getVersion());
+        entity.getVersion(),
+        // Story 3.2 AC5 — propagate the Story 3.1 stage-cache columns into the domain model so the
+        // CaseDto and the (Story 3.3) timeline UI can read them. Zero-stage CaseTypes ⇒ null/null.
+        entity.getCurrentStageId(),
+        entity.getCurrentStageOrdinal());
   }
 
   public static CaseEntity toEntity(Case domain) {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ZeroStageZeroProcessTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ZeroStageZeroProcessTest.java
@@ -1,0 +1,315 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.event.CaseCreated;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseQuery;
+import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.model.Stage;
+import com.wkspower.platform.domain.page.Page;
+import com.wkspower.platform.domain.page.PageRequest;
+import com.wkspower.platform.domain.port.CaseDataValidator;
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.port.CaseTypeReader;
+import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
+import com.wkspower.platform.domain.port.StageRepository;
+import com.wkspower.platform.domain.port.WorkflowEngine;
+import com.wkspower.platform.domain.workflow.DeploymentInfo;
+import com.wkspower.platform.domain.workflow.DeploymentRequest;
+import com.wkspower.platform.domain.workflow.DeploymentResult;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 3.2 — headline-matrix unit tests for the zero-stage zero-process CaseType. Pure-Java stubs
+ * (mirrors {@link CaseServiceTest}'s no-Spring no-DB enumeration) so a regression here is easy to
+ * triage without booting an integration slice.
+ *
+ * <p>Covers AC11 scenarios 1, 4, 5 (downshifted), 6, 8. Scenarios 2, 3 are exercised in {@code
+ * ConfigValidatorTest#story32_*}. Scenario 7 (comment / attachment / ad-hoc task surfaces) lives in
+ * the Story 2.x controller-IT base; this class does not duplicate that surface.
+ */
+class ZeroStageZeroProcessTest {
+
+  private static final UUID ACTOR = UUID.randomUUID();
+  private static final Instant FIXED = Instant.parse("2026-05-05T10:00:00Z");
+
+  private final RecordingRepo repo = new RecordingRepo();
+  private final NoopValidator validator = new NoopValidator();
+  private final TrackingEngine engine = new TrackingEngine();
+  private final TrackingResolver resolver = new TrackingResolver();
+  private final RecordingPublisher publisher = new RecordingPublisher();
+
+  private CaseService svc(CaseTypeConfig config) {
+    WksStageAdvancer advancer =
+        new WksStageAdvancer(new NoopStageRepository(), publisher, () -> FIXED);
+    return new CaseService(
+        repo, reader(config), validator, engine, resolver, publisher, () -> FIXED, advancer);
+  }
+
+  // ---- AC11 §4 — create on zero-zero CaseType ----
+
+  @Test
+  void story32_createOnZeroProcess_skipsEngineCallAndPersistsNullProcessInstanceId() {
+    CaseService svc = svc(zeroZeroType());
+
+    Case created = svc.create("zero-zero", Map.of(), null, ACTOR);
+
+    assertThat(created.processInstanceId())
+        .as("zero-process create must NOT invoke the engine")
+        .isNull();
+    assertThat(created.currentStageId()).isNull();
+    assertThat(created.currentStageOrdinal()).isNull();
+    assertThat(created.status()).isEqualTo("open");
+    assertThat(engine.startCalls)
+        .as("engine.startProcessInstance must NOT be invoked for zero-process CaseTypes")
+        .isZero();
+    assertThat(resolver.calls)
+        .as("processKeyResolver.resolve must NOT be invoked for zero-process CaseTypes")
+        .isZero();
+    assertThat(publisher.events).hasSize(1);
+    assertThat(publisher.events.get(0)).isInstanceOf(CaseCreated.class);
+  }
+
+  @Test
+  void story32_createOnWorkflowAttached_stillInvokesEngine() {
+    CaseService svc = svc(workflowAttachedType());
+
+    Case created = svc.create("loan-application", Map.of("name", "Asha"), null, ACTOR);
+
+    assertThat(created.processInstanceId()).isEqualTo("pi-1");
+    assertThat(engine.startCalls).isEqualTo(1);
+    assertThat(resolver.calls).isEqualTo(1);
+  }
+
+  // ---- AC11 §5 — DOWNSHIFTED status transition surface ----
+
+  @Test
+  void story32_transitionOnZeroProcessCase_raisesEngineCouplingError() {
+    // Per Q5 spike (2026-05-05): CaseService.transition() is engine-coupled — requires non-null
+    // processInstanceId. AC4/AC11§5 are downshifted to surface-only; full transition behaviour
+    // is folded into Story 4.4 (BackendSignalRouter / Mapping Layer).
+    CaseService svc = svc(zeroZeroType());
+    Case created = svc.create("zero-zero", Map.of(), null, ACTOR);
+
+    assertThatThrownBy(() -> svc.transition(created.id(), "close", Map.of(), ACTOR))
+        .isInstanceOf(WksWorkflowEngineException.class)
+        .hasMessageContaining("no associated process instance")
+        .hasMessageContaining("cannot transition");
+  }
+
+  // ---- AC11 §1 — repeated parse-time confirmation: workflowOpt empty ----
+
+  @Test
+  void story32_zeroZeroCaseTypeConfig_workflowOptIsEmpty() {
+    CaseTypeConfig zz = zeroZeroType();
+    assertThat(zz.workflowOpt()).isEmpty();
+    assertThat(zz.stages()).isEmpty();
+    assertThat(zz.statuses()).hasSize(2);
+    assertThat(zz.statuses().get(0).id()).isEqualTo("open");
+    assertThat(zz.statuses().get(1).id()).isEqualTo("closed");
+  }
+
+  // ---- AC11 §8 — coexistence with workflow-attached CaseType ----
+
+  @Test
+  void story32_zeroZeroAndWorkflowAttachedCoexist() {
+    CaseService zzSvc = svc(zeroZeroType());
+    CaseService waSvc = svc(workflowAttachedType());
+
+    Case zz = zzSvc.create("zero-zero", Map.of(), null, ACTOR);
+    engine.reset();
+    resolver.reset();
+    Case wa = waSvc.create("loan-application", Map.of("name", "Asha"), null, ACTOR);
+
+    assertThat(zz.processInstanceId()).isNull();
+    assertThat(wa.processInstanceId()).isEqualTo("pi-1");
+    assertThat(engine.startCalls).isEqualTo(1);
+    assertThat(resolver.calls).isEqualTo(1);
+  }
+
+  // ---- helpers ----
+
+  private static CaseTypeConfig zeroZeroType() {
+    // Story 3.2 — smallest valid CaseType: no stages, no workflow, default statuses.
+    return new CaseTypeConfig(
+        "zero-zero",
+        "Zero Zero",
+        1,
+        null,
+        null, // workflow omitted
+        List.of(), // fields empty (legal additive default)
+        List.of(
+            new StatusDefinition("open", "Open", StatusColor.BLUE),
+            new StatusDefinition("closed", "Closed", StatusColor.ZINC)),
+        List.of(),
+        List.of(new RoleDefinition("admin", List.of(Permission.VIEW, Permission.CREATE))),
+        List.of()); // stages empty
+  }
+
+  private static CaseTypeConfig workflowAttachedType() {
+    return new CaseTypeConfig(
+        "loan-application",
+        "Loan Application",
+        1,
+        null,
+        new com.wkspower.platform.domain.config.model.WorkflowRef("loan-application.bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("name"),
+        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))));
+  }
+
+  private static CaseTypeReader reader(CaseTypeConfig config) {
+    return new CaseTypeReader() {
+      @Override
+      public Optional<CaseTypeConfig> find(String id) {
+        return id.equals(config.id()) ? Optional.of(config) : Optional.empty();
+      }
+
+      @Override
+      public Collection<CaseTypeConfig> all() {
+        return List.of(config);
+      }
+    };
+  }
+
+  private static final class RecordingRepo implements CaseRepository {
+    final List<Case> saved = new ArrayList<>();
+
+    @Override
+    public Case save(Case caseToSave) {
+      saved.removeIf(c -> c.id().equals(caseToSave.id()));
+      saved.add(caseToSave);
+      return caseToSave;
+    }
+
+    @Override
+    public Optional<Case> findById(UUID id) {
+      return saved.stream().filter(c -> c.id().equals(id)).findFirst();
+    }
+
+    @Override
+    public Page<CaseSummary> findByCaseType(CaseQuery query, PageRequest pageRequest) {
+      return new Page<>(List.of(), 0, pageRequest.page(), pageRequest.size());
+    }
+
+    @Override
+    public Map<UUID, Map<String, Object>> findDataByIds(
+        Collection<UUID> ids, java.util.Set<String> projectedFieldIds) {
+      return Map.of();
+    }
+  }
+
+  private static final class NoopValidator implements CaseDataValidator {
+    @Override
+    public List<ErrorDetail> validate(CaseTypeConfig caseType, Map<String, Object> data) {
+      return List.of();
+    }
+  }
+
+  private static final class TrackingEngine implements WorkflowEngine {
+    int startCalls = 0;
+
+    void reset() {
+      startCalls = 0;
+    }
+
+    @Override
+    public DeploymentResult deploy(DeploymentRequest request) {
+      return new DeploymentResult("d", request.processDefinitionKey(), "p", 1, FIXED);
+    }
+
+    @Override
+    public Optional<DeploymentInfo> latestDeployment(String key) {
+      return Optional.empty();
+    }
+
+    @Override
+    public String startProcessInstance(String key, Map<String, Object> variables) {
+      startCalls++;
+      return "pi-1";
+    }
+
+    @Override
+    public Optional<com.wkspower.platform.domain.model.Task> findTask(String taskId) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void completeTask(String taskId, Map<String, Object> variables) {}
+
+    @Override
+    public void claimTask(String taskId, UUID userId) {}
+
+    @Override
+    public void signalTransition(
+        String processInstanceId, String action, Map<String, Object> variables) {}
+
+    @Override
+    public List<com.wkspower.platform.domain.model.Task> findTasksByCase(UUID caseId) {
+      return List.of();
+    }
+
+    @Override
+    public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+      return null;
+    }
+  }
+
+  private static final class TrackingResolver implements ProcessDefinitionKeyResolver {
+    int calls = 0;
+
+    void reset() {
+      calls = 0;
+    }
+
+    @Override
+    public Optional<String> resolve(String caseTypeId) {
+      calls++;
+      return Optional.of("processKey-" + caseTypeId);
+    }
+  }
+
+  private static final class RecordingPublisher implements EventPublisher {
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public void publish(Object event) {
+      events.add(event);
+    }
+  }
+
+  private static final class NoopStageRepository implements StageRepository {
+    @Override
+    public List<Stage> loadHistory(UUID caseId) {
+      return List.of();
+    }
+
+    @Override
+    public void materialiseStages(
+        UUID caseId, List<StageDefinition> stages, java.time.Instant createdAt) {}
+
+    @Override
+    public void appendTransition(Transition transition) {}
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
@@ -488,6 +488,100 @@ class ConfigValidatorTest {
     assertThat(result.errors().size()).isGreaterThanOrEqualTo(5);
   }
 
+  // ---- Story 3.2 AC1 — workflow: is now OPTIONAL ----
+
+  @Test
+  void story32_workflowOmitted_validates() {
+    String yaml =
+        """
+        id: zero-zero
+        displayName: Zero Zero
+        version: 1
+        fields:
+          - id: subject
+            displayName: Subject
+            type: text
+        statuses:
+          - id: open
+            displayName: Open
+        listColumns: [subject]
+        roles:
+          - name: officer
+            permissions: [view, create]
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid())
+        .as("workflow-omitted YAML must NOT raise WKS-CFG-001 — got %s", result.errors())
+        .isFalse();
+    assertThat(result.config()).isPresent();
+    assertThat(result.config().get().workflow()).isNull();
+    assertThat(result.config().get().workflowOpt()).isEmpty();
+  }
+
+  @Test
+  void story32_workflowPresentButBlankBpmn_validates() {
+    String yaml =
+        """
+        id: zero-zero
+        displayName: Zero Zero
+        version: 1
+        workflow:
+          bpmn: ""
+        fields:
+          - id: subject
+            displayName: Subject
+            type: text
+        statuses:
+          - id: open
+            displayName: Open
+        listColumns: [subject]
+        roles:
+          - name: officer
+            permissions: [view, create]
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid())
+        .as("workflow.bpmn blank must be treated as omitted — got %s", result.errors())
+        .isFalse();
+    assertThat(result.config().get().workflowOpt()).isEmpty();
+  }
+
+  @Test
+  void story32_workflowDeclared_stillValidatesAsToday() {
+    var result = validate(GREEN_YAML);
+    assertThat(result.isInvalid()).isFalse();
+    assertThat(result.config().get().workflowOpt()).isPresent();
+    assertThat(result.config().get().workflowOpt().get().bpmn()).isEqualTo("loan-application.bpmn");
+  }
+
+  // ---- Story 3.2 AC8 — default status set when YAML omits statuses ----
+
+  @Test
+  void story32_statusesOmitted_defaultsToOpenClosed() {
+    String yaml =
+        """
+        id: zero-zero
+        displayName: Zero Zero
+        version: 1
+        fields:
+          - id: subject
+            displayName: Subject
+            type: text
+        listColumns: [subject]
+        roles:
+          - name: officer
+            permissions: [view, create]
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid())
+        .as("statuses-omitted YAML must use the default — got %s", result.errors())
+        .isFalse();
+    var statuses = result.config().get().statuses();
+    assertThat(statuses).hasSize(2);
+    assertThat(statuses.get(0).id()).isEqualTo("open");
+    assertThat(statuses.get(1).id()).isEqualTo("closed");
+  }
+
   // ---- helpers ----
 
   private ValidationResult validate(String yaml) {


### PR DESCRIPTION
## Summary

Story 3.2 makes the post-pivot headline claim true in code: a CaseType with no `stages:` AND no `workflow:` deploys, creates cases, and runs end-to-end (modulo the AC4 downshift below). After this lands, the smallest valid WKS case type is genuinely *a name → a tracker* per `product-brief-wks-platform2.md` §"smallest valid WKS case type" and Decision 19's "zero-stage case types are first-class" invariant.

- `workflow:` becomes optional in YAML — `ConfigValidator.checkWorkflow` no-ops; `WKS-CFG-001` preserved for slots that ARE still required.
- `CaseService.create` skips the BPMN-engine call when no workflow is declared (`caseType.workflowOpt().ifPresent(...)`). When workflow is declared, behaviour is byte-equivalent.
- Default status set `[open, closed]` synthesised at parse time when YAML omits `statuses:` (AC8).
- `CaseDto` exposes nullable `currentStageId` / `currentStageOrdinal` scalars (AC5) — the wire half of Story 3.3's frontend contract.
- Tests: 4 new `ConfigValidatorTest` cases + new `ZeroStageZeroProcessTest` (5 AC11 scenarios).

### Decisions surfaced

- **AC4 / AC11 §5 DOWNSHIFTED per Q5 spike (recorded in story file 2026-05-05):** `CaseService.transition()` is engine-coupled — it requires a non-null `processInstanceId` and directly invokes `workflowEngine.signalTransition(...)`. Decoupling status transitions from the BPMN engine is **Epic 4 / Story 4.4** scope (`BackendSignalRouter` + Mapping Layer). The downshifted AC4 surfaces the existing engine-coupling error deterministically; the downshifted IT (`story32_transitionOnZeroProcessCase_raisesEngineCouplingError`) will be flipped from "expects error" to "expects 200 with status changed" when 4.4 ships. **Fold-into-4-4 note** per `feedback_fold_debt_into_stories.md`: track via Story 4.4 acceptance criteria; do not retrofit this story.
- **DTO scalar fields (AC5) DID land here.** Story 3.3's PR adds the `stages: List<StageView>` array field; this PR adds only the two scalars. Per the cross-story coordination note in the story file, 3.2 owns the scalars, 3.3 owns the array.
- **J9 (not J8) seed** — Story 4.2 had already taken the J8 slot for the Mapping Layer smoke. The "zero-zero" seed lands at `seed/j9-zero-zero.yaml` to keep both seeds co-resident. Functionally identical to the AC9 spec; flagged in `seed/JOURNEYS.md` and the story dev record. Seed work + JOURNEYS.md + quickstart-zero-stage.md + architecture.md addition under Decision 19 land in the planning repo (`wks-platform2/`); this PR carries only the backend code.
- **No new error codes** introduced (per `feedback_error_codes_are_wire_contract.md`).
- **Default `closed` status uses `StatusColor.ZINC`** (closest neutral). The Q1-locked spec said `gray` with `terminal: true`, but `StatusDefinition` has no `terminal` slot today — flagged as future work for the status semantics story (no impact on the downstream surfaces in scope here).
- **Debt flagged for Story 4.4:** `CaseService.transition()` engine-decoupling. The downshifted IT in this PR is the test seam 4.4 will flip.

## Test plan

- [x] `mvn verify` (backend) — 312 unit + 66 IT green; ArchUnit + Spotless clean.
- [x] `./backend/.ci/check-tenant-invariant.sh` — D25 invariant green.
- [x] `npm ci && npm run lint && npm run format:check && npm test && npm run build` — frontend clean (236 tests, 4 woff2 in dist).
- [ ] Reviewer: spot-check that `caseType.workflowOpt().ifPresent(...)` in `CaseService.create` is the only branch on workflow presence in domain services (Decision 19 unbranched-paths invariant).
- [ ] Reviewer: confirm no `tenant_id` slipped into modified files.
- [ ] Reviewer: confirm `CaseCreated` event signature is unchanged (out-of-scope guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)