### PR TITLE
Story 3.6: Stage-Scoped Status Set CRUD — schema, validator, transition guards, DTO

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseDto.java
@@ -23,6 +23,11 @@ import java.util.UUID;
  * CaseTypes). The two scalar denormalised cache fields above are owned by Story 3.2; the array is
  * owned by Story 3.3 per the locked Sprint 2 coordination split. Scalars give O(1) "which stage am
  * I on?" without iterating the array.
+ *
+ * <p>Story 3.6 AC8 — appends {@code availableStatuses: List<StatusView>} (always non-null; empty
+ * only when both stage-scoped and flat status sets are empty — should be impossible after Story
+ * 3.2's default). Resolved at mapping time using {@code caseType.statusesFor(currentStageId)} per
+ * Decision 19's unbranched-paths invariant.
  */
 public record CaseDto(
     UUID id,
@@ -40,13 +45,58 @@ public record CaseDto(
     CaseTypeViewDto caseType,
     String currentStageId,
     Integer currentStageOrdinal,
-    List<StageView> stages) {
+    List<StageView> stages,
+    List<StatusView> availableStatuses) {
 
   /**
-   * Compact constructor — defensive-copy {@code stages} so the wire shape is immutable end-to-end
-   * (mirrors {@code CaseTypeConfig}'s {@code List.copyOf} discipline).
+   * Compact constructor — defensive-copy {@code stages} and {@code availableStatuses} so the wire
+   * shape is immutable end-to-end (mirrors {@code CaseTypeConfig}'s {@code List.copyOf}
+   * discipline).
    */
   public CaseDto {
     stages = stages == null ? List.of() : List.copyOf(stages);
+    availableStatuses = availableStatuses == null ? List.of() : List.copyOf(availableStatuses);
+  }
+
+  /**
+   * Backward-compat constructor for Story 3.2 / 3.3 callers (and tests) authored before Story 3.6
+   * appended the {@code availableStatuses} slot. Defaults the new slot to the empty list — the
+   * mapper should always populate via the canonical constructor.
+   */
+  public CaseDto(
+      UUID id,
+      String caseTypeId,
+      int caseTypeVersion,
+      String status,
+      UUID assignee,
+      Map<String, Object> data,
+      String processInstanceId,
+      int documentCount,
+      Instant createdAt,
+      UUID createdBy,
+      Instant updatedAt,
+      long version,
+      CaseTypeViewDto caseType,
+      String currentStageId,
+      Integer currentStageOrdinal,
+      List<StageView> stages) {
+    this(
+        id,
+        caseTypeId,
+        caseTypeVersion,
+        status,
+        assignee,
+        data,
+        processInstanceId,
+        documentCount,
+        createdAt,
+        createdBy,
+        updatedAt,
+        version,
+        caseType,
+        currentStageId,
+        currentStageOrdinal,
+        stages,
+        List.of());
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/StatusView.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/StatusView.java
@@ -1,0 +1,24 @@
+package com.wkspower.platform.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Wire shape for one entry in {@link CaseDto#availableStatuses()} (Story 3.6 AC8).
+ *
+ * <p>The list is the resolved status set for the case's {@code currentStageId} — stage-scoped when
+ * the active stage declares its own {@code statuses:}, flat fallback otherwise (Decision 19's
+ * unbranched-paths invariant: callers iterate without a presence check). The DTO is a render hint —
+ * transitions still re-validate against the persisted {@code CaseTypeConfig} server-side
+ * (anti-pattern #11 in the Story 3.6 dev notes).
+ *
+ * @param id status id (kebab-case, matches {@code [a-z][a-z0-9-]{1,62}})
+ * @param displayName human-readable label, never blank
+ * @param color status color enum string (lowercase wire form, e.g. {@code "blue"}); nullable when
+ *     YAML omitted the slot
+ * @param terminal stage-scoped terminal flag — when {@code true}, transitions to other statuses on
+ *     the same stage are blocked (Story 3.6 AC1 / AC6)
+ * @param ordinal 0-based position in the resolved status list (declaration order)
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public record StatusView(
+    String id, String displayName, String color, boolean terminal, int ordinal) {}

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -7,9 +7,11 @@ import com.wkspower.platform.api.dto.response.CaseTypeViewDto.FieldView;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.OptionView;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.StageDefinitionView;
 import com.wkspower.platform.api.dto.response.StageView;
+import com.wkspower.platform.api.dto.response.StatusView;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.config.model.FieldDefinition;
 import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.model.CaseSummary;
 import com.wkspower.platform.domain.model.Stage;
@@ -78,7 +80,34 @@ public final class CaseDtoMapper {
         domain.currentStageId(),
         domain.currentStageOrdinal(),
         // Story 3.3 — full stage history projection (empty list for zero-stage CaseTypes).
-        stageViews);
+        stageViews,
+        // Story 3.6 AC8 — resolved status set for the active stage (stage-scoped if declared, flat
+        // fallback otherwise). Empty only when both stage-scoped and flat sets are empty — should
+        // be impossible after Story 3.2's default. Decision 19's unbranched-paths invariant: this
+        // call site does not branch on stage presence; statusesFor() handles the absence in one
+        // place.
+        toAvailableStatuses(caseType, domain.currentStageId()));
+  }
+
+  /**
+   * Story 3.6 AC8 — resolve the available status list for the case's current stage. Pure read; no
+   * I/O. The {@code currentStageId} can be {@code null} (zero-stage CaseType, or all stages
+   * completed) — in that case {@code statusesFor(null)} returns the flat set.
+   */
+  static List<StatusView> toAvailableStatuses(CaseTypeConfig caseType, String currentStageId) {
+    List<StatusDefinition> resolved = caseType.statusesFor(currentStageId);
+    List<StatusView> out = new java.util.ArrayList<>(resolved.size());
+    for (int i = 0; i < resolved.size(); i++) {
+      StatusDefinition s = resolved.get(i);
+      out.add(
+          new StatusView(
+              s.id(),
+              s.displayName(),
+              s.color() == null ? null : s.color().wire(),
+              s.terminal(),
+              i));
+    }
+    return out;
   }
 
   static StageView toStageView(Stage stage, StageDefinition def) {

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
@@ -72,6 +72,32 @@ public record CaseTypeConfig(
   }
 
   /**
+   * Story 3.6 AC2 / AC8 — locate a declared stage by id.
+   *
+   * <p>Returns {@link Optional#empty()} when the case type has no stages or none match. Read-only
+   * convenience; never throws.
+   */
+  public Optional<StageDefinition> stage(String stageId) {
+    if (stageId == null) {
+      return Optional.empty();
+    }
+    return stages.stream().filter(s -> s.id().equals(stageId)).findFirst();
+  }
+
+  /**
+   * Story 3.6 AC2 / AC8 — resolve the effective status set for a given stage.
+   *
+   * <p>Returns the stage-scoped {@code statuses:} when declared, otherwise falls back to the flat
+   * case-type-level {@link #statuses()} (which itself defaults to {@code [open, closed]} when YAML
+   * omits the slot — Story 3.2 default). Single source of truth for Decision 19's "stage-less paths
+   * must remain unbranched" — callers iterate the returned list without branching on stage
+   * presence.
+   */
+  public List<StatusDefinition> statusesFor(String stageId) {
+    return stage(stageId).flatMap(StageDefinition::statusesOpt).orElse(statuses);
+  }
+
+  /**
    * Story 3.2 — {@link Optional} view of the (now nullable) {@link #workflow()} component. Call
    * sites that need to skip engine work for process-less CaseTypes use {@code
    * workflowOpt().ifPresent(...)} per Decision 19's unbranched-paths invariant.

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/StageDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/StageDefinition.java
@@ -1,6 +1,8 @@
 package com.wkspower.platform.domain.config.model;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A stage declared on a case-type YAML (Story 3.1 AC1). Plain Java — no Spring, no JPA, no Jackson
@@ -13,7 +15,22 @@ import java.util.Objects;
  *   stages:
  *     - id: intake
  *       displayName: "Intake"                   # rich form (forward-compat for status-set / archetype slots)
+ *     - id: underwriting
+ *       displayName: "Underwriting"
+ *       statuses: [...]                          # Story 3.6 — stage-scoped status set
+ *       initialStatus: pending-docs              # Story 3.6 — defaults to first declared
  * </pre>
+ *
+ * <p>Story 3.6 AC2 — adds two slots:
+ *
+ * <ul>
+ *   <li>{@code statuses} — nullable. {@code null} means "key omitted; resolver falls back to flat
+ *       case-type-level set". Empty list ({@code []} declared in YAML) is rejected with {@code
+ *       WKS-STG-008}.
+ *   <li>{@code initialStatus} — {@link Optional}, resolved at parse time to the explicit YAML value
+ *       or the first declared status's id when omitted. Empty when {@code statuses} is also null
+ *       (the flat fallback owns initial-status resolution in that case).
+ * </ul>
  *
  * <p>{@code displayName} defaults to a Title-cased {@code id} when the YAML omits it (e.g. {@code
  * "loan-decision"} → {@code "Loan Decision"}). The {@code ordinal} is the 0-based position in the
@@ -22,8 +39,16 @@ import java.util.Objects;
  * @param id stage id (matches {@code [a-z][a-z0-9-]{0,62}}, not a reserved word)
  * @param displayName human-readable label, never blank
  * @param ordinal 0-based position in the declared {@code stages} list
+ * @param statuses stage-scoped status list; {@code null} ⇒ "use flat fallback"
+ * @param initialStatus resolved initial status id ({@code Optional.empty()} when {@code statuses}
+ *     is {@code null})
  */
-public record StageDefinition(String id, String displayName, int ordinal) {
+public record StageDefinition(
+    String id,
+    String displayName,
+    int ordinal,
+    List<StatusDefinition> statuses,
+    Optional<String> initialStatus) {
 
   public StageDefinition {
     Objects.requireNonNull(id, "id");
@@ -31,5 +56,26 @@ public record StageDefinition(String id, String displayName, int ordinal) {
     if (ordinal < 0) {
       throw new IllegalArgumentException("ordinal must be >= 0");
     }
+    Objects.requireNonNull(initialStatus, "initialStatus");
+    // Defensive copy — null distinguishes "omitted" (fall back to flat) from empty list (rejected
+    // by validator with WKS-STG-008 before we ever get here).
+    statuses = statuses == null ? null : List.copyOf(statuses);
+  }
+
+  /**
+   * Backward-compat constructor for Story 3.1 callers (and tests) authored before Story 3.6
+   * introduced stage-scoped statuses. Defaults both new slots to "absent" — equivalent to a YAML
+   * stage with no {@code statuses:} or {@code initialStatus:} keys.
+   */
+  public StageDefinition(String id, String displayName, int ordinal) {
+    this(id, displayName, ordinal, null, Optional.empty());
+  }
+
+  /**
+   * Convenience: returns the stage-scoped status list as an {@link Optional}. {@link
+   * Optional#empty()} means "fall back to the flat case-type-level set" (per Story 3.6 AC2).
+   */
+  public Optional<List<StatusDefinition>> statusesOpt() {
+    return Optional.ofNullable(statuses);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/StatusDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/StatusDefinition.java
@@ -1,4 +1,26 @@
 package com.wkspower.platform.domain.config.model;
 
-/** One custom status declared by a case type. {@code color} is optional. */
-public record StatusDefinition(String id, String displayName, StatusColor color) {}
+/**
+ * One custom status declared by a case type. {@code color} is optional.
+ *
+ * <p>Story 3.6 AC1 — adds the {@code terminal} flag (deferred from Story 3.2; the slot did not
+ * exist when the canonical {@code [open, closed]} default was introduced). Semantics: {@code
+ * terminal=true} declares the status as a stage-scoped dead-end — same-stage transitions are
+ * blocked once a case enters this status. The flag is purely declarative here; consumer enforcement
+ * lives in {@code CaseService.transition} (Story 3.6 Task 5). Stage advance always bypasses the
+ * terminal guard — advancing replaces the status anyway.
+ *
+ * <p>Defaults: omitted in YAML ⇒ {@code false}. The Story 3.2 canonical default flips {@code
+ * closed.terminal = true}; {@code open.terminal = false} (see {@code
+ * ConfigValidator.DEFAULT_STATUSES}).
+ */
+public record StatusDefinition(String id, String displayName, StatusColor color, boolean terminal) {
+
+  /**
+   * Backward-compat constructor for callers (and tests) authored before Story 3.6 introduced the
+   * {@code terminal} slot. Defaults to {@code false} — matches the YAML-omitted shape.
+   */
+  public StatusDefinition(String id, String displayName, StatusColor color) {
+    this(id, displayName, color, false);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -216,6 +216,41 @@ public enum ErrorCode {
   /** advance / skipTo references an unknown caseId. HTTP 404. */
   WKS_STG_004("WKS-STG-004"),
 
+  // Story 3.6 — stage-scoped status set deploy-time + transition-time codes.
+  // Band: WKS-STG-005..011 consumed; -009 reserved for Story 3.7 / 3.8 mutate-class CRUD.
+  /** Duplicate status id within a stage's status set (Story 3.6 AC3). HTTP 422. */
+  WKS_STG_005("WKS-STG-005"),
+  /**
+   * Stage's {@code initialStatus:} references an id not present in the stage's status set (Story
+   * 3.6 AC3). HTTP 422.
+   */
+  WKS_STG_006("WKS-STG-006"),
+  /**
+   * Stage's {@code statuses: []} is empty (key declared but empty list — must be {@code >= 1} or
+   * omit the key entirely to fall back to the flat set per Story 3.6 AC2). HTTP 422.
+   */
+  WKS_STG_008("WKS-STG-008"),
+  /**
+   * RESERVED for Story 3.7 (live append) / Story 3.8 (mutate-class version-bump enforcement). Story
+   * 3.6 reserves the slot in the band; not emitted by any path in this story.
+   */
+  WKS_STG_009("WKS-STG-009"),
+  /**
+   * Story 3.6 AC6 — transition request targets a status id that is not declared on the case's
+   * current stage's status set. The Story 3.6 dev story originally suggested reusing {@code
+   * WKS-STG-002}; that code is wire-locked by Story 3.1 ("backward skip"), so a fresh code lands
+   * here per {@code feedback_error_codes_are_wire_contract.md}. HTTP 422.
+   */
+  WKS_STG_010("WKS-STG-010"),
+  /**
+   * Story 3.6 AC6 — transition rejected because the case's current status declares {@code terminal:
+   * true} on the active stage. Same-stage transitions are blocked; advance the stage to continue.
+   * The Story 3.6 dev story originally suggested reusing {@code WKS-STG-001}; that code is
+   * wire-locked by Story 3.1 ("advance/skip on completed/zero-stage case"). Fresh code per {@code
+   * feedback_error_codes_are_wire_contract.md}. HTTP 422.
+   */
+  WKS_STG_011("WKS-STG-011"),
+
   // 409 / 422 — CaseType Version Registry (Story 3.4 / Decision 20).
   // Band: WKS-VER-001..099 RESERVED for version-registry-related errors. Future stories (3.5
   // bootstrap, 3.8 blast-radius validator, 3.9 rebase tooling) draw from this band per

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -6,8 +6,10 @@ import com.wkspower.platform.domain.event.CaseCreated;
 import com.wkspower.platform.domain.event.CaseUpdated;
 import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.ErrorDetail;
+// Story 3.6 — ErrorCode + WksStageException used by transition guards (AC6).
 import com.wkspower.platform.domain.exception.WksConflictException;
 import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.exception.WksStageException;
 import com.wkspower.platform.domain.exception.WksValidationAggregateException;
 import com.wkspower.platform.domain.exception.WksVersionException;
 import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
@@ -218,6 +220,58 @@ public class CaseService {
         caseRepository
             .findById(caseId)
             .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
+    // Story 3.6 AC6 — stage-scoped status guards run BEFORE the engine-coupling null-check (Q5
+    // carry-forward note in the story file). Pure reads against the in-memory CaseTypeConfig — no
+    // engine call. Decision 19's unbranched-paths invariant: caseType.statusesFor(stageId)
+    // resolves stage-scoped or flat fallback in one place; this site does not branch on stage
+    // presence.
+    CaseTypeConfig caseType = requireCaseType(existing.caseTypeId());
+    String stageId = existing.currentStageId();
+    List<StatusDefinition> stageStatuses = caseType.statusesFor(stageId);
+    // Terminal-status block: if the case's current status is terminal in its stage, reject any
+    // same-stage transition (advance-stage bypasses this guard — it lives on a different
+    // service call). WKS-STG-011 is freshly allocated per Story 3.6 dev-notes anti-pattern #3
+    // (the original story plan's reuse of WKS-STG-001 violates the wire-contract memory).
+    StatusDefinition currentStatus =
+        stageStatuses.stream()
+            .filter(sd -> sd.id().equals(existing.status()))
+            .findFirst()
+            .orElse(null);
+    if (currentStatus != null && currentStatus.terminal()) {
+      throw new WksStageException(
+          ErrorCode.WKS_STG_011,
+          "Case "
+              + caseId
+              + " is in terminal status '"
+              + existing.status()
+              + "' on stage '"
+              + stageId
+              + "' — advance the stage to transition further");
+    }
+    // Foreign-stage status rejection: when the {@code action} names a status id that exists in
+    // the case-type-level set but is not declared on the current stage, reject before any engine
+    // call. Matches today's seed-time wire reality where {@code action} doubles as the target
+    // status id (e.g. j5-status-rainbow). When {@code action} doesn't resolve to any known status
+    // id at all, this guard is a no-op and the engine layer still owns "unknown message name"
+    // semantics. WKS-STG-010 freshly allocated per dev-notes anti-pattern #3.
+    boolean actionIsAStatusIdAnywhere =
+        caseType.statuses().stream().anyMatch(sd -> sd.id().equals(action))
+            || caseType.stages().stream()
+                .anyMatch(
+                    st ->
+                        st.statusesOpt()
+                            .map(list -> list.stream().anyMatch(sd -> sd.id().equals(action)))
+                            .orElse(false));
+    boolean actionIsOnCurrentStage = stageStatuses.stream().anyMatch(sd -> sd.id().equals(action));
+    if (actionIsAStatusIdAnywhere && !actionIsOnCurrentStage) {
+      throw new WksStageException(
+          ErrorCode.WKS_STG_010,
+          "Status '"
+              + action
+              + "' is not declared on stage '"
+              + stageId
+              + "' — foreign-stage status rejected");
+    }
     if (existing.processInstanceId() == null || existing.processInstanceId().isBlank()) {
       throw new WksWorkflowEngineException(
           "Case " + caseId + " has no associated process instance — cannot transition");

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 
@@ -209,10 +210,64 @@ public class ConfigValidator {
                   base + ".displayName"));
           continue;
         }
-        out.add(new StageDefinition(id, displayName, i));
+        // Story 3.6 AC2 / AC3 — stage-scoped status set + initialStatus resolution.
+        List<StatusDefinition> stageStatuses = checkStageStatuses(s.statuses(), base, eb, errors);
+        Optional<String> initialStatus =
+            resolveStageInitialStatus(s.initialStatus(), stageStatuses, base, eb, errors);
+        out.add(new StageDefinition(id, displayName, i, stageStatuses, initialStatus));
       }
     }
     return out;
+  }
+
+  /**
+   * Story 3.6 AC2 — resolve a stage's initial status. {@code explicit} non-blank: must match an id
+   * in the stage's {@code statuses:} list ({@code WKS-STG-006} otherwise). {@code explicit} blank
+   * or null: defaults to the first declared status's id. When the stage declares no {@code
+   * statuses:} at all, returns {@link Optional#empty()} — the flat fallback owns initial-status
+   * resolution.
+   */
+  private Optional<String> resolveStageInitialStatus(
+      String explicit,
+      List<StatusDefinition> stageStatuses,
+      String stageBase,
+      ErrorBuilder eb,
+      List<ErrorDetail> errors) {
+    if (stageStatuses == null || stageStatuses.isEmpty()) {
+      // null = key omitted (flat fallback). Empty = WKS-STG-008 already raised by
+      // checkStageStatuses.
+      // Either way no stage-scoped initialStatus to resolve.
+      if (explicit != null && !explicit.isBlank() && stageStatuses == null) {
+        // Edge case: initialStatus declared but statuses omitted — surfacing as WKS-STG-006 keeps
+        // the wire contract honest (the value cannot be checked because there is no list to check
+        // against).
+        errors.add(
+            eb.error(
+                ErrorCode.WKS_STG_006,
+                "Stage 'initialStatus: "
+                    + explicit
+                    + "' declared but stage has no 'statuses:' list to validate against",
+                stageBase + ".initialStatus"));
+      }
+      return Optional.empty();
+    }
+    if (explicit == null || explicit.isBlank()) {
+      // Default to first declared (per AC2: "stage B's `initialStatus` (or first declared if
+      // unspecified)").
+      return Optional.of(stageStatuses.get(0).id());
+    }
+    boolean present = stageStatuses.stream().anyMatch(sd -> sd.id().equals(explicit));
+    if (!present) {
+      errors.add(
+          eb.error(
+              ErrorCode.WKS_STG_006,
+              "Stage 'initialStatus: " + explicit + "' is not declared in this stage's status set",
+              stageBase + ".initialStatus"));
+      // Still return the explicit value — keeps the StageDefinition shape stable for downstream
+      // consumers; the validator already short-circuits the deploy via the accumulated errors.
+      return Optional.of(explicit);
+    }
+    return Optional.of(explicit);
   }
 
   /**
@@ -464,8 +519,11 @@ public class ConfigValidator {
    */
   private static final List<StatusDefinition> DEFAULT_STATUSES =
       List.of(
-          new StatusDefinition("open", "Open", StatusColor.BLUE),
-          new StatusDefinition("closed", "Closed", StatusColor.ZINC));
+          // Story 3.6 AC1 — closed.terminal flips to true (the slot did not exist when Story 3.2
+          // shipped the canonical default; this is the deferred-debt landing per
+          // project_status_definition_terminal_missing memory).
+          new StatusDefinition("open", "Open", StatusColor.BLUE, false),
+          new StatusDefinition("closed", "Closed", StatusColor.ZINC, true));
 
   private List<StatusDefinition> checkStatuses(
       List<RawCaseTypeConfig.RawStatus> raws, ErrorBuilder eb, List<ErrorDetail> errors) {
@@ -525,7 +583,89 @@ public class ConfigValidator {
         }
       }
       if (hasId && hasDn) {
-        out.add(new StatusDefinition(s.id(), s.displayName(), color));
+        // Story 3.6 AC1 — terminal flag carried through; null in YAML = false.
+        boolean terminal = Boolean.TRUE.equals(s.terminal());
+        out.add(new StatusDefinition(s.id(), s.displayName(), color, terminal));
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Story 3.6 AC2 / AC3 — validate one stage's {@code statuses:} sub-block. Returns {@code null}
+   * when the YAML key is omitted (resolver falls back to the flat case-type-level set per AC2).
+   * Empty list ({@code statuses: []}) is rejected with {@code WKS-STG-008}. Per-status checks emit
+   * {@code WKS-STG-005} (duplicate id) and {@code WKS-CFG-032} (id pattern violation — reused per
+   * Q2 default; wire-distinguishability handled by message). Other status-level rules (display name
+   * length, color enum) follow the flat-status path's WKS-CFG codes — not stage-scoped.
+   */
+  private List<StatusDefinition> checkStageStatuses(
+      List<RawCaseTypeConfig.RawStatus> raws,
+      String stageBase,
+      ErrorBuilder eb,
+      List<ErrorDetail> errors) {
+    if (raws == null) {
+      return null; // omitted key — flat fallback per AC2.
+    }
+    if (raws.isEmpty()) {
+      errors.add(
+          eb.error(
+              ErrorCode.WKS_STG_008,
+              "Stage statuses must declare at least 1 entry — omit the 'statuses:' key entirely"
+                  + " to fall back to the case-type-level status set",
+              stageBase + ".statuses"));
+      return List.of();
+    }
+    List<StatusDefinition> out = new ArrayList<>();
+    Set<String> seen = new HashSet<>();
+    for (int i = 0; i < raws.size(); i++) {
+      RawCaseTypeConfig.RawStatus s = raws.get(i);
+      String base = stageBase + ".statuses[" + i + "]";
+      if (s == null) {
+        errors.add(eb.error(ErrorCode.WKS_CFG_001, "Status entry is empty", base));
+        continue;
+      }
+      boolean hasId = checkRequiredString(base + ".id", s.id(), eb, errors);
+      boolean hasDn = checkRequiredString(base + ".displayName", s.displayName(), eb, errors);
+      if (hasId && !CaseTypeLimits.ID_PATTERN.matcher(s.id()).matches()) {
+        // Q2 default LOCKED — reuse WKS-CFG-032 for stage-scoped status id pattern violation;
+        // message disambiguates from the stage-id case. WKS-STG-007 is NOT introduced.
+        errors.add(
+            eb.error(
+                ErrorCode.WKS_CFG_032,
+                "Stage-scoped status id '" + s.id() + "' must match [a-z][a-z0-9-]{1,62}",
+                base + ".id"));
+      }
+      if (hasId && !seen.add(s.id())) {
+        errors.add(
+            eb.error(
+                ErrorCode.WKS_STG_005,
+                "Duplicate status id '" + s.id() + "' within stage status set",
+                base + ".id"));
+      }
+      if (hasDn && s.displayName().length() > CaseTypeLimits.MAX_DISPLAY_NAME_CHARS) {
+        errors.add(
+            eb.error(
+                ErrorCode.WKS_CFG_007,
+                "displayName must be ≤ " + CaseTypeLimits.MAX_DISPLAY_NAME_CHARS + " characters",
+                base + ".displayName"));
+      }
+      StatusColor color = null;
+      if (s.color() != null) {
+        var parsed = StatusColor.fromWire(s.color());
+        if (parsed.isEmpty()) {
+          errors.add(
+              eb.error(
+                  ErrorCode.WKS_CFG_008,
+                  "Unknown status color '" + s.color() + "'",
+                  base + ".color"));
+        } else {
+          color = parsed.get();
+        }
+      }
+      if (hasId && hasDn) {
+        boolean terminal = Boolean.TRUE.equals(s.terminal());
+        out.add(new StatusDefinition(s.id(), s.displayName(), color, terminal));
       }
     }
     return out;

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -85,8 +85,22 @@ public record RawCaseTypeConfig(
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawOption(String label, String value) {}
 
+  /**
+   * One {@code statuses[]} entry. Story 3.6 AC1 — adds {@code terminal} (boxed {@link Boolean};
+   * {@code null} means "key omitted in YAML" and is treated as {@code false} downstream).
+   */
   @JsonIgnoreProperties(ignoreUnknown = true)
-  public record RawStatus(String id, String displayName, String color) {}
+  public record RawStatus(String id, String displayName, String color, Boolean terminal) {
+
+    /**
+     * Backward-compat constructor — pre-Story 3.6 callers that didn't know about the {@code
+     * terminal} slot. Defaults {@code terminal} to {@code null} (loader treats absence as {@code
+     * false}).
+     */
+    public RawStatus(String id, String displayName, String color) {
+      this(id, displayName, color, null);
+    }
+  }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawRole(String name, List<String> permissions) {}
@@ -105,17 +119,30 @@ public record RawCaseTypeConfig(
    * form lands via {@link #fromObject} (PROPERTIES creator). Both produce the same record shape so
    * the validator can iterate uniformly.
    */
-  public record RawStage(String id, String displayName) {
+  public record RawStage(
+      String id, String displayName, List<RawStatus> statuses, String initialStatus) {
+
+    /**
+     * Backward-compat constructor — pre-Story 3.6 callers that didn't know about stage-scoped
+     * statuses. Defaults both new slots to {@code null} ("not declared in YAML"; resolver falls
+     * back to the flat case-type-level status set per Story 3.6 AC2).
+     */
+    public RawStage(String id, String displayName) {
+      this(id, displayName, null, null);
+    }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static RawStage fromString(String id) {
-      return new RawStage(id, null);
+      return new RawStage(id, null, null, null);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public static RawStage fromObject(
-        @JsonProperty("id") String id, @JsonProperty("displayName") String displayName) {
-      return new RawStage(id, displayName);
+        @JsonProperty("id") String id,
+        @JsonProperty("displayName") String displayName,
+        @JsonProperty("statuses") List<RawStatus> statuses,
+        @JsonProperty("initialStatus") String initialStatus) {
+      return new RawStage(id, displayName, statuses, initialStatus);
     }
   }
 

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
@@ -198,6 +198,162 @@ class CaseServiceTest {
         .isInstanceOf(WksValidationAggregateException.class);
   }
 
+  // ---- Story 3.6 AC6 — transition guards run BEFORE engine call ----
+
+  @Test
+  void transitionRejectsTerminalStatusWithWksStg011() {
+    var stage =
+        new StageDefinition(
+            "underwriting",
+            "Underwriting",
+            0,
+            List.of(
+                new StatusDefinition("pending", "Pending", StatusColor.AMBER, false),
+                new StatusDefinition("ready", "Ready", StatusColor.EMERALD, true)),
+            Optional.of("pending"));
+    var ct =
+        new CaseTypeConfig(
+            "ct-term",
+            "CT",
+            1,
+            null,
+            null,
+            List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, false)),
+            List.of(),
+            List.of(new RoleDefinition("officer", List.of(Permission.VIEW))),
+            List.of(stage));
+    UUID caseId = UUID.randomUUID();
+    Case existing =
+        new Case(
+            caseId,
+            "ct-term",
+            1,
+            "ready", // currently in terminal status
+            null,
+            Map.of(),
+            "pi-1",
+            FIXED,
+            ACTOR,
+            FIXED,
+            0L,
+            "underwriting",
+            0);
+    repo.saved.add(existing);
+    CaseService svc = svc(ct);
+    assertThatThrownBy(() -> svc.transition(caseId, "anything", Map.of(), ACTOR))
+        .isInstanceOf(com.wkspower.platform.domain.exception.WksStageException.class)
+        .matches(
+            t ->
+                ((com.wkspower.platform.domain.exception.WksStageException) t)
+                    .getCode()
+                    .equals("WKS-STG-011"))
+        .hasMessageContaining("terminal");
+  }
+
+  @Test
+  void transitionRejectsForeignStageStatusWithWksStg010() {
+    var stageA =
+        new StageDefinition(
+            "intake",
+            "Intake",
+            0,
+            List.of(new StatusDefinition("collecting", "Collecting", StatusColor.BLUE, false)),
+            Optional.of("collecting"));
+    var stageB =
+        new StageDefinition(
+            "decision",
+            "Decision",
+            1,
+            List.of(new StatusDefinition("approved", "Approved", StatusColor.EMERALD, true)),
+            Optional.of("approved"));
+    var ct =
+        new CaseTypeConfig(
+            "ct-foreign",
+            "CT",
+            1,
+            null,
+            null,
+            List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, false)),
+            List.of(),
+            List.of(new RoleDefinition("officer", List.of(Permission.VIEW))),
+            List.of(stageA, stageB));
+    UUID caseId = UUID.randomUUID();
+    Case existing =
+        new Case(
+            caseId,
+            "ct-foreign",
+            1,
+            "collecting",
+            null,
+            Map.of(),
+            "pi-1",
+            FIXED,
+            ACTOR,
+            FIXED,
+            0L,
+            "intake",
+            0);
+    repo.saved.add(existing);
+    CaseService svc = svc(ct);
+    assertThatThrownBy(() -> svc.transition(caseId, "approved", Map.of(), ACTOR))
+        .isInstanceOf(com.wkspower.platform.domain.exception.WksStageException.class)
+        .matches(
+            t ->
+                ((com.wkspower.platform.domain.exception.WksStageException) t)
+                    .getCode()
+                    .equals("WKS-STG-010"))
+        .hasMessageContaining("foreign-stage");
+  }
+
+  @Test
+  void transitionPassesThroughWhenActionIsNotKnownStatusId() {
+    // Ensures the foreign-stage guard does NOT fire for actions that are pure BPMN message names
+    // (no status id of that name anywhere on the case type). Engine-coupling check trips next
+    // (no processInstanceId on test case) — that's the existing Story 3.2 behaviour, unchanged.
+    var stage =
+        new StageDefinition(
+            "intake",
+            "Intake",
+            0,
+            List.of(new StatusDefinition("collecting", "Collecting", StatusColor.BLUE, false)),
+            Optional.of("collecting"));
+    var ct =
+        new CaseTypeConfig(
+            "ct-pass",
+            "CT",
+            1,
+            null,
+            null,
+            List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, false)),
+            List.of(),
+            List.of(new RoleDefinition("officer", List.of(Permission.VIEW))),
+            List.of(stage));
+    UUID caseId = UUID.randomUUID();
+    Case existing =
+        new Case(
+            caseId,
+            "ct-pass",
+            1,
+            "collecting",
+            null,
+            Map.of(),
+            null, // no engine — engine guard will fire
+            FIXED,
+            ACTOR,
+            FIXED,
+            0L,
+            "intake",
+            0);
+    repo.saved.add(existing);
+    CaseService svc = svc(ct);
+    assertThatThrownBy(() -> svc.transition(caseId, "submit-form", Map.of(), ACTOR))
+        .isInstanceOf(WksWorkflowEngineException.class)
+        .hasMessageContaining("no associated process instance");
+  }
+
   @Test
   void diffFieldIdsHandlesAddedRemovedAndChanged() {
     Map<String, Object> oldMap = Map.of("a", 1, "b", "two");

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
@@ -605,7 +605,202 @@ class ConfigValidatorTest {
     var statuses = result.config().get().statuses();
     assertThat(statuses).hasSize(2);
     assertThat(statuses.get(0).id()).isEqualTo("open");
+    assertThat(statuses.get(0).terminal()).isFalse();
     assertThat(statuses.get(1).id()).isEqualTo("closed");
+    // Story 3.6 AC1 — closed defaults to terminal:true (deferred from Story 3.2).
+    assertThat(statuses.get(1).terminal()).isTrue();
+  }
+
+  // ---- Story 3.6 — stage-scoped status sets (AC2, AC3, AC1) ----
+
+  @Test
+  void story36_stageScopedStatuses_parsesAndExposesTerminal() {
+    String yaml =
+        """
+        id: ct-stage-status
+        displayName: CT Stage Status
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+          - { id: closed, displayName: Closed, color: zinc }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view, create]
+        stages:
+          - id: underwriting
+            displayName: Underwriting
+            statuses:
+              - { id: pending-docs, displayName: Pending, color: amber }
+              - { id: in-review, displayName: In Review, color: blue }
+              - { id: ready-for-decision, displayName: Ready, color: emerald, terminal: true }
+            initialStatus: pending-docs
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).as("got %s", result.errors()).isFalse();
+    var stage = result.config().get().stage("underwriting").orElseThrow();
+    assertThat(stage.statusesOpt()).isPresent();
+    assertThat(stage.statusesOpt().get()).hasSize(3);
+    assertThat(stage.statusesOpt().get().get(2).terminal()).isTrue();
+    assertThat(stage.initialStatus()).contains("pending-docs");
+  }
+
+  @Test
+  void story36_stageScopedStatuses_initialStatusDefaultsToFirstDeclared() {
+    String yaml =
+        """
+        id: ct-init-default
+        displayName: CT Init
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+          - { id: closed, displayName: Closed, color: zinc }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view, create]
+        stages:
+          - id: intake
+            displayName: Intake
+            statuses:
+              - { id: collecting, displayName: Collecting, color: blue }
+              - { id: ready, displayName: Ready, color: emerald, terminal: true }
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).as("got %s", result.errors()).isFalse();
+    var stage = result.config().get().stage("intake").orElseThrow();
+    assertThat(stage.initialStatus()).contains("collecting");
+  }
+
+  @Test
+  void story36_stageOmittingStatuses_fallsBackToFlatSet() {
+    String yaml =
+        """
+        id: ct-flat-fallback
+        displayName: Flat
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+          - { id: closed, displayName: Closed, color: zinc }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        stages:
+          - id: only-stage
+            displayName: Only
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).as("got %s", result.errors()).isFalse();
+    var ct = result.config().get();
+    var stage = ct.stage("only-stage").orElseThrow();
+    assertThat(stage.statusesOpt()).isEmpty();
+    // Resolver returns flat fallback.
+    assertThat(ct.statusesFor("only-stage")).hasSize(2);
+    assertThat(ct.statusesFor("only-stage").get(0).id()).isEqualTo("open");
+  }
+
+  @Test
+  void story36_duplicateStatusIdInStage_emitsWksStg005() {
+    String yaml =
+        """
+        id: ct-dup
+        displayName: Dup
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+          - { id: closed, displayName: Closed, color: zinc }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        stages:
+          - id: stage-a
+            displayName: A
+            statuses:
+              - { id: dup, displayName: One, color: blue }
+              - { id: dup, displayName: Two, color: amber }
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).isTrue();
+    assertThat(result.errors().stream().anyMatch(e -> e.code().equals("WKS-STG-005"))).isTrue();
+  }
+
+  @Test
+  void story36_initialStatusMissingTarget_emitsWksStg006() {
+    String yaml =
+        """
+        id: ct-missing-init
+        displayName: Mi
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+          - { id: closed, displayName: Closed, color: zinc }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        stages:
+          - id: stage-a
+            displayName: A
+            statuses:
+              - { id: real, displayName: Real, color: blue }
+            initialStatus: ghost
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).isTrue();
+    assertThat(result.errors().stream().anyMatch(e -> e.code().equals("WKS-STG-006"))).isTrue();
+  }
+
+  @Test
+  void story36_emptyStageStatusesList_emitsWksStg008() {
+    String yaml =
+        """
+        id: ct-empty
+        displayName: E
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+          - { id: closed, displayName: Closed, color: zinc }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        stages:
+          - id: stage-a
+            displayName: A
+            statuses: []
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).isTrue();
+    assertThat(result.errors().stream().anyMatch(e -> e.code().equals("WKS-STG-008"))).isTrue();
+  }
+
+  @Test
+  void story36_stageScopedStatusIdPatternViolation_emitsWksCfg032Reused() {
+    // Q2 LOCKED — stage-scoped status id pattern violation reuses WKS-CFG-032; message
+    // disambiguates ("Stage-scoped status id"). WKS-STG-007 is NOT introduced.
+    String yaml =
+        """
+        id: ct-bad-id
+        displayName: Bad
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+          - { id: closed, displayName: Closed, color: zinc }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        stages:
+          - id: stage-a
+            displayName: A
+            statuses:
+              - { id: BAD_ID, displayName: Bad, color: blue }
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).isTrue();
+    assertThat(result.errors().stream().anyMatch(e -> e.code().equals("WKS-CFG-032"))).isTrue();
   }
 
   // ---- helpers ----


### PR DESCRIPTION
## Summary

- Lands stage-scoped status semantics (Decision 21): `StageDefinition.statuses` + `initialStatus` + `CaseTypeConfig.statusesFor(stageId)` resolver; flat fallback when stage omits the key (Decision 19's unbranched-paths invariant).
- **Adds the `StatusDefinition.terminal` flag** — closing the deferred slot from Story 3.2 and the `project_status_definition_terminal_missing` memory. The Story 3.2 canonical default flips: `closed.terminal = true`, `open.terminal = false`.
- New deploy-time codes `WKS-STG-005/-006/-008/-009 reserved`, new transition-time codes `WKS-STG-010` (foreign-stage status rejected) + `WKS-STG-011` (terminal block); `CaseService.transition` guards run **before** the engine-coupling check; `CaseDto.availableStatuses` + new `StatusView` DTO; J10 seed; `docs/concepts/status-sets.md` (structural stub); architecture + validator-table xrefs.

## StatusDefinition.terminal flag — confirmed

✅ The deferred slot from Story 3.2 is added in this PR (`StatusDefinition` record component with backward-compat constructor; `closed.terminal` flipped to `true` on the canonical default; `ConfigValidatorTest.story32_statusesOmitted_defaultsToOpenClosed` extended to assert the flag round-trip). The `project_status_definition_terminal_missing` memory is **closed by this PR**.

## Critical wire-code deviation from story plan

The original story plan's AC6 reused `WKS-STG-002` for "foreign-stage status rejected" and `WKS-STG-001` for "terminal block". **Both codes are wire-locked by Story 3.1** (`backward skip` and `advance/skip on completed/zero-stage`). Per `feedback_error_codes_are_wire_contract.md` (non-negotiable: never reuse a wire code for a different meaning), **fresh codes were allocated**:

- `WKS-STG-010` — foreign-stage status rejected
- `WKS-STG-011` — terminal block on transition

`docs/concepts/status-sets.md`, the architecture validation table, and the dev record reflect the actual codes.

## Q&A outcomes (from the story Open Questions block)

- **Q1 (3.4 ↔ 3.6 sequencing):** path (a) — 3.6 ships standalone. `status_options.version=1` is moot here since the table is deferred to 3.7.
- **Q2 (`WKS-STG-007` introduce or reuse `WKS-CFG-032`):** REUSE WKS-CFG-032 (LOCKED default) — message disambiguates.
- **Q3 (terminal block code):** REJECTED reuse of `WKS-STG-001`; fresh `WKS-STG-011` (see deviation above).
- **Q4 (admin path 404 code):** MOOT — admin CRUD deferred to 3.7.
- **Q5 (full doc or stub):** STUB (LOCKED default). Tech Writer Gate-2 polish flagged in the doc.
- **Q6 (hot-reload pickup of `status_options` writes):** MOOT — persistence deferred to 3.7.

## Scope deferred (with rationale)

- **AC4 — admin CRUD endpoints** → Story 3.7. Without persistence (AC5) the wire surface would be stub-only; the natural slot is alongside 3.7's live-append wiring.
- **AC5 — `status_options` table + JPA entity + adapter** → Story 3.7 (same rationale).
- **AC6 success path — status-reset on stage advance** → Story 4.4 per the explicit Q5 carry-forward note in the story file. The reset must update `cases.status` in the same transaction as `WksStageAdvancer.advance`, requiring a `CaseTypeReader` injection across the hexagonal boundary that 4.4 owns when reframing 2.4/2.9.
- **AC9 IT scenarios 6–9 (CRUD over HTTP), §11 (advance status-reset)** → deferred with the above. Schema-parse / validator / transition-guard / DTO scenarios (1–5, 10, 13–15) are covered by 7 new `ConfigValidatorTest` cases + 3 new `CaseServiceTest` cases.

## Architecture references

- Decision 21 — Status Set Runtime-Extensibility (stage-scoped). Footer paragraph added cross-referencing this story.
- Decision 19 — Stage as first-class primitive (unbranched-paths invariant). Honoured by `caseType.statusesFor(stageId)` single-call-site resolution.
- Decision 25 — zero-`tenant_id` invariant. No new file carries `tenant_id`; tenant-invariant lint passes.
- Decision 12 validation table extended with `WKS-STG-005/-006/-008/-009/-010/-011`.

## Test plan

Each AC verified — checklist:

- [x] **AC1** — `StatusDefinition.terminal` slot lands; `closed` default flips to `terminal: true`; `open` to `false`. `ConfigValidatorTest.story32_statusesOmitted_defaultsToOpenClosed` asserts both.
- [x] **AC2** — Stage-scoped statuses parse; `initialStatus` resolves to first declared when omitted; flat fallback when `statuses:` omitted; id-pattern shared with `StatusDefinition`/`StageDefinition` regex. 3 new `ConfigValidatorTest` cases.
- [x] **AC3** — `WKS-STG-005` (duplicate id), `WKS-STG-006` (missing initialStatus target), `WKS-STG-008` (empty list); `WKS-CFG-032` reused for stage-scoped pattern violation; `WKS-STG-009` reserved-and-not-emitted. 4 new `ConfigValidatorTest` cases (including pattern violation).
- [ ] **AC4** — Deferred to Story 3.7 (CRUD endpoints).
- [ ] **AC5** — Deferred to Story 3.7 (`status_options` persistence).
- [x] **AC6 (rejection paths)** — Foreign-stage `WKS-STG-010` + terminal-block `WKS-STG-011` guards run before engine-coupling check. 3 new `CaseServiceTest` cases.
- [ ] **AC6 (success path — advance status reset)** — Deferred to Story 4.4 (Q5 carry-forward).
- [x] **AC7** — Legacy flat-status CaseTypes preserved via runtime resolution; no YAML auto-rewrite. j7-stage-walk regression passes (366 backend tests + 66 ITs all green).
- [x] **AC8** — `CaseDto.availableStatuses` + `StatusView`; mapper resolves via `caseType.statusesFor(currentStageId)`; backward-compat 16-arg constructor preserves all existing call sites.
- [ ] **AC9** — Scenarios 1–5, 10, 13–15 covered by new unit tests; 6–9, 11 deferred with AC4/AC5/AC6-success.
- [x] **AC10** — `seed/j10-stage-scoped-statuses.yaml` (3-stage BFSI shape, terminal flags throughout); `seed.sh` + `JOURNEYS.md` updated; no `.bpmn` (per-seed bpmn-guard from Story 3.2).
- [x] **AC11** — `docs/concepts/status-sets.md` structural stub (Q5 LOCKED). Tech Writer Gate-2 polish flagged in doc front-matter.
- [x] **AC12** — Decision 21 footer one-line clarification. Decision 12 validation table extended.
- [x] **AC13** — Net-new codes only: `WKS_STG_005/-006/-008/-009/-010/-011`. `WKS-CFG-032` reused with disambiguating message. Zero existing wire codes reassigned.

## Local CI gauntlet (per `feedback_match_ci_locally.md`)

- [x] `./mvnw -B -ntp verify` from `backend/` — BUILD SUCCESS (365 unit + 66 IT, 0 failures, 0 errors). Spotless clean (264 files).
- [x] `./backend/.ci/check-tenant-invariant.sh` — "Tenant invariant (D25) OK".
- [x] Frontend `npm ci && npm run lint && npm run format:check && npm test && npm run build` — 68 test files / 251 tests pass; Prettier clean; ESLint clean; build emits 4 woff2 fonts (asserted).
- [x] `docker buildx build -f docker/Dockerfile .` — BUILD SUCCESS.
- [x] Operator-surface tenant scan (`deploy/clients/`) — clean.
- [ ] `shellcheck` — not installed locally; CI gate covers. No `deploy/wks-deploy.sh` change in this PR.
- [ ] `production-profile-smoke` — not run locally (requires booting full prod compose with explicit service list per Story 14.1 docs); CI gate. **No production-profile change in this PR**.

## Notes for reviewer

- The 3.4 ↔ 3.6 sequencing path-(a) note matters: when 3.7 lands the `status_options` table, version-binding integration with 3.4 happens on 3.7's surface (per Story 3.7's own Task list, when authored).
- `CaseDtoMapper`'s 16-arg backward-compat constructor on `CaseDto` is the surface-stability primitive for the 50+ tests that build `CaseDto` directly. New consumers should use the canonical 17-arg constructor.
- Anti-patterns from the dev notes were heeded: no `if (caseType.hasStages())` branching, no wire-code reassignment, no `tenant_id` introduction, no engine-routed status validation, no auto-rewrite of legacy YAML, no stage-scoped permission introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)