### PR TITLE
fix(admin-deploy): optional bpmn part + relax fields/listColumns required-key checks

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
@@ -3,6 +3,7 @@ package com.wkspower.platform.api.controller;
 import com.wkspower.platform.api.dto.ApiResponse;
 import com.wkspower.platform.api.dto.response.DeployResponseDto;
 import com.wkspower.platform.domain.config.DeployResult;
+import com.wkspower.platform.domain.config.ValidationResult;
 import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.ErrorDetail;
 import com.wkspower.platform.domain.exception.WksConfigException;
@@ -41,12 +42,14 @@ public class AdminController {
   @PostMapping(path = "/deploy", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @PreAuthorize("hasRole('ADMIN')")
   @Operation(
-      summary = "Deploy a case-type + BPMN pair",
+      summary = "Deploy a case-type, optionally with a BPMN",
       description =
-          "Multipart body with two required parts: 'caseType' (YAML, ≤1 MB) and 'bpmn' (BPMN 2.0"
-              + " XML, ≤1 MB). Both validators run before the registry is touched; on success the"
-              + " case type is registered, the BPMN is deployed to the embedded engine, and a"
-              + " ConfigDeployed event is published.")
+          "Multipart body. Required: 'caseType' (YAML, ≤1 MB). Optional: 'bpmn' (BPMN 2.0 XML, ≤1"
+              + " MB) — omit for zero-process case types (Story 3.2). Both validators run before"
+              + " the registry is touched; on success the case type is registered, and when a BPMN"
+              + " is present it is deployed to the embedded engine. A ConfigDeployed event is"
+              + " published when a BPMN deployment occurs; YAML-only registrations skip the engine"
+              + " deploy and return null deployment fields.")
   @ApiResponses(
       value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -68,14 +71,31 @@ public class AdminController {
       })
   public ApiResponse<DeployResponseDto> deploy(
       @RequestPart("caseType") MultipartFile caseTypePart,
-      @RequestPart("bpmn") MultipartFile bpmnPart,
+      @RequestPart(name = "bpmn", required = false) MultipartFile bpmnPart,
       HttpServletRequest request)
       throws Exception {
     rejectDuplicateParts(request);
     byte[] yaml = caseTypePart.getBytes();
-    byte[] bpmn = bpmnPart.getBytes();
-
     String actorEmail = currentActorEmail();
+
+    // Story 3.2: zero-process case types deploy YAML-only — no BPMN part means no engine deploy.
+    // An attached but empty `bpmn` part is treated the same as absent.
+    if (bpmnPart == null || bpmnPart.isEmpty()) {
+      ValidationResult yamlResult = configService.validateAndRegister("api-deploy.yaml", yaml);
+      if (yamlResult.isInvalid()) {
+        throw new WksConfigException(yamlResult.errors());
+      }
+      var caseType = yamlResult.config().orElseThrow();
+      return ApiResponse.success(
+          new DeployResponseDto(
+              caseType.id(),
+              caseType.version(),
+              null,
+              null,
+              "/api/admin/case-types/" + caseType.id() + "/schema"));
+    }
+
+    byte[] bpmn = bpmnPart.getBytes();
     DeployResult result = configService.deploy(yaml, bpmn, actorEmail);
     if (result.isInvalid()) {
       throw new WksConfigException(result.errors());

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -287,7 +287,8 @@ public class ConfigValidator {
       List<ErrorDetail> errors,
       List<ErrorDetail> warnings) {
     if (raws == null || raws.isEmpty()) {
-      errors.add(eb.error(ErrorCode.WKS_CFG_001, "Required key missing: fields", "fields"));
+      // Story 3.2 follow-up: zero-process / "name + tracker" case types are first-class.
+      // Omitted `fields:` defaults to empty — no error.
       return List.of();
     }
     if (raws.size() > CaseTypeLimits.MAX_FIELDS) {
@@ -620,8 +621,8 @@ public class ConfigValidator {
       ErrorBuilder eb,
       List<ErrorDetail> errors) {
     if (raws == null || raws.isEmpty()) {
-      errors.add(
-          eb.error(ErrorCode.WKS_CFG_001, "Required key missing: listColumns", "listColumns"));
+      // Story 3.2 follow-up: omitted `listColumns:` defaults to empty — no error.
+      // Aligned with the `fields:` relaxation above; the consuming UI tolerates an empty list.
       return List.of();
     }
     if (raws.size() > CaseTypeLimits.MAX_LIST_COLUMNS) {

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.wkspower.platform.api.GlobalExceptionHandler;
 import com.wkspower.platform.domain.config.DeployResult;
+import com.wkspower.platform.domain.config.ValidationResult;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.config.model.RoleDefinition;
 import com.wkspower.platform.domain.config.model.StatusColor;
@@ -149,7 +150,7 @@ class AdminControllerTest {
             multipart("/api/admin/deploy")
                 .file(
                     new MockMultipartFile("caseType", "ct.yaml", "text/plain", "broken".getBytes()))
-                .file(new MockMultipartFile("bpmn", "p.bpmn", "application/xml", "".getBytes()))
+                .file(new MockMultipartFile("bpmn", "p.bpmn", "application/xml", "<x/>".getBytes()))
                 .with(user("admin").roles("ADMIN")))
         .andExpect(status().isUnprocessableEntity())
         .andExpect(jsonPath("$.error.code").value("WKS-CFG-000"))
@@ -182,15 +183,67 @@ class AdminControllerTest {
     verify(configService).deploy(any(), any(), any());
   }
 
-  // ---- missing part ------------------------------------------------------
+  // ---- YAML-only deploy (Story 3.2: zero-process case types) -------------
 
   @Test
-  void missingPartReturnsBadRequest() throws Exception {
+  void missingBpmnPartDeploysYamlOnlyAndReturnsOk() throws Exception {
+    // Story 3.2 made zero-process case types first-class. The HTTP endpoint must accept a deploy
+    // with only the `caseType` part: YAML is registered, no engine deploy occurs, and the response
+    // carries null deploymentId / processDefinitionId.
+    CaseTypeConfig config =
+        new CaseTypeConfig(
+            "j9-zero-zero",
+            "Zero",
+            1,
+            null,
+            null,
+            List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(),
+            List.of(new RoleDefinition("admin", List.of())));
+    byte[] yamlBytes = "id: j9-zero-zero".getBytes();
+    when(configService.validateAndRegister(eq("api-deploy.yaml"), any(byte[].class)))
+        .thenReturn(ValidationResult.ok(config));
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(new MockMultipartFile("caseType", "ct.yaml", "text/plain", yamlBytes))
+                .with(user("admin").roles("ADMIN")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.caseTypeId").value("j9-zero-zero"))
+        .andExpect(jsonPath("$.data.version").value(1))
+        .andExpect(jsonPath("$.data.deploymentId").doesNotExist())
+        .andExpect(jsonPath("$.data.processDefinitionId").doesNotExist())
+        .andExpect(jsonPath("$.data.schemaUri").value("/api/admin/case-types/j9-zero-zero/schema"));
+
+    verify(configService).validateAndRegister(eq("api-deploy.yaml"), any(byte[].class));
+  }
+
+  @Test
+  void missingBpmnPartWithInvalidYamlReturns422() throws Exception {
+    when(configService.validateAndRegister(eq("api-deploy.yaml"), any(byte[].class)))
+        .thenReturn(
+            ValidationResult.invalid(List.of(ErrorDetail.of("WKS-CFG-099", "YAML parse failed"))));
+
     mockMvc
         .perform(
             multipart("/api/admin/deploy")
                 .file(
-                    new MockMultipartFile("caseType", "ct.yaml", "text/plain", "id: x".getBytes()))
+                    new MockMultipartFile("caseType", "ct.yaml", "text/plain", "broken".getBytes()))
+                .with(user("admin").roles("ADMIN")))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.error.code").value("WKS-CFG-000"))
+        .andExpect(jsonPath("$.error.errors[0].code").value("WKS-CFG-099"));
+  }
+
+  @Test
+  void missingCaseTypePartReturnsBadRequest() throws Exception {
+    // The `caseType` part remains required — only `bpmn` was relaxed. This pins that contract.
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(new MockMultipartFile("bpmn", "p.bpmn", "application/xml", "<x/>".getBytes()))
                 .with(user("admin").roles("ADMIN")))
         .andExpect(status().isBadRequest());
   }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
@@ -210,10 +210,13 @@ class ConfigValidatorTest {
     assertErrorOn(result.errors(), "WKS-CFG-001", "version");
   }
 
-  // ---- Patch 17: missing fields key → exactly one WKS-CFG-001 fields, no WKS-CFG-005 cascade ----
+  // ---- Story 3.2 follow-up: omitted `fields` is legal (zero-process case types) ----
 
   @Test
-  void missingFieldsSkipsListColumnsCrossRef() {
+  void missingFieldsIsLegalAndSkipsListColumnsCrossRef() {
+    // Original "Patch 17" test pinned WKS-CFG-001 on missing `fields`. Story 3.2 made
+    // zero-process / "name + tracker" case types first-class, so `fields:` is now optional and
+    // defaults to an empty list. The cross-ref skip when fields is absent is preserved.
     String yaml =
         """
         id: loan-application
@@ -234,9 +237,32 @@ class ConfigValidatorTest {
         result.errors().stream()
             .filter(e -> "WKS-CFG-001".equals(e.code()) && "fields".equals(e.field()))
             .count();
-    assertThat(fieldErr).isEqualTo(1);
+    assertThat(fieldErr).as("`fields` is now optional — no WKS-CFG-001").isZero();
     long unknownRef = result.errors().stream().filter(e -> "WKS-CFG-005".equals(e.code())).count();
     assertThat(unknownRef).as("no unknown-field cascade when fields is absent").isZero();
+  }
+
+  @Test
+  void smallestValidCaseType_noFieldsNoListColumnsNoStatusesNoWorkflow_isValid() {
+    // The Story 3.2 headline shape: id + displayName + version + roles. Defaults applied
+    // everywhere else. Was failing in seed.sh against j9-zero-zero with WKS-CFG-001 on both
+    // `fields` and `listColumns`; this test locks the relaxation.
+    String yaml =
+        """
+        id: j9-zero-zero
+        displayName: "[J9] Zero"
+        version: 1
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid())
+        .as("smallest valid case type must validate cleanly: errors = " + result.errors())
+        .isFalse();
+    var ct = result.config().orElseThrow();
+    assertThat(ct.fields()).isEmpty();
+    assertThat(ct.listColumns()).isEmpty();
   }
 
   // ---- Patch 23: description > 400 chars → WKS-CFG-007 ----


### PR DESCRIPTION
## Summary

Story 3.2 made zero-stage / zero-process case types first-class in the domain layer but missed two boundary surfaces:

1. **`POST /api/admin/deploy`** still required the `bpmn` multipart part — Spring rejected zero-process seeds (`j9-zero-zero`) with `HTTP 400 "Required part 'bpmn' is not present"` before the request reached the controller body. Fix: `@RequestPart("bpmn") → required = false`. When absent or empty, the controller routes to the existing `ConfigService.validateAndRegister(name, bytes)` YAML-only path (already used by the startup loader's BPMN-missing path) and returns `DeployResponseDto` with null `deploymentId` / `processDefinitionId`. `@Operation` description updated. Existing happy path (YAML + BPMN) is unchanged.
2. **`ConfigValidator`** still required `fields:` and `listColumns:` keys — `j9-zero-zero.yaml` (smallest valid CaseType per the product brief) failed YAML validation. Fix: drop the `WKS-CFG-001 Required key missing` adds for both keys; null/empty defaults to an empty list. The cross-ref check on listColumns was already gated by `fieldsParentPresent`, so dropping the required-key error doesn't weaken cross-validation. Mirrors how Story 3.2 treated `workflow:` and how this PR's controller change treats the `bpmn` multipart part.

No new error codes. Wire contract unchanged for non-zero-zero case types — existing positive `WKS-CFG-001` firings on `id`, `displayName`, `version`, `roles` are untouched.

## Test plan

- [x] `mvn verify` — `BUILD SUCCESS`, 66 tests, 0 failures.
- [x] `AdminControllerTest` — flipped `missingPartReturnsBadRequest` → `missingBpmnPartDeploysYamlOnlyAndReturnsOk`; added `missingBpmnPartWithInvalidYamlReturns422` and `missingCaseTypePartReturnsBadRequest` (caseType part remains required); `validationFailureReturns422Aggregate` now sends non-empty bpmn bytes (per spec I/O matrix: empty bpmn = absent).
- [x] `ConfigValidatorTest` — flipped `missingFieldsSkipsListColumnsCrossRef` → `missingFieldsIsLegalAndSkipsListColumnsCrossRef`; added `smallestValidCaseType_noFieldsNoListColumnsNoStatusesNoWorkflow_isValid` pinning the Story 3.2 headline shape.
- [x] End-to-end: `./seed/seed.sh` (in wks-platform2 paired PR) — 11/11 ✓, `ok=28 fail=0`. J7/J8/J9 visible in UI under `admin@wkspower.local`.

## Related

Pairs with `wkspower/wks-platform2-strategy#4` (`fix/seed-green-j7-j8-j9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)