### PR TITLE
Story 4.3: BackendSignalRouter — single routing surface (WKS-MAP-404)

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/domain/config/ValidationResult.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/ValidationResult.java
@@ -1,6 +1,7 @@
 package com.wkspower.platform.domain.config;
 
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
 import com.wkspower.platform.domain.exception.ErrorDetail;
 import java.util.List;
 import java.util.Optional;
@@ -14,13 +15,24 @@ import java.util.Optional;
  * level but do not prevent the case-type from loading. Today only {@code WKS-CFG-013} (file field
  * marked {@code requiredOnCreate}) populates this list. Existing callers that read {@link
  * #errors()} see no behavior change.
+ *
+ * <p>Story 4.3 introduces {@link #mappingDefinition()} — the validated {@link MappingDefinition}
+ * produced by Story 4.2's {@code MappingValidator} when the YAML carries an {@code attachments:}
+ * block (or {@link MappingDefinition#empty()} when it does not). {@code ConfigService} threads this
+ * value into {@code MappingRegistry} after a successful registry write so the runtime router (Story
+ * 4.3) can resolve the active mapping by {@code (caseTypeId, version)}. The slot is optional —
+ * older callers and validation-failure paths continue to construct without it.
  */
 public record ValidationResult(
-    List<ErrorDetail> errors, List<ErrorDetail> warnings, Optional<CaseTypeConfig> config) {
+    List<ErrorDetail> errors,
+    List<ErrorDetail> warnings,
+    Optional<CaseTypeConfig> config,
+    Optional<MappingDefinition> mappingDefinition) {
 
   public ValidationResult {
     errors = List.copyOf(errors);
     warnings = warnings == null ? List.of() : List.copyOf(warnings);
+    mappingDefinition = mappingDefinition == null ? Optional.empty() : mappingDefinition;
     if (errors.isEmpty() == config.isEmpty()) {
       throw new IllegalStateException(
           "ValidationResult invariant: exactly one of errors-empty and config-present must hold "
@@ -32,16 +44,31 @@ public record ValidationResult(
     }
   }
 
+  /** Backward-compat 3-arg constructor — defaults {@link #mappingDefinition()} to empty. */
+  public ValidationResult(
+      List<ErrorDetail> errors, List<ErrorDetail> warnings, Optional<CaseTypeConfig> config) {
+    this(errors, warnings, config, Optional.empty());
+  }
+
   public static ValidationResult ok(CaseTypeConfig config) {
-    return new ValidationResult(List.of(), List.of(), Optional.of(config));
+    return new ValidationResult(List.of(), List.of(), Optional.of(config), Optional.empty());
   }
 
   public static ValidationResult ok(CaseTypeConfig config, List<ErrorDetail> warnings) {
-    return new ValidationResult(List.of(), warnings, Optional.of(config));
+    return new ValidationResult(List.of(), warnings, Optional.of(config), Optional.empty());
+  }
+
+  /**
+   * Story 4.3 — variant carrying the validated {@link MappingDefinition} for registry threading.
+   */
+  public static ValidationResult ok(
+      CaseTypeConfig config, List<ErrorDetail> warnings, MappingDefinition mappingDefinition) {
+    return new ValidationResult(
+        List.of(), warnings, Optional.of(config), Optional.ofNullable(mappingDefinition));
   }
 
   public static ValidationResult invalid(List<ErrorDetail> errors) {
-    return new ValidationResult(errors, List.of(), Optional.empty());
+    return new ValidationResult(errors, List.of(), Optional.empty(), Optional.empty());
   }
 
   public boolean isInvalid() {

--- a/backend/src/main/java/com/wkspower/platform/domain/event/BackendSignalRouted.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/BackendSignalRouted.java
@@ -1,0 +1,57 @@
+package com.wkspower.platform.domain.event;
+
+import com.wkspower.platform.domain.model.AuditSource;
+import com.wkspower.platform.domain.port.BackendSignalKind;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Story 4.3 AC5 / AC7 — domain event emitted by {@code BackendSignalRouter} for every {@code
+ * BackendSignal} it processes (success and miss alike). Carries the typed {@link AuditSource} —
+ * {@code source.toString()} renders to {@code "backend(<adapterName>)"} on success and {@code
+ * "backend(unmapped)"} on a {@code WKS-MAP-404} miss (FR8 source attribution).
+ *
+ * <p>Publication discipline: published via {@code EventPublisher.publishAfterCommit(...)} so audit
+ * observers see the post-commit state and never observe a phantom row. This is the audit-row seam
+ * AC7's IT asserts against; existing string-based {@code Stage.source} / {@code
+ * StageEntered.source} columns continue to carry the legacy {@code "backend-signal"} bare string
+ * (migration to typed {@link AuditSource} is folded into Story 4.4).
+ *
+ * @param caseId WKS case instance id the signal targeted
+ * @param caseTypeId stable CaseType id (e.g. {@code "loan-application"})
+ * @param caseTypeVersion pinned CaseType version string the signal resolved against (D20)
+ * @param kind the {@link BackendSignalKind} of the originating signal
+ * @param signalSource adapter-internal element id from {@code BackendSignal.source} (BPMN element
+ *     id, state-machine state name, etc.) for traceability
+ * @param source typed {@link AuditSource} — always an {@code AuditSource.Backend} carrying the
+ *     adapter name (or {@code "unmapped"} on a {@code WKS-MAP-404} miss)
+ * @param errorCode WKS error code wire string (e.g. {@code "WKS-MAP-404"}) on a miss; {@code null}
+ *     on a successful dispatch
+ * @param detail free-form key→value map (currently {@code originAdapter}, {@code reason}); may be
+ *     extended in future stories
+ * @param timestamp commit timestamp from {@code Clock.now}
+ */
+public record BackendSignalRouted(
+    UUID caseId,
+    String caseTypeId,
+    String caseTypeVersion,
+    BackendSignalKind kind,
+    String signalSource,
+    AuditSource source,
+    String errorCode,
+    Map<String, String> detail,
+    Instant timestamp) {
+
+  public BackendSignalRouted {
+    Objects.requireNonNull(caseId, "caseId");
+    Objects.requireNonNull(caseTypeId, "caseTypeId");
+    Objects.requireNonNull(caseTypeVersion, "caseTypeVersion");
+    Objects.requireNonNull(kind, "kind");
+    Objects.requireNonNull(signalSource, "signalSource");
+    Objects.requireNonNull(source, "source");
+    Objects.requireNonNull(timestamp, "timestamp");
+    detail = detail == null ? Map.of() : Map.copyOf(detail);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -199,6 +199,19 @@ public enum ErrorCode {
    * meaning.
    */
   WKS_MAP_007("WKS-MAP-007"),
+  /**
+   * Runtime — emitted by {@link com.wkspower.platform.domain.service.BackendSignalRouter} when an
+   * incoming {@link com.wkspower.platform.domain.port.BackendSignal} does not match any rule in the
+   * active {@link com.wkspower.platform.domain.config.model.MappingDefinition}, when the
+   * CaseInstance's pinned {@code (caseTypeId, version)} is missing from {@link
+   * com.wkspower.platform.domain.service.MappingRegistry}, or when a property emission attempts to
+   * drive a stage transition (Story 4.3 AC2 / AC4 / AC9). Distinct from deploy-time {@link
+   * #WKS_MAP_001}..{@link #WKS_MAP_006}; the {@code 404} number intentionally mirrors HTTP
+   * not-found semantics for "rule not found." Per {@code
+   * feedback_error_codes_are_wire_contract.md}: the wire string is stable; never reuse for any
+   * other meaning.
+   */
+  WKS_MAP_404("WKS-MAP-404"),
 
   // 409 / 422 / 404 — Stage lifecycle runtime errors (Story 3.1 AC9). Band: WKS-STG-001..099.
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/WksMappingMissException.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/WksMappingMissException.java
@@ -1,0 +1,37 @@
+package com.wkspower.platform.domain.exception;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Story 4.3 AC4 — runtime miss in {@code BackendSignalRouter}: an incoming {@code BackendSignal}
+ * did not resolve to any rule in the active {@code MappingDefinition} (or the CaseInstance's pinned
+ * {@code (caseTypeId, version)} is not registered, or a {@code USER_TASK_PROPERTY} signal attempted
+ * to drive a stage transition). Carries {@link ErrorCode#WKS_MAP_404}.
+ *
+ * <p>Distinct from deploy-time {@code WKS-MAP-001..006} (Story 4.2). The router catches this
+ * exception at its boundary, writes an audit row, and does NOT propagate to the adapter — see AC4.
+ *
+ * <p>Carries the originating adapter name and the case instance id explicitly so the audit row's
+ * {@code originAdapter} detail and the {@code caseInstance} reference can be filled without
+ * re-deriving from the signal.
+ */
+public class WksMappingMissException extends WksException {
+
+  private final String originAdapter;
+  private final UUID caseInstanceId;
+
+  public WksMappingMissException(String originAdapter, UUID caseInstanceId, String reason) {
+    super(ErrorCode.WKS_MAP_404, reason);
+    this.originAdapter = Objects.requireNonNull(originAdapter, "originAdapter");
+    this.caseInstanceId = Objects.requireNonNull(caseInstanceId, "caseInstanceId");
+  }
+
+  public String originAdapter() {
+    return originAdapter;
+  }
+
+  public UUID caseInstanceId() {
+    return caseInstanceId;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/model/AuditSource.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/AuditSource.java
@@ -1,0 +1,72 @@
+package com.wkspower.platform.domain.model;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Typed source attribution for stage / status / task transitions (Story 4.3 AC5; Decision 1's three
+ * canonical sources). The legacy bare-string vocabulary lived in {@link Stage#source()}, {@link
+ * com.wkspower.platform.domain.event.StageEntered#source()}, {@link
+ * com.wkspower.platform.domain.event.StageExited#source()} and friends — strings {@code
+ * "wks-auto-rule"}, {@code "manual"}, {@code "backend-signal"}.
+ *
+ * <p>Story 4.3 introduces this {@code sealed interface} for the new {@code BackendSignalRouter}
+ * code path only; the existing string slots stay unchanged. Migration of every call site to {@code
+ * AuditSource} is folded into Story 4.4 (the next story to touch the audit surface for backend
+ * signals) per {@code feedback_fold_debt_into_stories.md}.
+ *
+ * <p>{@link #toString()} is the bridge: it returns the bare wire string already used in the legacy
+ * {@code source} columns so a router-emitted audit event carrying an {@code AuditSource} can be
+ * compared to the existing {@code Stage.source} convention without drift. {@link AuditSourceTest}
+ * pins the three return values exactly.
+ *
+ * <p>One difference from the legacy vocabulary: {@link Backend} renders as {@code
+ * "backend(<adapterName>)"} (e.g. {@code "backend(bpmn)"}) — FR8 source attribution. The legacy
+ * bare string was {@code "backend-signal"} with no adapter identity baked in; Story 4.3 reframes
+ * this as the new contract per AC5. The legacy {@code "backend-signal"} string remains accepted by
+ * {@link com.wkspower.platform.domain.service.WksStageAdvancer#advance} so existing call sites do
+ * not break — that migration is part of 4.4.
+ *
+ * <p>The interface is {@code sealed} with three permitted records — adding a fourth source kind
+ * requires editing this file (reviewer-visible surface change), matching the rigour of {@code
+ * feedback_error_codes_are_wire_contract.md} for load-bearing wire shapes.
+ */
+public sealed interface AuditSource
+    permits AuditSource.User, AuditSource.AutoRule, AuditSource.Backend {
+
+  /** Manual user action — wire string {@code "manual"}. */
+  record User(UUID actorId) implements AuditSource {
+    public User {
+      Objects.requireNonNull(actorId, "actorId");
+    }
+
+    @Override
+    public String toString() {
+      return "manual";
+    }
+  }
+
+  /** WKS-internal auto-rule transition — wire string {@code "wks-auto-rule"}. */
+  record AutoRule(String ruleId) implements AuditSource {
+    public AutoRule {
+      Objects.requireNonNull(ruleId, "ruleId");
+    }
+
+    @Override
+    public String toString() {
+      return "wks-auto-rule";
+    }
+  }
+
+  /** Backend-driven transition — wire string {@code "backend(<adapterName>)"} (FR8). */
+  record Backend(String adapterName) implements AuditSource {
+    public Backend {
+      Objects.requireNonNull(adapterName, "adapterName");
+    }
+
+    @Override
+    public String toString() {
+      return "backend(" + adapterName + ")";
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/BackendSignalRouter.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/BackendSignalRouter.java
@@ -1,0 +1,280 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.config.model.AttachmentDefinition;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.EndEventMapping;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.SignalMapping;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import com.wkspower.platform.domain.event.BackendSignalRouted;
+import com.wkspower.platform.domain.exception.WksMappingMissException;
+import com.wkspower.platform.domain.model.AuditSource;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.port.BackendSignal;
+import com.wkspower.platform.domain.port.BackendSignalHandler;
+import com.wkspower.platform.domain.port.BackendSignalKind;
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.port.CaseStatusUpdater;
+import com.wkspower.platform.domain.port.CaseTypeRef;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Story 4.3 — single routing surface for every {@link BackendSignal} emitted by any {@code
+ * BackendAdapter} (Story 4.1). Architecture Decision 22 — the Mapping Layer is the only seam
+ * between WKS primitives and any execution backend; this router is the runtime half (Story 4.2's
+ * {@code MappingDefinition} is the deploy-time half).
+ *
+ * <p><b>Single-subscriber invariant (AC1, AC6):</b> production wiring registers exactly one {@link
+ * BackendSignalHandler} per adapter — this class. ArchUnit guardrail {@code
+ * BackendAdapterPortIsolationTest} enforces the rule at build time. Adding a second subscriber is a
+ * deliberate, reviewer-visible surface change.
+ *
+ * <p><b>No router-side reordering (AC2):</b> {@link BackendSignalKind}'s precedence ordering is a
+ * <b>mapping-author</b> guarantee — Story 4.2's validator emits {@code WKS-MAP-002} when two rules
+ * from different kinds target the same {@code (stage, status)} without explicit precedence. The
+ * router processes signals in the order the adapter emits them. Do <b>not</b> add a priority queue
+ * here.
+ *
+ * <p><b>Transaction model (AC8):</b> the router runs inside whatever transactional context the
+ * adapter provides (BPMN: engine transaction; in-memory state machine: adapter-defined). Stage and
+ * status mutations propagate exceptions to roll the engine state back together with the WKS write.
+ * Only {@link WksMappingMissException} is caught at the router boundary and converted to an
+ * audit-only event — every other exception is rethrown.
+ *
+ * <p><b>Audit attribution (AC5 / FR8):</b> every routed signal — success or miss — emits a {@link
+ * BackendSignalRouted} event via {@link EventPublisher#publishAfterCommit} carrying a typed {@link
+ * AuditSource.Backend} whose {@code toString()} renders to {@code "backend(<adapterName>)"}.
+ * Existing string-based {@code source} columns (Stage.source, StageEntered.source, etc.) keep their
+ * bare {@code "backend-signal"} value — migration is folded into Story 4.4 per {@code
+ * feedback_fold_debt_into_stories.md}.
+ *
+ * <p>Pure-Java, framework-free (NFR36) — wired as a {@code @Bean} from {@code
+ * infrastructure.config.BackendAdapterConfig}.
+ */
+public class BackendSignalRouter implements BackendSignalHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(BackendSignalRouter.class);
+
+  /** Terminal stage markers per AC2 — invoke case-level lifecycle (advance through last stage). */
+  private static final String COMPLETED = "completed";
+
+  private static final String SKIPPED = "skipped";
+
+  /** Legacy {@code source} string for {@link WksStageAdvancer} call sites — Decision 1. */
+  private static final String LEGACY_BACKEND_SOURCE = "backend-signal";
+
+  private final MappingRegistry mappingRegistry;
+  private final WksStageAdvancer stageAdvancer;
+  private final CaseStatusUpdater statusUpdater;
+  private final CaseRepository caseRepository;
+  private final EventPublisher eventPublisher;
+  private final Clock clock;
+
+  public BackendSignalRouter(
+      MappingRegistry mappingRegistry,
+      WksStageAdvancer stageAdvancer,
+      CaseStatusUpdater statusUpdater,
+      CaseRepository caseRepository,
+      EventPublisher eventPublisher,
+      Clock clock) {
+    this.mappingRegistry = Objects.requireNonNull(mappingRegistry, "mappingRegistry");
+    this.stageAdvancer = Objects.requireNonNull(stageAdvancer, "stageAdvancer");
+    this.statusUpdater = Objects.requireNonNull(statusUpdater, "statusUpdater");
+    this.caseRepository = Objects.requireNonNull(caseRepository, "caseRepository");
+    this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher");
+    this.clock = Objects.requireNonNull(clock, "clock");
+  }
+
+  @Override
+  public void onSignal(BackendSignal signal) {
+    Objects.requireNonNull(signal, "signal");
+    Optional<Case> caseOpt = caseRepository.findById(signal.caseInstance().id());
+    if (caseOpt.isEmpty()) {
+      // No case row to audit against — log structured warning only; the audit-row event requires
+      // a caseTypeId/version we do not have. This branch is defensive: the adapter should never
+      // emit a signal for a non-existent case in production, since the case lifecycle is the
+      // adapter's parent.
+      log.atWarn()
+          .addKeyValue("wksErrorCode", "WKS-MAP-404")
+          .addKeyValue("originAdapter", signal.adapterName())
+          .addKeyValue("caseId", signal.caseInstance().id().toString())
+          .log("backend signal targets unknown caseId — dropped");
+      return;
+    }
+    Case caseRow = caseOpt.get();
+
+    String caseTypeVersion = String.valueOf(caseRow.caseTypeVersion());
+    CaseTypeRef pinned = new CaseTypeRef(caseRow.caseTypeId(), caseTypeVersion);
+
+    Optional<MappingDefinition> mappingOpt = mappingRegistry.resolve(pinned, caseTypeVersion);
+    if (mappingOpt.isEmpty()) {
+      // AC9 — fail-loud, never fall back to "latest version" silently.
+      auditMiss(signal, caseRow, "caseTypeVersion not in registry");
+      return;
+    }
+
+    try {
+      switch (signal.kind()) {
+        case END_EVENT -> dispatchEndEvent(signal, caseRow, mappingOpt.get());
+        case NAMED_SIGNAL -> dispatchNamedSignal(signal, caseRow, mappingOpt.get());
+        case USER_TASK_PROPERTY -> dispatchUserTaskProperty(signal, caseRow, mappingOpt.get());
+        case OUTCOME ->
+            // Phase-1 reservation per AC2.
+            throw new WksMappingMissException(
+                signal.adapterName(), signal.caseInstance().id(), "outcome routing is Phase-1");
+      }
+      auditSuccess(signal, caseRow);
+    } catch (WksMappingMissException miss) {
+      auditMiss(signal, caseRow, miss.getMessage());
+      // AC4: caught at router boundary; do NOT propagate to the adapter.
+    }
+  }
+
+  // ---- per-kind dispatch -------------------------------------------------
+
+  private void dispatchEndEvent(BackendSignal signal, Case caseRow, MappingDefinition mapping) {
+    EndEventMapping rule =
+        firstAttachment(mapping)
+            .flatMap(AttachmentDefinition::endEventMapping)
+            .orElseThrow(
+                () ->
+                    new WksMappingMissException(
+                        signal.adapterName(),
+                        signal.caseInstance().id(),
+                        "no endEvent rule in mapping"));
+    applyStageTransition(signal, caseRow, rule.stageTransition());
+  }
+
+  private void dispatchNamedSignal(BackendSignal signal, Case caseRow, MappingDefinition mapping) {
+    SignalMapping rule =
+        firstAttachment(mapping)
+            .map(a -> a.signalMappings().get(signal.source()))
+            .orElseThrow(
+                () ->
+                    new WksMappingMissException(
+                        signal.adapterName(),
+                        signal.caseInstance().id(),
+                        "no signal rule for source '" + signal.source() + "'"));
+    if (rule == null) {
+      throw new WksMappingMissException(
+          signal.adapterName(),
+          signal.caseInstance().id(),
+          "no signal rule for source '" + signal.source() + "'");
+    }
+    applyStageTransition(signal, caseRow, rule.stageTransition());
+  }
+
+  private void dispatchUserTaskProperty(
+      BackendSignal signal, Case caseRow, MappingDefinition mapping) {
+    String onKey = "userTask:" + signal.source();
+    PropertyEmissionRule rule =
+        firstAttachment(mapping).stream()
+            .flatMap(a -> a.propertyEmissionRules().stream())
+            .filter(r -> onKey.equals(r.on()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new WksMappingMissException(
+                        signal.adapterName(),
+                        signal.caseInstance().id(),
+                        "no property rule for on='" + onKey + "'"));
+
+    // D22 clarification of Story 2.9 ambiguity — userTask property emission is restricted to
+    // status transitions within a stage. Only USER_TASK_PROPERTY emissions drive status writes;
+    // any rule whose emits is not USER_TASK_PROPERTY is treated as a stage transition attempt and
+    // rejected.
+    if (rule.emits() != BackendSignalKind.USER_TASK_PROPERTY) {
+      throw new WksMappingMissException(
+          signal.adapterName(),
+          signal.caseInstance().id(),
+          "userTaskProperty cannot drive stage transition");
+    }
+
+    Object value = signal.payload().get("value");
+    if (!(value instanceof String newStatus) || ((String) value).isBlank()) {
+      throw new WksMappingMissException(
+          signal.adapterName(),
+          signal.caseInstance().id(),
+          "userTask property emission missing scalar 'value' in payload");
+    }
+    statusUpdater.updateStatus(caseRow.id(), newStatus);
+  }
+
+  // ---- helpers -----------------------------------------------------------
+
+  /**
+   * Phase-0 simplification — a CaseType has at most one attachment by AC of Story 4.2 ({@code
+   * WKS-MAP-006} forbids duplicate scopes). Multi-attachment routing (per-stage attachments) lands
+   * with Story 4.5; today the router consults the single declared attachment.
+   */
+  private static Optional<AttachmentDefinition> firstAttachment(MappingDefinition mapping) {
+    return mapping.attachments().isEmpty()
+        ? Optional.empty()
+        : Optional.of(mapping.attachments().get(0));
+  }
+
+  private void applyStageTransition(BackendSignal signal, Case caseRow, String spec) {
+    String[] parts = spec.split("\\s*->\\s*");
+    if (parts.length != 2 || parts[1].isBlank()) {
+      throw new WksMappingMissException(
+          signal.adapterName(),
+          signal.caseInstance().id(),
+          "malformed stageTransition '" + spec + "'");
+    }
+    String to = parts[1].trim();
+    String sourceRef = signal.adapterName() + ":" + signal.source();
+    if (COMPLETED.equals(to) || SKIPPED.equals(to)) {
+      // AC2 — case-level lifecycle: advance through last stage.
+      stageAdvancer.advance(caseRow.id(), LEGACY_BACKEND_SOURCE, sourceRef);
+      return;
+    }
+    // skipTo handles forward-by-one as equivalent to advance (Story 3.1 AC6).
+    stageAdvancer.skipTo(caseRow.id(), to, LEGACY_BACKEND_SOURCE, sourceRef);
+  }
+
+  private void auditSuccess(BackendSignal signal, Case caseRow) {
+    publish(signal, caseRow, new AuditSource.Backend(signal.adapterName()), null, Map.of());
+  }
+
+  private void auditMiss(BackendSignal signal, Case caseRow, String reason) {
+    Map<String, String> detail = new HashMap<>();
+    detail.put("originAdapter", signal.adapterName());
+    if (reason != null) {
+      detail.put("reason", reason);
+    }
+    log.atWarn()
+        .addKeyValue("wksErrorCode", "WKS-MAP-404")
+        .addKeyValue("originAdapter", signal.adapterName())
+        .addKeyValue("caseId", signal.caseInstance().id().toString())
+        .addKeyValue("kind", signal.kind().name())
+        .addKeyValue("signalSource", signal.source())
+        .log("backend signal unmapped: {}", reason);
+    publish(signal, caseRow, new AuditSource.Backend("unmapped"), "WKS-MAP-404", detail);
+  }
+
+  private void publish(
+      BackendSignal signal,
+      Case caseRow,
+      AuditSource source,
+      String errorCode,
+      Map<String, String> detail) {
+    String caseTypeVersion = String.valueOf(caseRow.caseTypeVersion());
+    eventPublisher.publishAfterCommit(
+        new BackendSignalRouted(
+            caseRow.id(),
+            caseRow.caseTypeId(),
+            caseTypeVersion,
+            signal.kind(),
+            signal.source(),
+            source,
+            errorCode,
+            detail,
+            clock.now()));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
@@ -5,10 +5,12 @@ import com.wkspower.platform.domain.config.DeployResult;
 import com.wkspower.platform.domain.config.RegistrationResult;
 import com.wkspower.platform.domain.config.ValidationResult;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
 import com.wkspower.platform.domain.event.ConfigDeployed;
 import com.wkspower.platform.domain.exception.ErrorDetail;
 import com.wkspower.platform.domain.port.BpmnValidationService;
 import com.wkspower.platform.domain.port.CaseTypeReader;
+import com.wkspower.platform.domain.port.CaseTypeRef;
 import com.wkspower.platform.domain.port.CaseTypeRegistrar;
 import com.wkspower.platform.domain.port.CaseTypeSource;
 import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
@@ -47,6 +49,7 @@ public class ConfigService {
   private final BpmnValidationService bpmnValidator;
   private final WorkflowEngine workflowEngine;
   private final EventPublisher eventPublisher;
+  private final MappingRegistry mappingRegistry;
 
   /**
    * Story 3.4 / Decision 20 — every successful YAML validate flows through {@link
@@ -71,7 +74,8 @@ public class ConfigService {
       BpmnValidationService bpmnValidator,
       WorkflowEngine workflowEngine,
       EventPublisher eventPublisher,
-      CaseTypeVersionRegistry versionRegistry) {
+      CaseTypeVersionRegistry versionRegistry,
+      MappingRegistry mappingRegistry) {
     this.source = source;
     this.registrar = registrar;
     this.reader = reader;
@@ -79,6 +83,7 @@ public class ConfigService {
     this.workflowEngine = workflowEngine;
     this.eventPublisher = eventPublisher;
     this.versionRegistry = versionRegistry;
+    this.mappingRegistry = mappingRegistry;
   }
 
   /**
@@ -110,7 +115,9 @@ public class ConfigService {
     if (reg.outcome() == RegistrationResult.Outcome.REJECTED_OLDER_VERSION) {
       return ValidationResult.invalid(reg.errors());
     }
-    return ValidationResult.ok(versioned, result.warnings());
+    ValidationResult versionedResult = ValidationResult.ok(versioned, result.warnings());
+    publishMappingToRegistry(versionedResult);
+    return versionedResult;
   }
 
   /** Byte-driven YAML-only variant. Retained for the startup loader's BPMN-missing path. */
@@ -136,7 +143,28 @@ public class ConfigService {
     }
     // Carry the version-overridden config back to callers (startup loader, admin endpoint) so the
     // ConfigDeployed event and any post-validate logging see the registry-authoritative version.
-    return ValidationResult.ok(versioned, result.warnings());
+    // Story 4.3 — publishMappingToRegistry runs against the same versioned result so the
+    // (caseTypeId, version) key in MappingRegistry matches what the in-memory CaseTypeRegistry
+    // advertises.
+    ValidationResult versionedResult = ValidationResult.ok(versioned, result.warnings());
+    publishMappingToRegistry(versionedResult);
+    return versionedResult;
+  }
+
+  /**
+   * Story 4.3 AC9 — populate {@link MappingRegistry} keyed by {@code (caseTypeId, version)} after a
+   * successful CaseType registration. Empty {@link MappingDefinition} is registered for every
+   * zero-attachment CaseType (D22, first-class). When the registry was not provided (legacy
+   * constructor) the call short-circuits — the router's {@code WKS-MAP-404} path covers the case.
+   */
+  private void publishMappingToRegistry(ValidationResult result) {
+    if (mappingRegistry == null || result.config().isEmpty()) {
+      return;
+    }
+    CaseTypeConfig config = result.config().get();
+    MappingDefinition definition = result.mappingDefinition().orElse(MappingDefinition.empty());
+    String version = String.valueOf(config.version());
+    mappingRegistry.register(new CaseTypeRef(config.id(), version), version, definition);
   }
 
   /**
@@ -182,6 +210,7 @@ public class ConfigService {
       if (reg.outcome() == RegistrationResult.Outcome.REJECTED_OLDER_VERSION) {
         return DeployResult.invalid(reg.errors());
       }
+      publishMappingToRegistry(yamlResult);
 
       try {
         deployment =

--- a/backend/src/main/java/com/wkspower/platform/domain/service/MappingRegistry.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/MappingRegistry.java
@@ -1,0 +1,76 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import com.wkspower.platform.domain.port.CaseTypeRef;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Story 4.3 AC3 — runtime-side index from {@code (caseTypeId, version)} to the validated {@link
+ * MappingDefinition} produced at deploy time by Story 4.2's {@code MappingValidator}. Pure-Java —
+ * no Spring annotations on the class itself; wired as a singleton {@code @Bean} from {@code
+ * infrastructure.config.BackendAdapterConfig} (NFR36 — domain has zero framework imports).
+ *
+ * <p>Backed by a {@link ConcurrentHashMap} for read-heavy concurrent access (mirrors {@link
+ * BackendAdapterBinder}'s pattern). Reads never block; the single-writer {@code register} / {@code
+ * unregister} swap is atomic at the key.
+ *
+ * <p>{@link MappingDefinition#empty()} is a legal value — registered for every CaseType version
+ * whose YAML omits {@code attachments:} or declares {@code attachments: []}. Architecture D22 +
+ * D19's "stage-less paths must remain unbranched" — the router treats empty mapping identically to
+ * "no rule matches", surfacing {@code WKS-MAP-404} on any signal arrival.
+ *
+ * <p><b>Frozen-on-version pin (D20):</b> the lookup key is {@code (caseTypeId, version)}; the
+ * router uses the CaseInstance's pinned version, never the latest deployed version. Hot-reload (D3)
+ * re-runs {@link #register} for the new version while in-flight cases continue resolving against
+ * their pinned older version.
+ */
+public class MappingRegistry {
+
+  private final ConcurrentMap<MappingKey, MappingDefinition> byKey = new ConcurrentHashMap<>();
+
+  /**
+   * Register {@code definition} as the active mapping for {@code (caseType.caseTypeId(), version)}.
+   * The {@code version} parameter is treated as opaque (D20) — same semantics as {@link
+   * CaseTypeRef#version()}.
+   *
+   * <p>Same-key replacement is allowed (hot-reload) — the most recent registration wins.
+   */
+  public void register(CaseTypeRef caseType, String version, MappingDefinition definition) {
+    Objects.requireNonNull(caseType, "caseType");
+    Objects.requireNonNull(version, "version");
+    Objects.requireNonNull(definition, "definition");
+    byKey.put(new MappingKey(caseType.caseTypeId(), version), definition);
+  }
+
+  /**
+   * Drop the registered mapping for {@code (caseType.caseTypeId(), version)}. Idempotent on unknown
+   * / already-removed keys.
+   */
+  public void unregister(CaseTypeRef caseType, String version) {
+    Objects.requireNonNull(caseType, "caseType");
+    Objects.requireNonNull(version, "version");
+    byKey.remove(new MappingKey(caseType.caseTypeId(), version));
+  }
+
+  /**
+   * Resolve the {@link MappingDefinition} bound to {@code (caseType.caseTypeId(), version)}. Empty
+   * when the key was never registered — the router translates that into {@code WKS-MAP-404} with
+   * detail {@code caseTypeVersion not in registry}.
+   */
+  public Optional<MappingDefinition> resolve(CaseTypeRef caseType, String version) {
+    Objects.requireNonNull(caseType, "caseType");
+    Objects.requireNonNull(version, "version");
+    return Optional.ofNullable(byKey.get(new MappingKey(caseType.caseTypeId(), version)));
+  }
+
+  /** Composite lookup key — kept private since callers only see the {@link CaseTypeRef} surface. */
+  private record MappingKey(String caseTypeId, String version) {
+    private MappingKey {
+      Objects.requireNonNull(caseTypeId, "caseTypeId");
+      Objects.requireNonNull(version, "version");
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/package-info.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/package-info.java
@@ -1,2 +1,12 @@
-/** Domain services — business rules coordinated via ports. */
+/**
+ * Domain services — business rules coordinated via ports.
+ *
+ * <p>Story 4.3 (Decision 22 — Mapping Layer): {@link
+ * com.wkspower.platform.domain.service.BackendSignalRouter} is the single runtime routing surface
+ * for every {@link com.wkspower.platform.domain.port.BackendSignal} emitted by any {@link
+ * com.wkspower.platform.domain.port.BackendAdapter}. {@link
+ * com.wkspower.platform.domain.service.MappingRegistry} indexes validated {@link
+ * com.wkspower.platform.domain.config.model.MappingDefinition} values by {@code (caseTypeId,
+ * version)} for D20 frozen-on-version routing.
+ */
 package com.wkspower.platform.domain.service;

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/BackendAdapterConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/BackendAdapterConfig.java
@@ -1,7 +1,14 @@
 package com.wkspower.platform.infrastructure.config;
 
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.port.CaseStatusUpdater;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
 import com.wkspower.platform.domain.service.BackendAdapterBinder;
+import com.wkspower.platform.domain.service.BackendSignalRouter;
+import com.wkspower.platform.domain.service.MappingRegistry;
 import com.wkspower.platform.domain.service.NullAdapter;
+import com.wkspower.platform.domain.service.WksStageAdvancer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,9 +17,11 @@ import org.springframework.context.annotation.Configuration;
  * {@code domain/service}, framework-free per NFR36) as Spring singletons so future call sites
  * (Story 4.4 / 4.5) can inject {@code BackendAdapterBinder}.
  *
- * <p>This config has zero call sites in Story 4.1 — it exists so the beans are present on the
- * application context and so Story 4.4 can refactor call sites without re-wiring. The
- * infrastructure boundary is the correct home: {@code domain/} stays Spring-free.
+ * <p>Story 4.3 — extends with two new beans: {@link MappingRegistry} (runtime index from {@code
+ * (caseTypeId, version)} → {@code MappingDefinition}, populated at deploy time by {@code
+ * ConfigService}) and {@link BackendSignalRouter} (single subscriber for every {@code
+ * BackendAdapter.onBackendSignal} surface). Both stay framework-free; this config is the only
+ * Spring boundary.
  */
 @Configuration
 public class BackendAdapterConfig {
@@ -25,5 +34,32 @@ public class BackendAdapterConfig {
   @Bean
   public BackendAdapterBinder backendAdapterBinder(NullAdapter nullAdapter) {
     return new BackendAdapterBinder(nullAdapter);
+  }
+
+  /**
+   * Story 4.3 AC3 — singleton runtime registry of validated {@code MappingDefinition}s, populated
+   * by {@code ConfigService} after every successful CaseType registration.
+   */
+  @Bean
+  public MappingRegistry mappingRegistry() {
+    return new MappingRegistry();
+  }
+
+  /**
+   * Story 4.3 AC1 — single routing surface for every {@code BackendSignal}. Domain-side dependency
+   * on {@link WksStageAdvancer} (Story 3.1), {@link CaseStatusUpdater} (Story 2.4), {@link
+   * CaseRepository}, {@link EventPublisher}, and {@link Clock} — all already wired by other
+   * infrastructure configs.
+   */
+  @Bean
+  public BackendSignalRouter backendSignalRouter(
+      MappingRegistry mappingRegistry,
+      WksStageAdvancer stageAdvancer,
+      CaseStatusUpdater statusUpdater,
+      CaseRepository caseRepository,
+      EventPublisher eventPublisher,
+      Clock clock) {
+    return new BackendSignalRouter(
+        mappingRegistry, stageAdvancer, statusUpdater, caseRepository, eventPublisher, clock);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
@@ -14,6 +14,7 @@ import com.wkspower.platform.domain.port.StageRepository;
 import com.wkspower.platform.domain.port.WorkflowEngine;
 import com.wkspower.platform.domain.service.CaseService;
 import com.wkspower.platform.domain.service.ConfigService;
+import com.wkspower.platform.domain.service.MappingRegistry;
 import com.wkspower.platform.domain.service.TaskService;
 import com.wkspower.platform.domain.service.WksStageAdvancer;
 import org.springframework.context.annotation.Bean;
@@ -34,9 +35,17 @@ public class ConfigServiceConfig {
       BpmnValidationService bpmnValidator,
       WorkflowEngine workflowEngine,
       EventPublisher eventPublisher,
-      CaseTypeVersionRegistry versionRegistry) {
+      CaseTypeVersionRegistry versionRegistry,
+      MappingRegistry mappingRegistry) {
     return new ConfigService(
-        source, registrar, reader, bpmnValidator, workflowEngine, eventPublisher, versionRegistry);
+        source,
+        registrar,
+        reader,
+        bpmnValidator,
+        workflowEngine,
+        eventPublisher,
+        versionRegistry,
+        mappingRegistry);
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -126,6 +126,8 @@ public class ConfigValidator {
     // Story 4.2 AC5 — Mapping Layer validation runs after stage validation, with the stage id set
     // already known. The validator is collect-all; its findings merge into {@code errors} so a
     // single ValidationResult surfaces both stage and mapping failures (no parallel call site).
+    com.wkspower.platform.domain.config.model.MappingDefinition mappingDefinition =
+        com.wkspower.platform.domain.config.model.MappingDefinition.empty();
     if (mappingValidator != null) {
       Set<String> stageIds = new HashSet<>();
       for (StageDefinition sd : stages) {
@@ -133,6 +135,7 @@ public class ConfigValidator {
       }
       MappingValidator.Result mappingResult = mappingValidator.validate(raw, stageIds, bpmnFiles);
       errors.addAll(mappingResult.errors());
+      mappingDefinition = mappingResult.definition();
     }
 
     if (!errors.isEmpty()) {
@@ -151,7 +154,11 @@ public class ConfigValidator {
             listColumns,
             roles,
             stages);
-    return ValidationResult.ok(config, warnings);
+    // Story 4.3 — surface the validated MappingDefinition through ValidationResult so
+    // ConfigService can populate MappingRegistry on registration. Empty MappingDefinition is the
+    // first-class zero-attachment value (D22 — Story 4.2's MappingValidator returns empty()
+    // unconditionally when no attachments block is present).
+    return ValidationResult.ok(config, warnings, mappingDefinition);
   }
 
   /**

--- a/backend/src/test/java/com/wkspower/platform/architecture/BackendAdapterPortIsolationTest.java
+++ b/backend/src/test/java/com/wkspower/platform/architecture/BackendAdapterPortIsolationTest.java
@@ -44,6 +44,34 @@ class BackendAdapterPortIsolationTest {
   }
 
   @Test
+  void onBackendSignalIsCalledFromRouterAndBinderOnly() {
+    // Story 4.3 AC6 — single-routing-surface invariant. The router is the only
+    // BackendSignalHandler that may subscribe to BackendAdapter.onBackendSignal in production.
+    // ArchUnit's method-call-level guardrail makes this load-bearing: a future "logging
+    // listener" or "metrics listener" would silently break the single-subscriber guarantee, but
+    // adding the call site without editing this test fails the build.
+    noClasses()
+        .that()
+        .resideInAPackage("com.wkspower.platform..")
+        .and()
+        .doNotHaveFullyQualifiedName("com.wkspower.platform.domain.service.BackendSignalRouter")
+        .and()
+        .doNotHaveFullyQualifiedName("com.wkspower.platform.domain.service.BackendAdapterBinder")
+        .should()
+        .callMethod(
+            com.wkspower.platform.domain.port.BackendAdapter.class,
+            "onBackendSignal",
+            com.wkspower.platform.domain.port.BackendSignalHandler.class)
+        .because(
+            "Story 4.3 AC6: BackendSignalRouter is the only legitimate subscriber to "
+                + "BackendAdapter.onBackendSignal in production wiring. The binder mediates "
+                + "adapter resolution; nothing else may call this method. A second subscriber "
+                + "would silently break the single-routing-surface guarantee — adding one "
+                + "requires a deliberate edit of this test, surfacing the change to reviewers.")
+        .check(CLASSES);
+  }
+
+  @Test
   void nullAdapterAndBinderHaveNoEngineImports() {
     // NullAdapter and BackendAdapterBinder live in domain.service alongside CaseService etc., so
     // we cannot use a package-wide rule. Pin by simple name — these two classes ship with the

--- a/backend/src/test/java/com/wkspower/platform/domain/model/AuditSourceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/model/AuditSourceTest.java
@@ -1,0 +1,55 @@
+package com.wkspower.platform.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 4.3 AC5 — pin {@link AuditSource}'s {@link Object#toString()} renderings exactly to the
+ * bare strings already used in {@link Stage#source()} and the {@code StageEntered}/{@code
+ * StageExited} domain events ({@code "wks-auto-rule"}, {@code "manual"}, {@code "backend-signal"} /
+ * FR8 {@code "backend(<adapter>)"}). Drift here would silently desync the new router code path from
+ * the legacy string slots that Story 4.4 must keep aligning until the migration completes.
+ */
+class AuditSourceTest {
+
+  @Test
+  void userTypeRendersAsManual() {
+    AuditSource source = new AuditSource.User(UUID.randomUUID());
+
+    assertThat(source.toString()).isEqualTo("manual");
+  }
+
+  @Test
+  void autoRuleTypeRendersAsWksAutoRule() {
+    AuditSource source = new AuditSource.AutoRule("auto-1");
+
+    assertThat(source.toString()).isEqualTo("wks-auto-rule");
+  }
+
+  @Test
+  void backendTypeRendersAsBackendOfAdapterName() {
+    AuditSource source = new AuditSource.Backend("bpmn");
+
+    assertThat(source.toString()).isEqualTo("backend(bpmn)");
+  }
+
+  @Test
+  void backendUnmappedAdapterRendersExactly() {
+    // The router uses adapterName "unmapped" when no rule matches — pin that exact wire string.
+    AuditSource source = new AuditSource.Backend("unmapped");
+
+    assertThat(source.toString()).isEqualTo("backend(unmapped)");
+  }
+
+  @Test
+  void nullArgumentsAreRejected() {
+    assertThatThrownBy(() -> new AuditSource.User(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new AuditSource.AutoRule(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new AuditSource.Backend(null))
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/service/BackendSignalRouterIT.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/BackendSignalRouterIT.java
@@ -1,0 +1,602 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.model.AttachmentDefinition;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.EndEventMapping;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.SignalMapping;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.event.BackendSignalRouted;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.port.AttachmentScope;
+import com.wkspower.platform.domain.port.BackendSignal;
+import com.wkspower.platform.domain.port.BackendSignalKind;
+import com.wkspower.platform.domain.port.BackendSignalSubscription;
+import com.wkspower.platform.domain.port.CaseInstanceRef;
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.port.CaseStatusUpdater;
+import com.wkspower.platform.domain.port.CaseTypeRef;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.FakeRecordingAdapter;
+import com.wkspower.platform.domain.port.StageRepository;
+import com.wkspower.platform.infrastructure.persistence.RouterItPersistenceImports;
+import com.wkspower.platform.infrastructure.persistence.entity.RoleEntity;
+import com.wkspower.platform.infrastructure.persistence.entity.UserEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.RoleEntityRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.UserEntityRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Story 4.3 AC7 / AC8 — end-to-end IT for {@link BackendSignalRouter} using {@link
+ * FakeRecordingAdapter} (Story 4.1 fixture). Boots a Spring slice with the real router, registry,
+ * advancer, status updater, and case repository — no CIB seven dependency. Covers the headline
+ * routing matrix plus transaction-rollback semantics.
+ *
+ * <p>Postgres-IT parity is deferred per {@code project_postgres_it_parity_gap.md} — H2-only here
+ * matches Stories 3.1 / 3.2 precedent.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({BackendSignalRouterIT.RouterTestConfig.class, RouterItPersistenceImports.class})
+@ActiveProfiles("dev")
+@Transactional
+class BackendSignalRouterIT {
+
+  private static final Instant NOW = Instant.parse("2026-05-05T12:00:00Z");
+  private static final List<StageDefinition> STAGES =
+      List.of(
+          new StageDefinition("stage1", "Stage 1", 0),
+          new StageDefinition("stage2", "Stage 2", 1),
+          new StageDefinition("stage3", "Stage 3", 2));
+  private static final String ADAPTER_NAME = "fake";
+
+  @Autowired BackendSignalRouter router;
+  @Autowired MappingRegistry mappingRegistry;
+  @Autowired BackendAdapterBinder binder;
+  @Autowired CaseRepository caseRepository;
+  @Autowired StageRepository stageRepository;
+  @Autowired CaseStatusUpdater statusUpdater;
+  @Autowired RecordingEventPublisher events;
+  @Autowired UserEntityRepository userRepo;
+  @Autowired RoleEntityRepository roleRepo;
+  @Autowired EntityManager em;
+
+  private UUID actorId;
+  private FakeRecordingAdapter fake;
+  private BackendSignalSubscription subscription;
+
+  @BeforeEach
+  void seedActorAndAdapter() {
+    RoleEntity role =
+        roleRepo
+            .findByName("admin")
+            .orElseGet(
+                () ->
+                    roleRepo.save(
+                        new RoleEntity(UUID.randomUUID(), "admin", Instant.now(), Instant.now())));
+    UserEntity u =
+        userRepo.save(
+            new UserEntity(
+                UUID.randomUUID(),
+                "router-it-" + UUID.randomUUID() + "@x",
+                "x",
+                true,
+                Instant.now(),
+                Instant.now(),
+                new HashSet<>(List.of(role))));
+    actorId = u.getId();
+
+    fake = new FakeRecordingAdapter(binder);
+    subscription = fake.onBackendSignal(router::onSignal);
+    events.clear();
+  }
+
+  // ---------- AC7 §1 — END_EVENT happy path ------------------------------
+
+  @Test
+  void endEventAdvancesActiveStage() {
+    Case caseRow = newBootstrappedCase("loan-end", 1);
+    CaseTypeRef caseType = new CaseTypeRef(caseRow.caseTypeId(), "1");
+    fake.attach(caseType, AttachmentScope.ofCase());
+    mappingRegistry.register(
+        caseType,
+        "1",
+        defWith(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.of(new EndEventMapping("stage1 -> stage2")),
+                Map.of(),
+                List.of())));
+
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.END_EVENT,
+            ADAPTER_NAME,
+            new CaseInstanceRef(caseRow.id(), caseType),
+            "end_1",
+            Map.of()));
+    flushClear();
+
+    Case after = caseRepository.findById(caseRow.id()).orElseThrow();
+    assertThat(after.currentStageId()).isEqualTo("stage2");
+    assertThat(events.routed())
+        .singleElement()
+        .satisfies(
+            e -> {
+              assertThat(e.kind()).isEqualTo(BackendSignalKind.END_EVENT);
+              assertThat(e.source().toString()).isEqualTo("backend(fake)");
+              assertThat(e.errorCode()).isNull();
+            });
+  }
+
+  // ---------- AC7 §2 — NAMED_SIGNAL skip-class --------------------------
+
+  @Test
+  void namedSignalSkipsToTargetStage() {
+    Case caseRow = newBootstrappedCase("loan-named", 1);
+    CaseTypeRef caseType = new CaseTypeRef(caseRow.caseTypeId(), "1");
+    fake.attach(caseType, AttachmentScope.ofCase());
+    mappingRegistry.register(
+        caseType,
+        "1",
+        defWith(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.empty(),
+                Map.of("escalate", new SignalMapping("stage1 -> stage3")),
+                List.of())));
+
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.NAMED_SIGNAL,
+            ADAPTER_NAME,
+            new CaseInstanceRef(caseRow.id(), caseType),
+            "escalate",
+            Map.of()));
+    flushClear();
+
+    Case after = caseRepository.findById(caseRow.id()).orElseThrow();
+    assertThat(after.currentStageId()).isEqualTo("stage3");
+    assertThat(events.routed())
+        .singleElement()
+        .satisfies(e -> assertThat(e.source().toString()).isEqualTo("backend(fake)"));
+  }
+
+  // ---------- AC7 §3 — USER_TASK_PROPERTY status change -----------------
+
+  @Test
+  void userTaskPropertyUpdatesStatus() {
+    Case caseRow = newBootstrappedCase("loan-prop", 1);
+    CaseTypeRef caseType = new CaseTypeRef(caseRow.caseTypeId(), "1");
+    fake.attach(caseType, AttachmentScope.ofCase());
+    mappingRegistry.register(
+        caseType,
+        "1",
+        defWith(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.empty(),
+                Map.of(),
+                List.of(
+                    new PropertyEmissionRule(
+                        "userTask:review",
+                        "status",
+                        BackendSignalKind.USER_TASK_PROPERTY,
+                        "stage:stage1")))));
+
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.USER_TASK_PROPERTY,
+            ADAPTER_NAME,
+            new CaseInstanceRef(caseRow.id(), caseType),
+            "review",
+            Map.of("camunda:property", "status", "value", "approved")));
+    flushClear();
+
+    Case after = caseRepository.findById(caseRow.id()).orElseThrow();
+    assertThat(after.status()).isEqualTo("approved");
+    assertThat(events.routed())
+        .singleElement()
+        .satisfies(
+            e -> {
+              assertThat(e.source().toString()).isEqualTo("backend(fake)");
+              assertThat(e.kind()).isEqualTo(BackendSignalKind.USER_TASK_PROPERTY);
+            });
+  }
+
+  // ---------- AC7 §4 — userTask property cannot drive stage transition ---
+
+  @Test
+  void userTaskPropertyEmittingNonStatusKindIsRejected() {
+    Case caseRow = newBootstrappedCase("loan-stage-rej", 1);
+    CaseTypeRef caseType = new CaseTypeRef(caseRow.caseTypeId(), "1");
+    fake.attach(caseType, AttachmentScope.ofCase());
+    // Rule whose emits is END_EVENT (a stage-transition kind) — router rejects.
+    mappingRegistry.register(
+        caseType,
+        "1",
+        defWith(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.empty(),
+                Map.of(),
+                List.of(
+                    new PropertyEmissionRule(
+                        "userTask:review",
+                        "stage",
+                        BackendSignalKind.END_EVENT,
+                        "stage:stage1")))));
+
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.USER_TASK_PROPERTY,
+            ADAPTER_NAME,
+            new CaseInstanceRef(caseRow.id(), caseType),
+            "review",
+            Map.of("camunda:property", "stage", "value", "stage2")));
+    flushClear();
+
+    Case after = caseRepository.findById(caseRow.id()).orElseThrow();
+    assertThat(after.currentStageId()).isEqualTo("stage1");
+    assertThat(after.status()).isEqualTo("open");
+    assertThat(events.routed())
+        .singleElement()
+        .satisfies(
+            e -> {
+              assertThat(e.errorCode()).isEqualTo("WKS-MAP-404");
+              assertThat(e.source().toString()).isEqualTo("backend(unmapped)");
+              assertThat(e.detail()).containsEntry("originAdapter", ADAPTER_NAME);
+            });
+  }
+
+  // ---------- AC7 §5 — unmapped signal -----------------------------------
+
+  @Test
+  void unmappedNamedSignalIsAuditedWithMap404() {
+    Case caseRow = newBootstrappedCase("loan-unmapped", 1);
+    CaseTypeRef caseType = new CaseTypeRef(caseRow.caseTypeId(), "1");
+    fake.attach(caseType, AttachmentScope.ofCase());
+    mappingRegistry.register(
+        caseType,
+        "1",
+        defWith(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.empty(),
+                Map.of(), // no signal rules at all
+                List.of())));
+
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.NAMED_SIGNAL,
+            ADAPTER_NAME,
+            new CaseInstanceRef(caseRow.id(), caseType),
+            "undeclared",
+            Map.of()));
+    flushClear();
+
+    Case after = caseRepository.findById(caseRow.id()).orElseThrow();
+    assertThat(after.currentStageId()).isEqualTo("stage1");
+    assertThat(events.routed())
+        .singleElement()
+        .satisfies(
+            e -> {
+              assertThat(e.errorCode()).isEqualTo("WKS-MAP-404");
+              assertThat(e.source().toString()).isEqualTo("backend(unmapped)");
+              assertThat(e.detail()).containsEntry("originAdapter", ADAPTER_NAME);
+            });
+  }
+
+  // ---------- AC7 §6 — zero-attachment CaseType -------------------------
+
+  @Test
+  void zeroAttachmentCaseTypeYieldsMap404OnAnySignal() {
+    Case caseRow = newBootstrappedCase("loan-empty", 1);
+    CaseTypeRef caseType = new CaseTypeRef(caseRow.caseTypeId(), "1");
+    fake.attach(caseType, AttachmentScope.ofCase());
+    mappingRegistry.register(caseType, "1", MappingDefinition.empty());
+
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.END_EVENT,
+            ADAPTER_NAME,
+            new CaseInstanceRef(caseRow.id(), caseType),
+            "end_1",
+            Map.of()));
+    flushClear();
+
+    Case after = caseRepository.findById(caseRow.id()).orElseThrow();
+    assertThat(after.currentStageId()).isEqualTo("stage1");
+    assertThat(events.routed())
+        .singleElement()
+        .satisfies(e -> assertThat(e.errorCode()).isEqualTo("WKS-MAP-404"));
+  }
+
+  // ---------- AC7 §7 — adapter-emission order honoured (no reorder) -----
+
+  @Test
+  void routerProcessesSignalsInArrivalOrderWithoutReordering() {
+    Case caseRow = newBootstrappedCase("loan-order", 1);
+    CaseTypeRef caseType = new CaseTypeRef(caseRow.caseTypeId(), "1");
+    fake.attach(caseType, AttachmentScope.ofCase());
+    mappingRegistry.register(
+        caseType,
+        "1",
+        defWith(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.of(new EndEventMapping("stage1 -> stage2")),
+                Map.of(),
+                List.of(
+                    new PropertyEmissionRule(
+                        "userTask:review",
+                        "status",
+                        BackendSignalKind.USER_TASK_PROPERTY,
+                        "stage:stage1")))));
+
+    // First: status change. Second: stage advance.
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.USER_TASK_PROPERTY,
+            ADAPTER_NAME,
+            new CaseInstanceRef(caseRow.id(), caseType),
+            "review",
+            Map.of("camunda:property", "status", "value", "approved")));
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.END_EVENT,
+            ADAPTER_NAME,
+            new CaseInstanceRef(caseRow.id(), caseType),
+            "end_1",
+            Map.of()));
+    flushClear();
+
+    Case after = caseRepository.findById(caseRow.id()).orElseThrow();
+    assertThat(after.status()).isEqualTo("approved");
+    assertThat(after.currentStageId()).isEqualTo("stage2");
+    assertThat(events.routed()).hasSize(2);
+    assertThat(events.routed().get(0).kind()).isEqualTo(BackendSignalKind.USER_TASK_PROPERTY);
+    assertThat(events.routed().get(1).kind()).isEqualTo(BackendSignalKind.END_EVENT);
+  }
+
+  // ---------- AC7 §8 — frozen-on-version pin ---------------------------
+
+  @Test
+  void pinnedCaseInstanceVersionResolvesAgainstItsOwnRegistryEntry() {
+    Case caseRow = newBootstrappedCase("loan-pinned", 1); // pinned at v=1
+    CaseTypeRef caseTypeV1 = new CaseTypeRef(caseRow.caseTypeId(), "1");
+    CaseTypeRef caseTypeV2 = new CaseTypeRef(caseRow.caseTypeId(), "2");
+    fake.attach(caseTypeV1, AttachmentScope.ofCase());
+
+    mappingRegistry.register(
+        caseTypeV1,
+        "1",
+        defWith(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.of(new EndEventMapping("stage1 -> stage2")),
+                Map.of(),
+                List.of())));
+    // v2 mapping points to a different target stage — must NOT be consulted because the case is
+    // pinned at v1.
+    mappingRegistry.register(
+        caseTypeV2,
+        "2",
+        defWith(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.of(new EndEventMapping("stage1 -> stage3")),
+                Map.of(),
+                List.of())));
+
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.END_EVENT,
+            ADAPTER_NAME,
+            new CaseInstanceRef(caseRow.id(), caseTypeV1),
+            "end_1",
+            Map.of()));
+    flushClear();
+
+    Case after = caseRepository.findById(caseRow.id()).orElseThrow();
+    // v1 mapping consulted → stage2 (not stage3).
+    assertThat(after.currentStageId()).isEqualTo("stage2");
+  }
+
+  // ---------- AC8 — transaction-rollback observable on illegal target ---
+
+  @Test
+  void illegalStageTargetRollsBackAndAuditsMap404() {
+    Case caseRow = newBootstrappedCase("loan-illegal", 1);
+    CaseTypeRef caseType = new CaseTypeRef(caseRow.caseTypeId(), "1");
+    fake.attach(caseType, AttachmentScope.ofCase());
+    // Backward-skip target ("stage1 -> stage1") → WksStageAdvancer raises WKS-STG-002.
+    // The router does NOT catch WksStageException — it catches only WksMappingMissException — so
+    // the engine sees the failure and the test asserts the rollback is observable: the case did
+    // not advance, and the WKS exception was not silently audited away.
+    mappingRegistry.register(
+        caseType,
+        "1",
+        defWith(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.of(new EndEventMapping("stage1 -> stage1")),
+                Map.of(),
+                List.of())));
+
+    try {
+      fake.emit(
+          new BackendSignal(
+              BackendSignalKind.END_EVENT,
+              ADAPTER_NAME,
+              new CaseInstanceRef(caseRow.id(), caseType),
+              "end_1",
+              Map.of()));
+      flushClear();
+    } catch (RuntimeException expected) {
+      // Engine sees the failure — the adapter would roll back its transaction.
+    }
+
+    Case after = caseRepository.findById(caseRow.id()).orElseThrow();
+    assertThat(after.currentStageId()).isEqualTo("stage1");
+    // No success audit; only failure audit if propagated, but per AC8 only WksMappingMiss is
+    // caught. The router does not emit BackendSignalRouted on uncaught exceptions — that's the
+    // engine's territory. Assert no success-audit was published.
+    assertThat(events.routed()).noneMatch(e -> e.errorCode() == null);
+  }
+
+  // ---------- helpers ----------------------------------------------------
+
+  private static MappingDefinition defWith(AttachmentDefinition attachment) {
+    return new MappingDefinition(List.of(attachment));
+  }
+
+  private Case newBootstrappedCase(String idSuffix, int caseTypeVersion) {
+    UUID id = UUID.randomUUID();
+    String caseTypeId = idSuffix; // unique per-test caseTypeId to avoid registry collisions
+    Case toSave =
+        new Case(
+            id, caseTypeId, caseTypeVersion, "open", null, Map.of(), null, NOW, actorId, NOW, 0L);
+    caseRepository.save(toSave);
+    stageRepository.materialiseStages(id, STAGES, NOW);
+    stageRepository.appendTransition(
+        new StageRepository.Transition(
+            id, null, null, "stage1", 0, List.of(), "wks-auto-rule", "case-create", NOW));
+    flushClear();
+    return caseRepository.findById(id).orElseThrow();
+  }
+
+  private void flushClear() {
+    em.flush();
+    em.clear();
+  }
+
+  // ---------- test config ------------------------------------------------
+
+  static class RouterTestConfig {
+
+    @Bean
+    NullAdapter nullAdapter() {
+      return new NullAdapter();
+    }
+
+    @Bean
+    BackendAdapterBinder binder(NullAdapter nullAdapter) {
+      return new BackendAdapterBinder(nullAdapter);
+    }
+
+    @Bean
+    MappingRegistry mappingRegistry() {
+      return new MappingRegistry();
+    }
+
+    @Bean
+    Clock testClock() {
+      return () -> NOW;
+    }
+
+    @Primary
+    @Bean
+    RecordingEventPublisher recordingEventPublisher() {
+      return new RecordingEventPublisher();
+    }
+
+    @Bean
+    WksStageAdvancer wksStageAdvancer(
+        StageRepository stageRepository, EventPublisher eventPublisher, Clock clock) {
+      return new WksStageAdvancer(stageRepository, eventPublisher, clock);
+    }
+
+    @Bean
+    BackendSignalRouter backendSignalRouter(
+        MappingRegistry mappingRegistry,
+        WksStageAdvancer stageAdvancer,
+        CaseStatusUpdater statusUpdater,
+        CaseRepository caseRepository,
+        EventPublisher eventPublisher,
+        Clock clock) {
+      return new BackendSignalRouter(
+          mappingRegistry, stageAdvancer, statusUpdater, caseRepository, eventPublisher, clock);
+    }
+  }
+
+  /** Synchronous EventPublisher recording — unit-test-style stub. */
+  static class RecordingEventPublisher implements EventPublisher {
+    private final List<Object> events = new ArrayList<>();
+
+    @Override
+    public synchronized void publish(Object event) {
+      events.add(event);
+    }
+
+    synchronized List<BackendSignalRouted> routed() {
+      List<BackendSignalRouted> out = new ArrayList<>();
+      for (Object e : events) {
+        if (e instanceof BackendSignalRouted r) {
+          out.add(r);
+        }
+      }
+      return out;
+    }
+
+    synchronized void clear() {
+      events.clear();
+    }
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
@@ -71,7 +71,8 @@ class ConfigServiceDeployTest {
         bpmn,
         engine,
         publisher,
-        new com.wkspower.platform.testsupport.FakeCaseTypeVersionRegistry());
+        new com.wkspower.platform.testsupport.FakeCaseTypeVersionRegistry(),
+        new MappingRegistry());
   }
 
   // ---- four-cases enumeration --------------------------------------------

--- a/backend/src/test/java/com/wkspower/platform/domain/service/MappingRegistryTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/MappingRegistryTest.java
@@ -1,0 +1,144 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wkspower.platform.domain.config.model.AttachmentDefinition;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import com.wkspower.platform.domain.port.CaseTypeRef;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/** Story 4.3 Task 2 — unit coverage for {@link MappingRegistry}. */
+class MappingRegistryTest {
+
+  private static final CaseTypeRef CASE_TYPE = new CaseTypeRef("loan-application", "v1");
+
+  private static MappingDefinition definitionWithOneAttachment() {
+    return new MappingDefinition(
+        List.of(
+            new AttachmentDefinition(
+                "bpmn",
+                "loan.bpmn",
+                "case",
+                Optional.empty(),
+                Map.of(),
+                Optional.empty(),
+                Map.of(),
+                List.of())));
+  }
+
+  @Test
+  void registerThenResolveReturnsTheDefinition() {
+    MappingRegistry registry = new MappingRegistry();
+    MappingDefinition def = definitionWithOneAttachment();
+
+    registry.register(CASE_TYPE, "v1", def);
+
+    assertThat(registry.resolve(CASE_TYPE, "v1")).contains(def);
+  }
+
+  @Test
+  void resolveMissingKeyReturnsEmpty() {
+    MappingRegistry registry = new MappingRegistry();
+
+    assertThat(registry.resolve(CASE_TYPE, "v1")).isEmpty();
+  }
+
+  @Test
+  void unregisterRemovesTheMapping() {
+    MappingRegistry registry = new MappingRegistry();
+    registry.register(CASE_TYPE, "v1", definitionWithOneAttachment());
+
+    registry.unregister(CASE_TYPE, "v1");
+
+    assertThat(registry.resolve(CASE_TYPE, "v1")).isEmpty();
+  }
+
+  @Test
+  void unregisterUnknownKeyIsIdempotent() {
+    MappingRegistry registry = new MappingRegistry();
+
+    registry.unregister(CASE_TYPE, "v1");
+
+    assertThat(registry.resolve(CASE_TYPE, "v1")).isEmpty();
+  }
+
+  @Test
+  void registerEmptyMappingRoundTripsAsEmpty() {
+    MappingRegistry registry = new MappingRegistry();
+
+    registry.register(CASE_TYPE, "v1", MappingDefinition.empty());
+
+    assertThat(registry.resolve(CASE_TYPE, "v1")).contains(MappingDefinition.empty());
+  }
+
+  @Test
+  void differentVersionsAreSeparateKeys() {
+    MappingRegistry registry = new MappingRegistry();
+    MappingDefinition v1 = definitionWithOneAttachment();
+    MappingDefinition v2 = MappingDefinition.empty();
+
+    registry.register(CASE_TYPE, "v1", v1);
+    registry.register(CASE_TYPE, "v2", v2);
+
+    assertThat(registry.resolve(CASE_TYPE, "v1")).contains(v1);
+    assertThat(registry.resolve(CASE_TYPE, "v2")).contains(v2);
+  }
+
+  @Test
+  void concurrentRegistersFromTwoThreadsBothLand() throws Exception {
+    MappingRegistry registry = new MappingRegistry();
+    CaseTypeRef ctA = new CaseTypeRef("a", "v1");
+    CaseTypeRef ctB = new CaseTypeRef("b", "v1");
+    MappingDefinition defA = definitionWithOneAttachment();
+    MappingDefinition defB = MappingDefinition.empty();
+
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    CountDownLatch start = new CountDownLatch(1);
+    try {
+      pool.submit(
+          () -> {
+            start.await();
+            registry.register(ctA, "v1", defA);
+            return null;
+          });
+      pool.submit(
+          () -> {
+            start.await();
+            registry.register(ctB, "v1", defB);
+            return null;
+          });
+      start.countDown();
+      pool.shutdown();
+      assertThat(pool.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertThat(registry.resolve(ctA, "v1")).contains(defA);
+    assertThat(registry.resolve(ctB, "v1")).contains(defB);
+  }
+
+  @Test
+  void nullArgumentsAreRejected() {
+    MappingRegistry registry = new MappingRegistry();
+    MappingDefinition def = MappingDefinition.empty();
+
+    assertThatThrownBy(() -> registry.register(null, "v1", def))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> registry.register(CASE_TYPE, null, def))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> registry.register(CASE_TYPE, "v1", null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> registry.resolve(null, "v1")).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> registry.unregister(null, "v1"))
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoaderTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeStartupLoaderTest.java
@@ -157,6 +157,7 @@ class CaseTypeStartupLoaderTest {
           }
         },
         event -> {},
-        new com.wkspower.platform.testsupport.FakeCaseTypeVersionRegistry());
+        new com.wkspower.platform.testsupport.FakeCaseTypeVersionRegistry(),
+        new com.wkspower.platform.domain.service.MappingRegistry());
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/RouterItPersistenceImports.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/RouterItPersistenceImports.java
@@ -1,0 +1,36 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.port.CaseStatusUpdater;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.StageRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseEntityRepository;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseStageHistoryJpaRepository;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Test-only helper config that re-exposes the package-private persistence adapters ({@code
+ * CaseRepositoryAdapter}, {@code StageRepositoryAdapter}, {@code CaseStatusAdapter}) as top-level
+ * beans for slice ITs that live outside this package (Story 4.3's {@code BackendSignalRouterIT}).
+ * The adapters stay package-private in production; this file is the only test-side bridge.
+ */
+@TestConfiguration
+public class RouterItPersistenceImports {
+
+  @Bean
+  public CaseRepository caseRepository(CaseEntityRepository entities) {
+    return new CaseRepositoryAdapter(entities);
+  }
+
+  @Bean
+  public StageRepository stageRepository(
+      CaseStageHistoryJpaRepository history, CaseEntityRepository cases) {
+    return new StageRepositoryAdapter(history, cases);
+  }
+
+  @Bean
+  public CaseStatusUpdater caseStatusUpdater(CaseEntityRepository entities, Clock clock) {
+    return new CaseStatusAdapter(entities, clock);
+  }
+}


### PR DESCRIPTION
## Summary

- Ships **`BackendSignalRouter`** as the single runtime routing surface for every `BackendSignal` (Story 4.1) — consults `MappingDefinition` from `MappingRegistry` (D20 frozen-on-version) and dispatches per `BackendSignalKind` to `WksStageAdvancer` / `CaseStatusUpdater`.
- Adds **`AuditSource`** sealed interface (FR8 attribution `backend(<adapter>)`), **`MappingRegistry`** (pure-Java, ConcurrentHashMap), **`WksMappingMissException`** + **`WKS-MAP-404`** runtime wire code, and an **ArchUnit single-subscriber rule**.
- End-to-end IT proves routing via `FakeRecordingAdapter` — no CIB seven dependency.

## Architecture references

- Decision 22 — Mapping Layer (architecture.md:788–848)
- Decision 1 — three transition sources (architecture.md:178–194)
- Decision 25 — zero `tenant_id` invariant (architecture.md:934–960)
- Story 4.1 (port contract — done) / Story 4.2 (deploy-time validator — done)
- Story 4.4 (next — absorbs 2.4 / 2.9, retires 3.2 deferred AC4 / AC11 §5)

## Routing matrix (verbatim from AC2)

| BackendSignalKind   | Mapping field                                | Domain effect                                        |
|---------------------|----------------------------------------------|------------------------------------------------------|
| END_EVENT           | events.endEvent.stageTransition              | WksStageAdvancer.advance(source=backend(<adapter>))  |
| NAMED_SIGNAL        | events.signal.<source>.stageTransition       | WksStageAdvancer.advance(source=backend(<adapter>))  |
| USER_TASK_PROPERTY  | properties[].on=userTask:<source>            | CaseStatusUpdater (status only; stage→ rejected)     |
| OUTCOME             | events.outcome.<source> (Phase-1)            | WKS-MAP-404 (Phase-1 capability)                     |

## New wire codes (only one, per AC11)

| Code         | Meaning                                                                                  |
|--------------|------------------------------------------------------------------------------------------|
| WKS-MAP-404  | Runtime mapping miss — emitted by `BackendSignalRouter` (no rule match / pinned version not in registry / userTaskProperty cannot drive stage transition / outcome routing is Phase-1). HTTP 404 mirror; distinct from deploy-time WKS-MAP-001..006. |

## Test plan

- [x] **AC1** — `BackendSignalRouter` is `@Bean`-wired in `BackendAdapterConfig`; no other class subscribes to `onBackendSignal`. Verified by ArchUnit `BackendAdapterPortIsolationTest.onBackendSignalIsCalledFromRouterAndBinderOnly`.
- [x] **AC2** — Routing matrix dispatch covered by `BackendSignalRouterIT` §1 (END_EVENT) / §2 (NAMED_SIGNAL skip-class) / §3 (USER_TASK_PROPERTY status) / §7 (no-reorder). Router does no priority queueing — Javadoc cites the no-reorder rule.
- [x] **AC3** — `MappingRegistryTest` (8 cases) covers register, resolve, missing-empty, unregister, idempotent-unregister, empty-mapping round-trip, version-keyed separation, concurrent register from two threads. Wired as `@Bean` in `BackendAdapterConfig`.
- [x] **AC4** — `WksMappingMissException` + `ErrorCode.WKS_MAP_404` ship; router catches the miss at its boundary, audits with `source = "backend(unmapped)"`, `originAdapter` in detail map; case state unchanged. IT §4 (userTask cannot drive stage), §5 (unmapped signal), §6 (zero-attachment) cover all three miss paths.
- [x] **AC5** — `AuditSource` sealed interface with locked `toString()` outputs (`AuditSourceTest` × 5). Existing string slots unchanged (migration → Story 4.4 per `feedback_fold_debt_into_stories.md`). New `BackendSignalRouted` event carries the typed source through `EventPublisher.publishAfterCommit(...)`.
- [x] **AC6** — Single-subscriber ArchUnit rule extends Story 4.1's `BackendAdapterPortIsolationTest` with a method-level `noClasses().should().callMethod(BackendAdapter, "onBackendSignal", ...)` rule allowing only `BackendSignalRouter` and `BackendAdapterBinder`. `grep -rn "BackendSignal\|onBackendSignal" backend/src/main/java/` returns only the whitelisted files.
- [x] **AC7** — `BackendSignalRouterIT` (9 tests, 8 routing scenarios + 1 transaction-rollback) — covers headline matrix end-to-end through real router + JPA adapters via `RouterItPersistenceImports` `@TestConfiguration`. No CIB seven dependency. H2 only (Postgres-IT deferred per `project_postgres_it_parity_gap.md`).
- [x] **AC8** — Transaction model: router catches only `WksMappingMissException`; every other exception (including `WksStageException`) propagates so the engine can roll back. IT §"illegalStageTargetRollsBackAndAuditsMap404" exercises the rollback path and asserts no success-audit was published. Audit emission via `publishAfterCommit` matches Story 2.4's pattern.
- [x] **AC9** — `MappingRegistry` populated by `ConfigService.validateAndRegister(...)` and `ConfigService.deploy(...)` after every successful `registrar.register(...)`. `ValidationResult` got an additive `Optional<MappingDefinition> mappingDefinition()` slot to thread the validator's output. `Case.caseTypeVersion()` is the pinned version slot — Story 3.4 (parallel `ready-for-dev`) does not block this story; the existing JPA shape works today.
- [x] **AC10** — `./backend/.ci/check-tenant-invariant.sh` reports `Tenant invariant (D25) OK`. Zero `tenant_id` / `tenantId` / `@TenantId` mentions in any new file.
- [x] **AC11** — `domain/service/package-info.java` updated; `WKS_MAP_404` is the only new code; `BackendAdapterPortIsolationTest` extended (not replaced); routing-matrix table reproduced verbatim above; `concepts/mapping-layer.md` Routing section appended (1 paragraph).
- [x] **AC12** — `./mvnw -B -ntp verify` BUILD SUCCESS (75 tests, 0 failures); `./mvnw spotless:apply` clean; `git diff backend/pom.xml` empty (zero new runtime deps); frontend `npm ci && lint && format:check && test && build` green; `production-profile-smoke` job parity executed locally (image build + `docker compose --profile production up -d postgres minio wks-platform-prod`, `/api/health` 200 within 90s, H2-driver invariant green, runtime tenant probe green).

## Deviations / decisions

- **Open Question #1** — `MappingRegistry` kept as pure-Java class (default), not promoted to a `domain/port/` interface. Mechanical refactor available in 4.5 if SM disagrees.
- **Open Question #2** — `WksMappingMissException` extends `WksException` directly (not `WksWorkflowEngineException`) so the global handler routes by the new `WKS-MAP-404` code rather than inheriting the 500 mapping; carries `originAdapter` + `caseInstanceId` for audit detail.
- **Open Question #3 (Postgres-IT)** — H2-only IT per Sprint 3 cross-story-decisions lock + `project_postgres_it_parity_gap.md`. Phase-1 sweep covers Postgres parity.
- **Audit-row implementation choice (clarification)** — AC5 / AC7 ask for an "audit row" with `source = backend(<adapter>)`. Implementation: a new domain event `BackendSignalRouted` carrying the typed `AuditSource`; the IT subscribes a recording publisher and asserts on emitted events. No new audit table — matches Story 2.4's `EventPublisher.publishAfterCommit` pattern referenced in AC8.
- **CaseInstance version pinning (Task 5)** — Story 3.4 parallel `ready-for-dev` (not yet merged). Used the existing `Case.caseTypeVersion()` integer slot via `String.valueOf(...)` for `MappingRegistry` lookup. No `@TODO Story 3.4` stub needed: the JPA shape already exists. If 3.4 lands first, no churn.
- **Test surface bridge** — `CaseRepositoryAdapter` / `StageRepositoryAdapter` / `CaseStatusAdapter` are package-private in production. Added `RouterItPersistenceImports` `@TestConfiguration` in the persistence test package to expose them as beans for the router IT (which lives in `domain/service/`). `@TestConfiguration` (not `@Configuration`) — avoids auto-discovery (caught and fixed during local CI parity; an initial `@Configuration` form double-registered `CaseStatusUpdater` and broke 58 `@SpringBootTest` ITs).
- **Routing simplifications (Phase-0)** — router consults `MappingDefinition.attachments().get(0)`. Story 4.2's `WKS-MAP-006` forbids duplicate scopes; multi-attachment routing is Story 4.5 territory. End-event terminal markers `completed`/`skipped` route through `WksStageAdvancer.advance` (case-level lifecycle); other targets through `WksStageAdvancer.skipTo` (forward-by-one is equivalent to advance per Story 3.1 AC6).
- **Out of scope (per locked decisions)** — no edits to `engine/listeners/CaseStatusListener.java`, `engine/CibSevenWorkflowEngine.java`, `domain/service/CaseService.transition(...)`, no `<camunda:property>` reader extraction (`feedback_consolidate_property_readers.md` flagged for Story 4.4), no flip of `ZeroStageZeroProcessTest` (`project_story_4_4_test_flip.md` — Story 4.4 owns).