### PR TITLE
Story 3.4.1: Version Registry Production Hardening (hotfix C3/I5-I8)

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import com.wkspower.platform.domain.exception.WksWorkflowEngineException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -204,8 +205,11 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   /**
-   * Story 3.4 / Decision 20 — CaseType version-registry exceptions. {@code WKS-VER-001} (no
-   * published version yet) → 409 Conflict.
+   * Story 3.4 / Decision 20 — CaseType version-registry exceptions. Story 3.4.1 AC4 (finding I6)
+   * flips the HTTP semantic from {@code 409 Conflict} (misleading — it is not a client conflict) to
+   * {@code 503 Service Unavailable} with a {@code Retry-After: 5} header: the registry-not- primed
+   * condition is recoverable (startup race, polling redeploy window) and "transient, retry safe" is
+   * the most actionable signal for SI operators.
    */
   @ExceptionHandler(com.wkspower.platform.domain.exception.WksVersionException.class)
   public ResponseEntity<ApiResponse<Void>> handleVersion(
@@ -213,7 +217,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     MDC.put(MDC_KEY, ex.getCode());
     try {
       log.warn("CaseType version-registry error: {}", ex.getCode());
-      return ResponseEntity.status(HttpStatus.CONFLICT)
+      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+          .header(HttpHeaders.RETRY_AFTER, "5")
           .body(ApiResponse.error(ErrorPayload.of(ex.getCode(), ex.getMessage())));
     } finally {
       MDC.remove(MDC_KEY);

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -264,16 +264,18 @@ public enum ErrorCode {
    */
   WKS_STG_011("WKS-STG-011"),
 
-  // 409 / 422 — CaseType Version Registry (Story 3.4 / Decision 20).
+  // 503 — CaseType Version Registry (Story 3.4 / Decision 20; HTTP semantic flipped by Story
+  // 3.4.1).
   // Band: WKS-VER-001..099 RESERVED for version-registry-related errors. Future stories (3.5
   // bootstrap, 3.8 blast-radius validator, 3.9 rebase tooling) draw from this band per
   // feedback_error_codes_are_wire_contract.md. Never reuse a code in this band for a different
   // meaning — the wire is a contract.
   /**
    * {@code CaseService.create} called for a CaseType that is registry-visible (in-memory) but has
-   * no row in {@code case_type_versions} yet — partial-failure recovery state. HTTP 409. Story 3.4
-   * introduces this code; Story 3.5's bootstrap migration closes the gap for pre-3.4 CaseTypes by
-   * materialising v1 rows.
+   * no row in {@code case_type_versions} yet — partial-failure recovery state, registry-not-
+   * yet-primed, or startup race. HTTP 503 (Retry-After: 5) — Story 3.4.1 AC4 (finding I6) flipped
+   * this from 409, which misleads as "client conflict." Story 3.4 introduces this code; Story 3.5's
+   * bootstrap migration closes the gap for pre-3.4 CaseTypes by materialising v1 rows.
    */
   WKS_VER_001("WKS-VER-001"),
 

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/WksVersionException.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/WksVersionException.java
@@ -8,7 +8,9 @@ package com.wkspower.platform.domain.exception;
  *
  * <ul>
  *   <li>{@code WKS-VER-001} (CaseType has no published version yet — partial-failure recovery
- *       state) — 409
+ *       state) — 503 + {@code Retry-After: 5} (Story 3.4.1 AC4 / finding I6 flipped this from 409,
+ *       which misled SI debugging as "client conflict"; 503 + Retry-After accurately signals
+ *       "transient, retry safe" for startup races and polling redeploy windows).
  * </ul>
  */
 public class WksVersionException extends WksException {

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -95,6 +95,22 @@ public class CaseService {
     UUID caseId = UUID.randomUUID();
     String initialStatus = initialStatus(caseType);
 
+    // Story 3.4.1 AC3 (finding I5) — bind the registry version BEFORE starting any engine
+    // process instance. If the registry has no current version (deploy-ordering bug, partial
+    // state, registry-not-yet-primed), failing fast here avoids a dangling process instance in
+    // the engine. Story 3.4 originally read after the engine call; that left a leaked PI on the
+    // WKS-VER-001 path.
+    int boundVersion =
+        versionRegistry
+            .currentVersion(caseType.id())
+            .orElseThrow(
+                () ->
+                    new WksVersionException(
+                        ErrorCode.WKS_VER_001,
+                        "CaseType "
+                            + caseType.id()
+                            + " has no published version yet — deploy completed?"));
+
     // Story 3.2 AC2 — engine call is OPTIONAL. Process-less CaseTypes (workflow: omitted) skip the
     // resolver + start call entirely. Decision 19 / 3.2 unbranched-paths invariant: do not branch
     // on caseType.hasWorkflow() — iterate via Optional.ifPresent and let absence be the no-op.
@@ -118,21 +134,6 @@ public class CaseService {
                       Map.of("caseId", caseId.toString(), "caseTypeId", caseType.id()));
             });
     String processInstanceId = processInstanceIdHolder[0];
-
-    // Story 3.4 / Decision 20 — bind to the registry's current version, not the in-memory
-    // CaseTypeConfig.version() (which IS the registry value post-Story-3.4 wiring, but the
-    // explicit registry read makes the binding contract grep-able and keeps cases stable when
-    // the in-memory registry briefly carries a not-yet-flushed value during deploy windows).
-    int boundVersion =
-        versionRegistry
-            .currentVersion(caseType.id())
-            .orElseThrow(
-                () ->
-                    new WksVersionException(
-                        ErrorCode.WKS_VER_001,
-                        "CaseType "
-                            + caseType.id()
-                            + " has no published version yet — deploy completed?"));
 
     Instant now = clock.now();
     Case toPersist =

--- a/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
@@ -299,7 +299,13 @@ public class ConfigService {
     CaseTypeVersionRegistration result =
         versionRegistry.register(caseType.id(), rawYamlBytes, publishedBy);
     int registryVersion = result.version();
-    if (authorVersion != registryVersion) {
+    // Story 3.4.1 AC6 (finding I8) — gate the author-version-mismatch WARN on actual registration
+    // (REGISTERED outcome). Idempotent re-deploys (file-watcher hot-reload, polling redeploy)
+    // produce CaseTypeVersionRegistration.Outcome.IDEMPOTENT and previously emitted this WARN on
+    // every poll, drowning the log buffer in production hot-reload scenarios. Emit once per
+    // outcome that actually changed registry state.
+    if (authorVersion != registryVersion
+        && result.outcome() == CaseTypeVersionRegistration.Outcome.REGISTERED) {
       log.warn(
           "author-supplied version {} for {} differs from registry-assigned version {};"
               + " registry is authoritative (Decision 20)",

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeRegistry.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeRegistry.java
@@ -12,13 +12,16 @@ import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -35,7 +38,24 @@ import org.springframework.stereotype.Component;
 public class CaseTypeRegistry implements CaseTypeReader, CaseTypeRegistrar {
 
   private final ConcurrentMap<String, Registered> byId = new ConcurrentHashMap<>();
-  private final ConcurrentMap<VersionKey, CaseTypeConfig> byVersion = new ConcurrentHashMap<>();
+
+  /**
+   * Story 3.4.1 AC5 (finding I7) — bounded LRU cache of historical (caseTypeId, version) ->
+   * CaseTypeConfig hydrations. Replaces the unbounded {@code ConcurrentHashMap} that grew without
+   * eviction over the application lifetime. Append-only registry semantics make eviction safe: the
+   * worst case on a miss is a re-parse via the YAML loader + validator, never stale data.
+   *
+   * <p>Default capacity 4096 — generous headroom (typical SI carries ~1000 entries lifetime),
+   * bounded against pathological hot-reload growth. Override via {@code
+   * wks.registry.cache.max-size}.
+   *
+   * <p>Wrapped in {@link Collections#synchronizedMap}: {@link LinkedHashMap}'s access-order
+   * eviction is not thread-safe by itself. The map is on the read-heavy side of {@code findVersion}
+   * but write contention is bounded by {@link CaseTypeYamlLoader} parse cost; a single mutex keeps
+   * the implementation auditable.
+   */
+  private final Map<VersionKey, CaseTypeConfig> byVersion;
+
   private final JsonSchemaGenerator schemaGenerator;
 
   // Story 3.4 — version-pinned hydration deps. Optional so unit tests that only exercise the
@@ -52,8 +72,20 @@ public class CaseTypeRegistry implements CaseTypeReader, CaseTypeRegistrar {
   @Autowired(required = false)
   private @Lazy ConfigValidator configValidator;
 
-  public CaseTypeRegistry(JsonSchemaGenerator schemaGenerator) {
+  public CaseTypeRegistry(
+      JsonSchemaGenerator schemaGenerator,
+      @Value("${wks.registry.cache.max-size:4096}") int byVersionMaxSize) {
     this.schemaGenerator = schemaGenerator;
+    final int capacity = byVersionMaxSize > 0 ? byVersionMaxSize : 4096;
+    // access-order LRU; removeEldestEntry kicks in once size > capacity.
+    this.byVersion =
+        Collections.synchronizedMap(
+            new LinkedHashMap<VersionKey, CaseTypeConfig>(16, 0.75f, true) {
+              @Override
+              protected boolean removeEldestEntry(Map.Entry<VersionKey, CaseTypeConfig> eldest) {
+                return size() > capacity;
+              }
+            });
   }
 
   @Override

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/CaseTypeVersionRegistryAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/CaseTypeVersionRegistryAdapter.java
@@ -9,35 +9,69 @@ import com.wkspower.platform.infrastructure.persistence.repository.CaseTypeVersi
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Optional;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * JPA adapter implementing {@link CaseTypeVersionRegistry} (Story 3.4 / Decision 20). Append-only —
  * every {@code register} call either inserts a row or short-circuits as idempotent. Never updates
  * an existing row.
  *
- * <p>Concurrency: {@link #register(String, byte[], String)} runs at {@link Isolation#SERIALIZABLE}
- * so two threads racing the same first-deploy produce exactly one row. The unique-by-hash index
- * (Story 3.4 AC1) is defence-in-depth — a {@link DataIntegrityViolationException} on insert is
- * translated to an idempotent return so the loser of the race sees the winner's row.
+ * <p>Concurrency (Story 3.4.1 AC1, finding C3): the insert runs at the datasource default isolation
+ * — typically {@code READ COMMITTED} on Postgres. Correctness is enforced by the database, not the
+ * isolation level: the primary key {@code (case_type_id, version)} plus the unique-by-hash index
+ * {@code (case_type_id, definition_hash)} guarantee "exactly one row" for both byte-canonical
+ * re-deploys (idempotent return) and racing first-deploys (loser catches the integrity violation
+ * and re-reads the winner's row in a fresh transaction).
+ *
+ * <p>Story 3.4 ran the whole method at {@code SERIALIZABLE} and caught {@link
+ * DataIntegrityViolationException} only. Two flaws surfaced in finding C3 / the Postgres-IT (Story
+ * 3.4.1 AC2):
+ *
+ * <ol>
+ *   <li>{@link ConcurrencyFailureException} is a sibling, not subclass, of {@link
+ *       DataIntegrityViolationException}; Postgres SSI {@code 40001 serialization_failure} would
+ *       propagate uncaught. H2 SERIALIZABLE serialises rather than aborts, hiding the divergence.
+ *   <li>Once Postgres aborts a transaction with {@code duplicate key}, every subsequent statement
+ *       in that same transaction errors out with {@code current transaction is aborted, commands
+ *       ignored}. Catching the exception inside a single {@code @Transactional} boundary means the
+ *       recovery {@code findByCaseTypeIdAndDefinitionHash} read fails too — the loser thread never
+ *       sees the winner's row and the {@link DataIntegrityViolationException} re-throws.
+ * </ol>
+ *
+ * <p>The fix: split the method. The outer {@link #register} is NOT {@code @Transactional}; it
+ * delegates the insert to {@link #attemptInsert} (a {@code REQUIRES_NEW} transaction that commits
+ * or rolls back independently), and on conflict performs the recovery read in a fresh {@link
+ * TransactionTemplate}-managed transaction. Both the unique-by-hash and PK-violation races are
+ * caught and translated to an idempotent return; any non-recoverable exception still propagates.
  */
 @Component
 public class CaseTypeVersionRegistryAdapter implements CaseTypeVersionRegistry {
 
   private final CaseTypeVersionJpaRepository repository;
   private final CaseTypeContentHasher hasher;
+  private final TransactionTemplate insertTx;
+  private final TransactionTemplate readTx;
 
   public CaseTypeVersionRegistryAdapter(
-      CaseTypeVersionJpaRepository repository, CaseTypeContentHasher hasher) {
+      CaseTypeVersionJpaRepository repository,
+      CaseTypeContentHasher hasher,
+      PlatformTransactionManager txManager) {
     this.repository = repository;
     this.hasher = hasher;
+    this.insertTx = new TransactionTemplate(txManager);
+    this.insertTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    this.readTx = new TransactionTemplate(txManager);
+    this.readTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    this.readTx.setReadOnly(true);
   }
 
   @Override
-  @Transactional(isolation = Isolation.SERIALIZABLE)
   public CaseTypeVersionRegistration register(
       String caseTypeId, byte[] rawYamlBytes, String publishedBy) {
     if (caseTypeId == null || caseTypeId.isBlank()) {
@@ -51,36 +85,57 @@ public class CaseTypeVersionRegistryAdapter implements CaseTypeVersionRegistry {
 
     String hash = hasher.hash(rawYamlBytes);
 
-    Optional<CaseTypeVersionEntity> existing =
-        repository.findByCaseTypeIdAndDefinitionHash(caseTypeId, hash);
+    // Idempotent short-circuit: byte-canonical re-deploy returns the existing row's version.
+    Optional<CaseTypeVersionEntity> existing = readByHash(caseTypeId, hash);
     if (existing.isPresent()) {
       return CaseTypeVersionRegistration.idempotent(existing.get().getVersion(), hash);
     }
 
-    int nextVersion =
-        repository
-            .findFirstByCaseTypeIdOrderByVersionDesc(caseTypeId)
-            .map(e -> e.getVersion() + 1)
-            .orElse(1);
-
-    String yamlAsText = new String(rawYamlBytes, StandardCharsets.UTF_8);
-    CaseTypeVersionEntity entity =
-        new CaseTypeVersionEntity(
-            caseTypeId, nextVersion, hash, yamlAsText, Instant.now(), resolvedPublishedBy);
     try {
-      repository.saveAndFlush(entity);
-    } catch (DataIntegrityViolationException race) {
-      // Concurrent first-deploy raced past the SERIALIZABLE check (e.g. H2 promoted a
-      // serialisation conflict to integrity violation, or a Postgres unique-violation): re-read
-      // by hash; if present, the other writer won — return idempotent. Otherwise rethrow.
-      Optional<CaseTypeVersionEntity> winner =
-          repository.findByCaseTypeIdAndDefinitionHash(caseTypeId, hash);
+      Integer assignedVersion = attemptInsert(caseTypeId, hash, rawYamlBytes, resolvedPublishedBy);
+      return CaseTypeVersionRegistration.registered(assignedVersion, hash);
+    } catch (DataIntegrityViolationException | ConcurrencyFailureException race) {
+      // Concurrent first-deploy: another thread won the (case_type_id, version) PK or the
+      // unique-by-hash index, or a Postgres SSI 40001 serialization_failure surfaced as
+      // ConcurrencyFailureException. Re-read by hash in a FRESH transaction (the original was
+      // aborted and is not usable on Postgres) — if present, the other writer won (return
+      // idempotent). Otherwise the loser hashed differently and lost a version-slot race; rethrow.
+      Optional<CaseTypeVersionEntity> winner = readByHash(caseTypeId, hash);
       if (winner.isPresent()) {
         return CaseTypeVersionRegistration.idempotent(winner.get().getVersion(), hash);
       }
       throw race;
     }
-    return CaseTypeVersionRegistration.registered(nextVersion, hash);
+  }
+
+  /**
+   * Inserts a new row in its own transaction (REQUIRES_NEW). Returns the assigned version on
+   * commit; throws {@link DataIntegrityViolationException} or {@link ConcurrencyFailureException}
+   * on race. The caller MUST treat both exception types identically.
+   */
+  private int attemptInsert(
+      String caseTypeId, String hash, byte[] rawYamlBytes, String publishedBy) {
+    Integer assigned =
+        insertTx.execute(
+            status -> {
+              int nextVersion =
+                  repository
+                      .findFirstByCaseTypeIdOrderByVersionDesc(caseTypeId)
+                      .map(e -> e.getVersion() + 1)
+                      .orElse(1);
+              String yamlAsText = new String(rawYamlBytes, StandardCharsets.UTF_8);
+              CaseTypeVersionEntity entity =
+                  new CaseTypeVersionEntity(
+                      caseTypeId, nextVersion, hash, yamlAsText, Instant.now(), publishedBy);
+              repository.saveAndFlush(entity);
+              return nextVersion;
+            });
+    return assigned == null ? -1 : assigned;
+  }
+
+  /** Read the row by hash in a FRESH transaction (the caller's may be aborted). */
+  private Optional<CaseTypeVersionEntity> readByHash(String caseTypeId, String hash) {
+    return readTx.execute(status -> repository.findByCaseTypeIdAndDefinitionHash(caseTypeId, hash));
   }
 
   @Override

--- a/backend/src/test/java/com/wkspower/platform/api/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/GlobalExceptionHandlerTest.java
@@ -3,9 +3,11 @@ package com.wkspower.platform.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.wkspower.platform.api.dto.ApiResponse;
+import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.WksAuthorizationException;
 import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.exception.WksValidationException;
+import com.wkspower.platform.domain.exception.WksVersionException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -78,6 +80,22 @@ class GlobalExceptionHandlerTest {
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody().error().code()).isEqualTo("WKS-API-001");
     assertThat(response.getBody().error().field()).isEqualTo("email");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void wksVersionExceptionMapsTo503WithRetryAfter5() {
+    // Story 3.4.1 AC4 (finding I6) — WKS-VER-001 must surface as 503 + Retry-After: 5, NOT 409.
+    ResponseEntity<ApiResponse<Void>> response =
+        handler.handleVersion(
+            new WksVersionException(
+                ErrorCode.WKS_VER_001,
+                "CaseType j9 has no published version yet — deploy completed?"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isEqualTo("5");
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().error().code()).isEqualTo("WKS-VER-001");
   }
 
   @Test

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeRegistryTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeRegistryTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 class CaseTypeRegistryTest {
 
   private final JsonSchemaGenerator schemas = new JsonSchemaGenerator();
-  private final CaseTypeRegistry registry = new CaseTypeRegistry(schemas);
+  private final CaseTypeRegistry registry = new CaseTypeRegistry(schemas, 4096);
 
   @Test
   void registerThenFind() {

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/CaseTypeVersionRegistryPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/CaseTypeVersionRegistryPostgresIT.java
@@ -1,0 +1,228 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.CaseTypeVersionRegistration;
+import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseTypeVersionJpaRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Story 3.4.1 AC2 — Postgres-backed integration test for {@link CaseTypeVersionRegistry}.
+ *
+ * <p>Discharges the {@code project_postgres_it_parity_gap} memory for the version-registry surface.
+ * The H2-only IT in {@code CaseTypeVersionRegistryIT} cannot expose the Postgres SSI {@code 40001
+ * serialization_failure} that finding C3 surfaced — H2's SERIALIZABLE serialises rather than
+ * aborts, so the {@link org.springframework.dao.ConcurrencyFailureException}-vs- {@link
+ * org.springframework.dao.DataIntegrityViolationException} sibling-not-subclass distinction is
+ * invisible. AC1 dropped SERIALIZABLE in favour of {@code READ COMMITTED + PK + unique-by-hash};
+ * this test proves correctness on the real Postgres engine.
+ *
+ * <p>Skipped automatically when Docker is unavailable.
+ */
+@SpringBootTest
+@ActiveProfiles("production")
+@Testcontainers(disabledWithoutDocker = true)
+class CaseTypeVersionRegistryPostgresIT {
+
+  @Container
+  @SuppressWarnings("resource")
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("wks")
+          .withUsername("wks")
+          .withPassword("wks");
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("WKS_DB_URL", POSTGRES::getJdbcUrl);
+    registry.add("WKS_DB_USER", POSTGRES::getUsername);
+    registry.add("WKS_DB_PASSWORD", POSTGRES::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    registry.add("WKS_ADMIN_EMAIL", () -> "admin@wkspower.local");
+    registry.add("WKS_ADMIN_PASSWORD", () -> "admin");
+    registry.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+    registry.add("WKS_CORS_ORIGINS", () -> "http://localhost:5173");
+    registry.add(
+        "camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+  }
+
+  private static final String J9_BASE =
+      "id: j9-zero-zero\n"
+          + "displayName: \"[J9] Zero Stages Zero Process\"\n"
+          + "version: 1\n"
+          + "roles:\n"
+          + "  - name: admin\n"
+          + "    permissions: [view, create, edit, transition]\n";
+
+  @Autowired private CaseTypeVersionRegistry registry;
+  @Autowired private CaseTypeVersionJpaRepository repo;
+
+  @AfterEach
+  void wipe() {
+    repo.deleteAll();
+  }
+
+  // ---- AC2 (a) Concurrent register with same hash → exactly one row, all threads idempotent ----
+  @Test
+  void concurrentRegisterSameHashProducesExactlyOneRow() throws Exception {
+    int threads = 8;
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch start = new CountDownLatch(1);
+    @SuppressWarnings("unchecked")
+    Future<CaseTypeVersionRegistration>[] futures = new Future[threads];
+    try {
+      for (int i = 0; i < threads; i++) {
+        futures[i] =
+            pool.submit(
+                () -> {
+                  start.await(2, TimeUnit.SECONDS);
+                  return registry.register(
+                      "j9-zero-zero", J9_BASE.getBytes(StandardCharsets.UTF_8), "system:startup");
+                });
+      }
+      start.countDown();
+      int successes = 0;
+      for (Future<CaseTypeVersionRegistration> f : futures) {
+        try {
+          CaseTypeVersionRegistration r = f.get(15, TimeUnit.SECONDS);
+          assertThat(r.version())
+              .as("every winner thread observes v1 (the only legal version for this hash)")
+              .isEqualTo(1);
+          successes++;
+        } catch (java.util.concurrent.ExecutionException ex) {
+          // AC1 / option-b: with SERIALIZABLE dropped + PK + unique-by-hash,
+          // every thread should ultimately return idempotent (or registered for the winner).
+          // The adapter catches DataIntegrityViolationException AND ConcurrencyFailureException
+          // (sibling, not subclass — the C3 finding) and re-reads by hash. Re-throw with cause to
+          // make Postgres-divergence regressions loud.
+          throw new AssertionError(
+              "Concurrent same-hash register raced past the adapter's catch — finding C3 regressed",
+              ex);
+        }
+      }
+      assertThat(successes)
+          .as("all threads must succeed (idempotent or registered) under same-hash concurrency")
+          .isEqualTo(threads);
+    } finally {
+      pool.shutdown();
+    }
+    assertThat(repo.findAll())
+        .as("AC2 (a) — exactly one row at v1; no duplicate inserts under concurrent same-hash")
+        .hasSize(1);
+    assertThat(repo.findAll().get(0).getVersion()).isEqualTo(1);
+  }
+
+  // ---- AC2 (b) Concurrent register with DIFFERENT hashes → exactly one row at v1, loser
+  // documented ----
+  @Test
+  void concurrentRegisterDifferentHashesProducesOneRowAtV1() throws Exception {
+    String yamlA = J9_BASE; // hashes one way
+    String yamlB =
+        J9_BASE.replace(
+            "  - name: admin\n    permissions: [view, create, edit, transition]\n",
+            "  - name: admin\n    permissions: [view, create, edit, transition]\n"
+                + "  - name: viewer\n    permissions: [view]\n"); // hashes the other way
+
+    int threadsPerHash = 3;
+    int total = threadsPerHash * 2;
+    ExecutorService pool = Executors.newFixedThreadPool(total);
+    CountDownLatch start = new CountDownLatch(1);
+    List<Future<CaseTypeVersionRegistration>> futures = new ArrayList<>();
+    try {
+      for (int i = 0; i < threadsPerHash; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  start.await(2, TimeUnit.SECONDS);
+                  return registry.register(
+                      "j9-zero-zero", yamlA.getBytes(StandardCharsets.UTF_8), "system:startup");
+                }));
+        futures.add(
+            pool.submit(
+                () -> {
+                  start.await(2, TimeUnit.SECONDS);
+                  return registry.register(
+                      "j9-zero-zero", yamlB.getBytes(StandardCharsets.UTF_8), "system:startup");
+                }));
+      }
+      start.countDown();
+
+      int v1 = 0;
+      int v2 = 0;
+      int losers = 0;
+      for (Future<CaseTypeVersionRegistration> f : futures) {
+        try {
+          CaseTypeVersionRegistration r = f.get(15, TimeUnit.SECONDS);
+          if (r.version() == 1) {
+            v1++;
+          } else if (r.version() == 2) {
+            v2++;
+          } else {
+            throw new AssertionError(
+                "Unexpected version " + r.version() + " — only 1 and 2 are reachable");
+          }
+        } catch (java.util.concurrent.ExecutionException ex) {
+          // Documented loser-thread outcome (AC2 b): under READ COMMITTED + the unique-by-hash
+          // index, the loser of a race for the same nextVersion may surface a
+          // DataIntegrityViolationException whose hash *does not* match the winner's row (because
+          // the loser's hash is from yamlB but the winner registered yamlA's hash at v1). The
+          // adapter's re-read by (id, hash) returns empty and the exception propagates. This is
+          // the documented loser semantic — at-least-one writer succeeds, AT-LEAST-ONE row exists,
+          // and operators retrying see the second hash land at v2.
+          losers++;
+        }
+      }
+      // Either: one hash won at v1, the other landed at v2 (interleaved success — happy path), OR
+      // one hash won and the other lost an integrity-violation race that the operator must retry.
+      // Both outcomes satisfy "exactly one row per (id, version)".
+      assertThat(v1).as("at least one thread succeeds at v1").isGreaterThanOrEqualTo(1);
+      assertThat(v1 + v2 + losers).isEqualTo(total);
+    } finally {
+      pool.shutdown();
+    }
+
+    var rows = repo.findAll();
+    assertThat(rows)
+        .as("AC2 (b) — distinct (id, version) rows; PK + unique-by-hash enforced by Postgres")
+        .hasSizeBetween(1, 2);
+    // Every row must have a unique version for this caseTypeId.
+    assertThat(rows.stream().map(e -> e.getVersion()).distinct().count()).isEqualTo(rows.size());
+  }
+
+  // ---- AC2 sanity: the production-profile flyway picks up the v202605060001 migration ----
+  @Test
+  void caseTypeVersionsTableExistsAndIndexIsEnforced() {
+    // First insert lands.
+    CaseTypeVersionRegistration r1 =
+        registry.register(
+            "j9-zero-zero", J9_BASE.getBytes(StandardCharsets.UTF_8), "system:startup");
+    assertThat(r1.outcome()).isEqualTo(CaseTypeVersionRegistration.Outcome.REGISTERED);
+    assertThat(r1.version()).isEqualTo(1);
+
+    // Byte-identical re-deploy short-circuits via the unique-by-hash idempotent path.
+    CaseTypeVersionRegistration r2 =
+        registry.register(
+            "j9-zero-zero", J9_BASE.getBytes(StandardCharsets.UTF_8), "system:startup");
+    assertThat(r2.outcome()).isEqualTo(CaseTypeVersionRegistration.Outcome.IDEMPOTENT);
+    assertThat(r2.version()).isEqualTo(1);
+    assertThat(repo.findAll()).hasSize(1);
+  }
+}

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -164,7 +164,7 @@ Band: `WKS-VER-001..099` reserved for version-registry-related errors. Future st
 
 | Code | HTTP | Meaning | Thrower(s) |
 | --- | --- | --- | --- |
-| `WKS-VER-001` | 409 | `CaseService.create` called for a CaseType that is registry-visible (in-memory) but has no row in `case_type_versions` yet — partial-failure recovery state. Story 3.5's bootstrap migration closes the gap for pre-3.4 CaseTypes by materialising v1 rows. | `domain/service/CaseService.java` |
+| `WKS-VER-001` | 503 (Retry-After: 5) | `CaseService.create` called for a CaseType that is registry-visible (in-memory) but has no row in `case_type_versions` yet — partial-failure recovery state, registry-not-yet-primed, or startup race. The 503 + Retry-After signal is "transient, retry safe" — the most actionable contract for SI operators (Story 3.4.1 AC4 flipped this from 409, which misleads as "client conflict"). Story 3.5's bootstrap migration closes the gap for pre-3.4 CaseTypes by materialising v1 rows. | `domain/service/CaseService.java`, `api/GlobalExceptionHandler.java` |
 
 ---
 


### PR DESCRIPTION
## Summary

Sprint 1-3 retroactive code-review hotfix on the CaseType Version Registry surface (Story 3.4 / Decision 20). Six ACs traceable to findings C3 (Postgres SSI uncaught + transactional anti-pattern), I5 (read-order leaking PI), I6 (wrong HTTP semantic), I7 (unbounded cache), I8 (WARN-on-poll spam). Discharges the `project_postgres_it_parity_gap` memory for the version-registry surface.

## Acceptance Criteria

- [x] **AC1** — `CaseTypeVersionRegistryAdapter.register` survives Postgres concurrency. Dropped `SERIALIZABLE` (option-b per Open Q1 resolution); correctness now pinned to PK `(case_type_id, version)` + unique-by-hash index. **Postgres-IT exposed a second flaw beyond the original C3 finding**: catching `DataIntegrityViolationException` inside the same `@Transactional` boundary triggers `current transaction is aborted, commands ignored` because the recovery `findByCaseTypeIdAndDefinitionHash` runs in the same aborted tx. Restructured: outer non-transactional `register` + `REQUIRES_NEW` `attemptInsert` + `REQUIRES_NEW` `readByHash` via `TransactionTemplate`. Also catches `ConcurrencyFailureException` (sibling of `DataIntegrityViolationException`, not subclass) for SSI 40001.
- [x] **AC2** — `CaseTypeVersionRegistryPostgresIT` against `postgres:16-alpine` testcontainer. Three scenarios: same-hash concurrent register (8 threads → 1 row, all idempotent), different-hash concurrent register (6 threads → 1-2 rows, loser semantics documented), Flyway migration sanity. Real Postgres caught the AC1 transactional anti-pattern that H2 hides.
- [x] **AC3** — `CaseService.create` reads `versionRegistry.currentVersion` **before** `workflowEngine.startProcessInstance`. Closes leaked-process-instance window on `WKS-VER-001`.
- [x] **AC4** — `WKS-VER-001` flipped `409 Conflict` → `503 Service Unavailable` + `Retry-After: 5` (per Open Q2). Updated `GlobalExceptionHandler`, `ErrorCode.java` javadoc, `WksVersionException` javadoc, `docs/error-codes.md`. New `GlobalExceptionHandlerTest` assertion.
- [x] **AC5** — `CaseTypeRegistry.byVersion` replaced unbounded `ConcurrentHashMap` with `Collections.synchronizedMap(LinkedHashMap)` access-order LRU, default capacity 4096, configurable via `wks.registry.cache.max-size` (per Open Q3). Append-only registry semantics make eviction safe.
- [x] **AC6** — `ConfigService.applyVersionRegistry` author-version-mismatch WARN gated on `CaseTypeVersionRegistration.Outcome.REGISTERED`. Idempotent re-deploys (file watcher hot-reload) no longer drown the log buffer.

## Postgres-IT Evidence

- Image: `postgres:16-alpine` via `org.testcontainers:postgresql`
- Profile: `production` (real `org.postgresql.Driver`, real Flyway path `db/migration/{common,postgresql}`)
- Scenarios:
  - `concurrentRegisterSameHashProducesExactlyOneRow` (8 threads) — exposed and now exercises the `current transaction is aborted` recovery via `REQUIRES_NEW`.
  - `concurrentRegisterDifferentHashesProducesOneRowAtV1` (6 threads, 2 hashes) — proves PK + unique-by-hash race semantics.
  - `caseTypeVersionsTableExistsAndIndexIsEnforced` — Flyway migration sanity + idempotent short-circuit.
- Result: 3/3 green; `case_type_versions_pkey` and `idx_case_type_versions_id_hash` actively trip during the race and the loser threads return idempotent.

## CI parity table (local)

| Job | Status | Notes |
| --- | --- | --- |
| `backend` (`mvn -B verify`) | ✓ | 89/89 tests, including 11/11 H2 IT + 3/3 Postgres-IT, spotless clean |
| `frontend` (`npm ci`/`lint`/`test`/`build`) | ✓ | 251/251 tests, eslint clean, build OK |
| `tenant-invariant` | ✓ | `Tenant invariant (D25) OK` |
| `deploy-runbook` | ✓ | shellcheck clean, compose template renders + validates, operator-surface tenant-invariant scan clean |
| `docker-build` (`docker buildx build`) | ✓ | image built and loaded |
| `production-profile-smoke` | ⊘ | full compose-up + health-poll; out of scope for this hotfix turnaround. CI owns. |

## Collision-rebase notes

- This story owns `ConfigService.applyVersionRegistry`. Story 4.3.1 owns `validateAndRegister` + `deploy`. Distinct methods, last-merger rebases trivially.
- Zero new `ErrorCode` entries minted. Reuses `WKS-VER-001` for both the read-order fix (AC3) and the HTTP semantic flip (AC4) per the wire-contract memory. Any 4.3.1 ErrorCode additions are additive — keep them on rebase.
- `CaseTypeRegistry` constructor signature changed (added `@Value("${wks.registry.cache.max-size:4096}") int byVersionMaxSize`). The single in-tree direct construction (`CaseTypeRegistryTest`) was updated.
- `CaseTypeVersionRegistryAdapter` constructor now takes a `PlatformTransactionManager`. Spring DI picks it up automatically; no production wiring change.

## Behavioural / wire changes

- `WKS-VER-001` HTTP status changes `409 Conflict` → `503 Service Unavailable` + `Retry-After: 5`. SI runbooks that grep for "409 with WKS-VER-001" need updating; the wire code is unchanged.
- `register`'s transactional contract changes: each call now spans up to two short-lived `REQUIRES_NEW` transactions (the insert + an optional recovery read). Callers wrapping `register` in a larger transaction will have their tx held across the inner ones (no behavioural difference for current callers — `ConfigService` does not wrap `register` in a tx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)