### PR TITLE
Story 4.3.1: Mapping Layer Production Fitness (hotfix C1/C2/I1-I4/I14-I17)

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -200,6 +200,20 @@ public enum ErrorCode {
    */
   WKS_MAP_007("WKS-MAP-007"),
   /**
+   * Story 4.3.1 AC8 — mapping YAML carries an unknown key (typo; e.g. {@code events.signl:}, {@code
+   * emits: { typ: status }}). Emitted at deploy time by {@link
+   * com.wkspower.platform.infrastructure.config.MappingValidator} (and the YAML loader when the
+   * unknown property surfaces during Jackson deserialization). Carries the file path + JSON pointer
+   * + offending key name so the operator can locate the typo without re-reading the YAML.
+   */
+  WKS_MAP_008("WKS-MAP-008"),
+  /**
+   * Story 4.3.1 AC9 — duplicate map key in mapping YAML (e.g. {@code userTasks.review-claim:}
+   * appearing twice). Default Jackson behavior is silent last-wins; this code surfaces the
+   * duplicate via {@code STRICT_DUPLICATE_DETECTION} so an operator never silently loses a rule.
+   */
+  WKS_MAP_009("WKS-MAP-009"),
+  /**
    * Runtime — emitted by {@link com.wkspower.platform.domain.service.BackendSignalRouter} when an
    * incoming {@link com.wkspower.platform.domain.port.BackendSignal} does not match any rule in the
    * active {@link com.wkspower.platform.domain.config.model.MappingDefinition}, when the
@@ -212,6 +226,15 @@ public enum ErrorCode {
    * other meaning.
    */
   WKS_MAP_404("WKS-MAP-404"),
+  /**
+   * Story 4.3.1 AC5 — runtime: {@link com.wkspower.platform.domain.service.BackendSignalRouter}
+   * received a {@link com.wkspower.platform.domain.port.BackendSignal} for a {@code caseId} that is
+   * no longer present in the case repository (purged, hot-reload race, adapter sending after case
+   * deletion). Distinct from {@code WKS-MAP-404} (rule miss); {@code -405} mirrors the HTTP "method
+   * not allowed / case-not-found" suffix convention. Audited via {@code BackendSignalRouted} with
+   * {@code source = backend(<adapter>)}; never silently dropped.
+   */
+  WKS_MAP_405("WKS-MAP-405"),
 
   // 409 / 422 / 404 — Stage lifecycle runtime errors (Story 3.1 AC9). Band: WKS-STG-001..099.
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/model/AuditSource.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/AuditSource.java
@@ -32,7 +32,10 @@ import java.util.UUID;
  * feedback_error_codes_are_wire_contract.md} for load-bearing wire shapes.
  */
 public sealed interface AuditSource
-    permits AuditSource.User, AuditSource.AutoRule, AuditSource.Backend {
+    permits AuditSource.User,
+        AuditSource.AutoRule,
+        AuditSource.Backend,
+        AuditSource.BackendUnmapped {
 
   /** Manual user action — wire string {@code "manual"}. */
   record User(UUID actorId) implements AuditSource {
@@ -67,6 +70,27 @@ public sealed interface AuditSource
     @Override
     public String toString() {
       return "backend(" + adapterName + ")";
+    }
+  }
+
+  /**
+   * Story 4.3.1 AC6 — un-spoofable miss-sentinel for {@link
+   * com.wkspower.platform.domain.service.BackendSignalRouter} {@code WKS-MAP-404} audit rows. The
+   * legacy single-{@link Backend}-record design rendered miss audits as {@code "backend(unmapped)"}
+   * by passing the literal string {@code "unmapped"} as the adapter name — which collides with any
+   * real adapter that happens to be named {@code "unmapped"}. This sealed sub-record carries the
+   * originating adapter name as a separate slot and renders as {@code
+   * "backend(unmapped:<originAdapter>)"} so the operator-facing audit string is always
+   * distinguishable from a regular {@link Backend} row.
+   */
+  record BackendUnmapped(String originAdapter) implements AuditSource {
+    public BackendUnmapped {
+      Objects.requireNonNull(originAdapter, "originAdapter");
+    }
+
+    @Override
+    public String toString() {
+      return "backend(unmapped:" + originAdapter + ")";
     }
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignalKind.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/BackendSignalKind.java
@@ -9,14 +9,24 @@ package com.wkspower.platform.domain.port;
  * <ol>
  *   <li>{@link #END_EVENT} — terminal; supersedes all other signals for the same instance.
  *   <li>{@link #NAMED_SIGNAL} — explicit signal/message correlation emitted by the backend.
- *   <li>{@link #USER_TASK_PROPERTY} — user-task-scoped property change (e.g. {@code
- *       <camunda:property>} on task complete).
+ *   <li>{@link #USER_TASK_STATUS} — user-task property change that drives a status transition.
+ *   <li>{@link #USER_TASK_COMPLETE} — user-task completion signal (e.g. BPMN {@code
+ *       <camunda:property>} fired on task complete that maps to a stage advance / case-level
+ *       outcome).
  *   <li>{@link #OUTCOME} — backend-internal outcome event.
  * </ol>
  *
  * <p>This generalises the "endEvent wins" rule documented at architecture §810 to all signal kinds.
  * Story 4.3 ({@code BackendSignalRouter}) is the enforcer; this enum only documents the ordering so
  * adapters and tests share one source of truth.
+ *
+ * <p>Story 4.3.1 AC10 / Option (a) — the legacy {@code USER_TASK_PROPERTY} value collapsed two
+ * author-distinguishable shapes ({@code emits.type: status} vs {@code emits.type: task-complete})
+ * onto the same enum constant. {@link com.wkspower.platform.infrastructure.config.MappingDiff}
+ * silently misclassified mutations as APPEND because {@code .equals()} treated them as identical.
+ * The split into {@link #USER_TASK_STATUS} and {@link #USER_TASK_COMPLETE} makes the type system
+ * the enforcer — every callsite that branches on the user-task family must opt into a single value,
+ * surfacing any future collapse to reviewers.
  */
 public enum BackendSignalKind {
 
@@ -26,8 +36,18 @@ public enum BackendSignalKind {
   /** Named signal/message correlation emitted by the backend. */
   NAMED_SIGNAL,
 
-  /** User-task-scoped property change (e.g. status property set on task complete). */
-  USER_TASK_PROPERTY,
+  /**
+   * User-task-scoped status property change (YAML {@code emits.type: status}). Drives a status
+   * transition within the active stage; never advances stages.
+   */
+  USER_TASK_STATUS,
+
+  /**
+   * User-task-completion signal (YAML {@code emits.type: task-complete}). Fires on task complete
+   * and may map to a stage advance via the surrounding rule. Distinct from {@link
+   * #USER_TASK_STATUS} so {@code MappingDiff} does not collapse the two shapes (Story 4.3.1 AC10).
+   */
+  USER_TASK_COMPLETE,
 
   /** Backend-internal outcome event. Lowest precedence. */
   OUTCOME

--- a/backend/src/main/java/com/wkspower/platform/domain/service/BackendSignalRouter.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/BackendSignalRouter.java
@@ -6,6 +6,7 @@ import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEm
 import com.wkspower.platform.domain.config.model.AttachmentDefinition.SignalMapping;
 import com.wkspower.platform.domain.config.model.MappingDefinition;
 import com.wkspower.platform.domain.event.BackendSignalRouted;
+import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.WksMappingMissException;
 import com.wkspower.platform.domain.model.AuditSource;
 import com.wkspower.platform.domain.model.Case;
@@ -96,15 +97,37 @@ public class BackendSignalRouter implements BackendSignalHandler {
     Objects.requireNonNull(signal, "signal");
     Optional<Case> caseOpt = caseRepository.findById(signal.caseInstance().id());
     if (caseOpt.isEmpty()) {
-      // No case row to audit against — log structured warning only; the audit-row event requires
-      // a caseTypeId/version we do not have. This branch is defensive: the adapter should never
-      // emit a signal for a non-existent case in production, since the case lifecycle is the
-      // adapter's parent.
+      // Story 4.3.1 AC5 — case-not-found is now an audit-emitting branch (WKS-MAP-405). The
+      // CaseInstanceRef carries caseTypeId + version, so we can synthesise a BackendSignalRouted
+      // event for operator observability rather than silently dropping. Distinct from WKS-MAP-404
+      // (rule miss): the case row itself is gone, so the rule lookup never ran.
+      String caseTypeVersion =
+          signal.caseInstance().caseType() == null
+              ? "?"
+              : signal.caseInstance().caseType().version();
+      String caseTypeId =
+          signal.caseInstance().caseType() == null
+              ? "?"
+              : signal.caseInstance().caseType().caseTypeId();
       log.atWarn()
-          .addKeyValue("wksErrorCode", "WKS-MAP-404")
+          .addKeyValue("wksErrorCode", ErrorCode.WKS_MAP_405.wire())
           .addKeyValue("originAdapter", signal.adapterName())
           .addKeyValue("caseId", signal.caseInstance().id().toString())
-          .log("backend signal targets unknown caseId — dropped");
+          .log("backend signal targets unknown caseId — case not found");
+      Map<String, String> detail = new HashMap<>();
+      detail.put("originAdapter", signal.adapterName());
+      detail.put("reason", "case not found in repository");
+      eventPublisher.publishAfterCommit(
+          new BackendSignalRouted(
+              signal.caseInstance().id(),
+              caseTypeId,
+              caseTypeVersion,
+              signal.kind(),
+              signal.source(),
+              new AuditSource.Backend(signal.adapterName()),
+              ErrorCode.WKS_MAP_405.wire(),
+              detail,
+              clock.now()));
       return;
     }
     Case caseRow = caseOpt.get();
@@ -123,7 +146,12 @@ public class BackendSignalRouter implements BackendSignalHandler {
       switch (signal.kind()) {
         case END_EVENT -> dispatchEndEvent(signal, caseRow, mappingOpt.get());
         case NAMED_SIGNAL -> dispatchNamedSignal(signal, caseRow, mappingOpt.get());
-        case USER_TASK_PROPERTY -> dispatchUserTaskProperty(signal, caseRow, mappingOpt.get());
+          // Story 4.3.1 AC10 — split USER_TASK_PROPERTY into USER_TASK_STATUS + USER_TASK_COMPLETE.
+          // Both inbound kinds dispatch through the same property-emission lookup; the rule's emits
+          // value distinguishes "drives status transition" (USER_TASK_STATUS) from
+          // "drives stage advance" (USER_TASK_COMPLETE).
+        case USER_TASK_STATUS, USER_TASK_COMPLETE ->
+            dispatchUserTaskProperty(signal, caseRow, mappingOpt.get());
         case OUTCOME ->
             // Phase-1 reservation per AC2.
             throw new WksMappingMissException(
@@ -133,7 +161,59 @@ public class BackendSignalRouter implements BackendSignalHandler {
     } catch (WksMappingMissException miss) {
       auditMiss(signal, caseRow, miss.getMessage());
       // AC4: caught at router boundary; do NOT propagate to the adapter.
+    } catch (RuntimeException other) {
+      // Story 4.3.1 AC4 — synchronous failure-audit emit BEFORE the rollback rethrow. Operator
+      // observability of failed dispatches (transaction rollback path) is the load-bearing
+      // contract advertised by Story 4.3 AC8. publishAfterCommit would never land if the outer
+      // transaction rolls back; we publish synchronously via {@code publish} so the audit row is
+      // visible irrespective of the engine's outcome. The exception is rethrown so the engine
+      // sees the failure and rolls its own state back.
+      Map<String, String> detail = new HashMap<>();
+      detail.put("originAdapter", signal.adapterName());
+      detail.put("reason", "dispatch failed: " + other.getClass().getSimpleName());
+      String exceptionCode = extractWksErrorCode(other);
+      log.atWarn()
+          .addKeyValue("wksErrorCode", exceptionCode == null ? "WKS-RTM-500" : exceptionCode)
+          .addKeyValue("originAdapter", signal.adapterName())
+          .addKeyValue("caseId", caseRow.id().toString())
+          .addKeyValue("kind", signal.kind().name())
+          .addKeyValue("signalSource", signal.source())
+          .log("backend signal dispatch failed — rolling back: {}", other.getMessage());
+      eventPublisher.publish(
+          new BackendSignalRouted(
+              caseRow.id(),
+              caseRow.caseTypeId(),
+              caseTypeVersion,
+              signal.kind(),
+              signal.source(),
+              new AuditSource.Backend(signal.adapterName()),
+              exceptionCode == null ? "WKS-RTM-500" : exceptionCode,
+              detail,
+              clock.now()));
+      throw other;
     }
+  }
+
+  /**
+   * Best-effort extraction of a WKS error code from a domain exception. Domain exceptions in the
+   * stage band ({@code WksStageException}) and friends carry a wire-string code field; we look it
+   * up reflectively via a no-arg {@code wksErrorCode()} or {@code errorCode()} accessor so the
+   * router stays decoupled from each domain exception class. Returns {@code null} when no code
+   * surface is available — the caller defaults to {@code WKS-RTM-500}.
+   */
+  private static String extractWksErrorCode(RuntimeException ex) {
+    for (String name : new String[] {"errorCode", "wksErrorCode", "code"}) {
+      try {
+        var m = ex.getClass().getMethod(name);
+        Object v = m.invoke(ex);
+        if (v != null) {
+          return v.toString();
+        }
+      } catch (ReflectiveOperationException ignored) {
+        // try next accessor name
+      }
+    }
+    return null;
   }
 
   // ---- per-kind dispatch -------------------------------------------------
@@ -186,10 +266,11 @@ public class BackendSignalRouter implements BackendSignalHandler {
                         "no property rule for on='" + onKey + "'"));
 
     // D22 clarification of Story 2.9 ambiguity — userTask property emission is restricted to
-    // status transitions within a stage. Only USER_TASK_PROPERTY emissions drive status writes;
-    // any rule whose emits is not USER_TASK_PROPERTY is treated as a stage transition attempt and
-    // rejected.
-    if (rule.emits() != BackendSignalKind.USER_TASK_PROPERTY) {
+    // status transitions within a stage. Only USER_TASK_STATUS / USER_TASK_COMPLETE emissions are
+    // valid (Story 4.3.1 AC10 split); any rule whose emits is a stage-transition kind (END_EVENT,
+    // NAMED_SIGNAL, OUTCOME) is treated as a stage transition attempt and rejected.
+    if (rule.emits() != BackendSignalKind.USER_TASK_STATUS
+        && rule.emits() != BackendSignalKind.USER_TASK_COMPLETE) {
       throw new WksMappingMissException(
           signal.adapterName(),
           signal.caseInstance().id(),
@@ -249,13 +330,21 @@ public class BackendSignalRouter implements BackendSignalHandler {
       detail.put("reason", reason);
     }
     log.atWarn()
-        .addKeyValue("wksErrorCode", "WKS-MAP-404")
+        .addKeyValue("wksErrorCode", ErrorCode.WKS_MAP_404.wire())
         .addKeyValue("originAdapter", signal.adapterName())
         .addKeyValue("caseId", signal.caseInstance().id().toString())
         .addKeyValue("kind", signal.kind().name())
         .addKeyValue("signalSource", signal.source())
         .log("backend signal unmapped: {}", reason);
-    publish(signal, caseRow, new AuditSource.Backend("unmapped"), "WKS-MAP-404", detail);
+    // Story 4.3.1 AC6 — un-spoofable miss-sentinel via AuditSource.BackendUnmapped. An adapter
+    // named "unmapped" cannot collide with the miss audit string because the sub-record renders
+    // distinctly as backend(unmapped:<originAdapter>).
+    publish(
+        signal,
+        caseRow,
+        new AuditSource.BackendUnmapped(signal.adapterName()),
+        ErrorCode.WKS_MAP_404.wire(),
+        detail);
   }
 
   private void publish(

--- a/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
@@ -115,7 +115,17 @@ public class ConfigService {
     if (reg.outcome() == RegistrationResult.Outcome.REJECTED_OLDER_VERSION) {
       return ValidationResult.invalid(reg.errors());
     }
-    ValidationResult versionedResult = ValidationResult.ok(versioned, result.warnings());
+    // Story 4.3.1 AC1 — preserve the original ValidationResult's MappingDefinition through the
+    // registry-binding rebuild. The 2-arg ValidationResult.ok(versioned, warnings) overload
+    // hardcodes Optional.empty() for mappingDefinition, so publishMappingToRegistry would
+    // register MappingDefinition.empty() under (caseTypeId, registryVersion) — every backend
+    // signal would then hit WKS-MAP-404 in production despite tests passing. Use the 3-arg
+    // overload that threads result.mappingDefinition() forward.
+    ValidationResult versionedResult =
+        ValidationResult.ok(
+            versioned,
+            result.warnings(),
+            result.mappingDefinition().orElse(MappingDefinition.empty()));
     publishMappingToRegistry(versionedResult);
     return versionedResult;
   }
@@ -145,8 +155,14 @@ public class ConfigService {
     // ConfigDeployed event and any post-validate logging see the registry-authoritative version.
     // Story 4.3 — publishMappingToRegistry runs against the same versioned result so the
     // (caseTypeId, version) key in MappingRegistry matches what the in-memory CaseTypeRegistry
-    // advertises.
-    ValidationResult versionedResult = ValidationResult.ok(versioned, result.warnings());
+    // advertises. Story 4.3.1 AC1 — thread result.mappingDefinition() through the rebuild so the
+    // validated MappingDefinition reaches MappingRegistry.register; the 2-arg ok() overload would
+    // silently downgrade to MappingDefinition.empty().
+    ValidationResult versionedResult =
+        ValidationResult.ok(
+            versioned,
+            result.warnings(),
+            result.mappingDefinition().orElse(MappingDefinition.empty()));
     publishMappingToRegistry(versionedResult);
     return versionedResult;
   }
@@ -210,7 +226,19 @@ public class ConfigService {
       if (reg.outcome() == RegistrationResult.Outcome.REJECTED_OLDER_VERSION) {
         return DeployResult.invalid(reg.errors());
       }
-      publishMappingToRegistry(yamlResult);
+      // Story 4.3.1 AC2 — register MappingRegistry under the registry-assigned version, NOT the
+      // author-supplied version carried by yamlResult.config(). When the version registry assigns
+      // version=1 (idempotent first-deploy or hash-mismatch override) but the YAML declared
+      // version=5, the original yamlResult would key the mapping under version "5" while the
+      // CaseTypeRegistry advertises "1" to CaseService.create — every signal would WKS-MAP-404.
+      // Rebuild the ValidationResult around the version-overridden caseType, preserving
+      // mappingDefinition + warnings.
+      ValidationResult versionedYamlResult =
+          ValidationResult.ok(
+              caseType,
+              yamlResult.warnings(),
+              yamlResult.mappingDefinition().orElse(MappingDefinition.empty()));
+      publishMappingToRegistry(versionedYamlResult);
 
       try {
         deployment =

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeYamlLoader.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeYamlLoader.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.type.LogicalType;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -41,7 +42,14 @@ public class CaseTypeYamlLoader {
         YAMLMapper.builder()
             .addModule(new JavaTimeModule())
             .addModule(new ParameterNamesModule())
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            // Story 4.3.1 AC8 — enable strict unknown-property failure at the mapper level. The
+            // top-level transport record ({@link RawCaseTypeConfig}) keeps {@code
+            // @JsonIgnoreProperties(ignoreUnknown = true)} so future case-type-level keys ship
+            // forward-compat; mapping subtree records (RawAttachment, RawAttachmentMap,
+            // RawUserTaskMapping, RawEventMappings, RawEndEventMapping, RawSignalMapping,
+            // RawPropertyEmissionRule, RawEmits) drop the annotation so unknown keys surface as
+            // {@code WKS-MAP-008}. Scoped — does NOT flip the global Jackson ObjectMapper.
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .disable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
             .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
             .build();
@@ -123,10 +131,42 @@ public class CaseTypeYamlLoader {
                 ErrorCode.WKS_CFG_099.wire(),
                 "case-type files must contain exactly one YAML document"));
       }
-    } catch (IOException e) {
+    } catch (UnrecognizedPropertyException upe) {
+      // Story 4.3.1 AC8 — unknown YAML key (typo). Surface with a Mapping-namespaced wire code so
+      // operators can grep WKS-MAP-008 and locate the offending key + JSON pointer.
+      String pointer = jsonPointerOf(upe);
+      String key = upe.getPropertyName() == null ? "<unknown>" : upe.getPropertyName();
       return RawReadResult.error(
           source,
-          ErrorDetail.of(ErrorCode.WKS_CFG_099.wire(), "YAML parse error: " + e.getMessage()));
+          ErrorDetail.ofField(
+              ErrorCode.WKS_MAP_008.wire(),
+              "Unknown YAML key '" + key + "' in " + source,
+              pointer));
+    } catch (IOException e) {
+      // Story 4.3.1 AC9 — STRICT_DUPLICATE_DETECTION raises a JsonMappingException whose message
+      // contains "Duplicate field". Surface as WKS-MAP-009 ONLY when the duplicate falls inside
+      // the mapping subtree (attachments[]) — top-level duplicates remain WKS-CFG-099 to preserve
+      // the wire contract pinned by ConfigValidatorTest.wksCfg099_duplicateTopLevelKey.
+      String msg = e.getMessage();
+      if (msg != null && msg.contains("Duplicate field")) {
+        boolean inMappingSubtree = false;
+        if (e instanceof com.fasterxml.jackson.databind.JsonMappingException jme) {
+          for (var ref : jme.getPath()) {
+            if (ref.getFieldName() != null && ref.getFieldName().equals("attachments")) {
+              inMappingSubtree = true;
+              break;
+            }
+          }
+        }
+        if (inMappingSubtree) {
+          return RawReadResult.error(
+              source,
+              ErrorDetail.of(
+                  ErrorCode.WKS_MAP_009.wire(), "Duplicate YAML key in " + source + ": " + msg));
+        }
+      }
+      return RawReadResult.error(
+          source, ErrorDetail.of(ErrorCode.WKS_CFG_099.wire(), "YAML parse error: " + msg));
     }
     if (raw == null) {
       return RawReadResult.error(
@@ -140,6 +180,28 @@ public class CaseTypeYamlLoader {
       index = YamlLineIndex.empty();
     }
     return RawReadResult.ok(source, raw, index);
+  }
+
+  /**
+   * Build a JSON-pointer-style locator from a Jackson {@link UnrecognizedPropertyException}'s
+   * property path. {@code "/attachments/0/map/events/signl"} when the path traverses {@code
+   * attachments[0].map.events.signl}.
+   */
+  private static String jsonPointerOf(UnrecognizedPropertyException upe) {
+    StringBuilder sb = new StringBuilder();
+    if (upe.getPath() != null) {
+      for (var ref : upe.getPath()) {
+        if (ref.getFieldName() != null) {
+          sb.append('/').append(ref.getFieldName());
+        } else if (ref.getIndex() >= 0) {
+          sb.append('/').append(ref.getIndex());
+        }
+      }
+    }
+    if (upe.getPropertyName() != null) {
+      sb.append('/').append(upe.getPropertyName());
+    }
+    return sb.length() == 0 ? "/" : sb.toString();
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/MappingValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/MappingValidator.java
@@ -367,6 +367,12 @@ public class MappingValidator {
         }
       }
 
+      // Story 4.3.1 AC3 — WKS-MAP-002 precedence-collision detection. Two rules from DIFFERENT
+      // BackendSignalKinds that target the same `(stage, status)` (modelled via the stageTransition
+      // tuple `<from> -> <to>`) without explicit precedence are disallowed at deploy time. Phase-0
+      // has no precedence vocabulary; Phase-1 may introduce one. The runtime contract documented at
+      // BackendSignalRouter.java:38-41 advertises this code; here is its emission site.
+      detectPrecedenceCollisions(endEventOut, signalsOut, errors, base);
       // Build the AttachmentDefinition only when type/file/scope are non-blank — otherwise the
       // record's invariants would throw NPE. We still keep collecting errors for fields that did
       // pass.
@@ -383,6 +389,54 @@ public class MappingValidator {
     }
 
     return new Result(new MappingDefinition(definitions), List.copyOf(errors));
+  }
+
+  /**
+   * Story 4.3.1 AC3 — emit {@code WKS-MAP-002} when an endEvent rule and a signal rule target the
+   * same stage transition (same {@code from -> to} tuple). These represent two rules from different
+   * {@link BackendSignalKind}s ({@link BackendSignalKind#END_EVENT} vs {@link
+   * BackendSignalKind#NAMED_SIGNAL}) competing for the same effect; Phase-0 disallows the ambiguity
+   * outright (no precedence vocabulary). Last-wins on rule ordering would be a worst-class silent
+   * bug.
+   */
+  private void detectPrecedenceCollisions(
+      Optional<EndEventMapping> endEventOut,
+      Map<String, SignalMapping> signalsOut,
+      List<ErrorDetail> errors,
+      String base) {
+    if (endEventOut.isEmpty() || signalsOut.isEmpty()) {
+      return;
+    }
+    String endTransition = normaliseTransition(endEventOut.get().stageTransition());
+    if (endTransition == null) {
+      return;
+    }
+    for (var sig : signalsOut.entrySet()) {
+      String sigTransition = normaliseTransition(sig.getValue().stageTransition());
+      if (sigTransition != null && sigTransition.equals(endTransition)) {
+        errors.add(
+            ErrorDetail.ofField(
+                ErrorCode.WKS_MAP_002.wire(),
+                "endEvent and signal '"
+                    + sig.getKey()
+                    + "' both target stageTransition '"
+                    + endEventOut.get().stageTransition()
+                    + "' — Phase-0 disallows two BackendSignalKind rules targeting the"
+                    + " same (stage, status) without explicit precedence",
+                base + "/map/events/signal/" + sig.getKey() + "/stageTransition"));
+      }
+    }
+  }
+
+  private static String normaliseTransition(String spec) {
+    if (spec == null || spec.isBlank()) {
+      return null;
+    }
+    var m = STAGE_TRANSITION.matcher(spec);
+    if (!m.matches()) {
+      return null;
+    }
+    return m.group(1) + "->" + m.group(2);
   }
 
   private boolean checkStageTransition(
@@ -426,10 +480,10 @@ public class MappingValidator {
       return null;
     }
     return switch (wire) {
-      case "status" -> BackendSignalKind.USER_TASK_PROPERTY;
+      case "status" -> BackendSignalKind.USER_TASK_STATUS;
       case "named-signal" -> BackendSignalKind.NAMED_SIGNAL;
       case "outcome" -> BackendSignalKind.OUTCOME;
-      case "task-complete" -> BackendSignalKind.USER_TASK_PROPERTY;
+      case "task-complete" -> BackendSignalKind.USER_TASK_COMPLETE;
       default -> {
         errors.add(
             ErrorDetail.ofField(

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -150,45 +150,43 @@ public record RawCaseTypeConfig(
   // Story 4.2 — attachments + mapping (architecture §790–809)
   // ---------------------------------------------------------------------------------------------
 
+  // Story 4.3.1 AC8 — mapping subtree records intentionally OMIT
+  // @JsonIgnoreProperties(ignoreUnknown = true) so unknown YAML keys (typos like
+  // events.signl: or emits: { typ: status }) surface as WKS-MAP-008 instead of being silently
+  // dropped. The top-level RawCaseTypeConfig keeps the annotation for forward-compat with future
+  // case-type-level keys; only the mapping block enforces strict schema.
+
   /** One {@code attachments[]} entry. */
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawAttachment(String type, String file, String scope, RawAttachmentMap map) {}
 
   /** {@code map: { userTasks, events, properties }} block inside an attachment. */
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawAttachmentMap(
       Map<String, RawUserTaskMapping> userTasks,
       RawEventMappings events,
       List<RawPropertyEmissionRule> properties) {}
 
   /** {@code map.userTasks.<id>} entry. */
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawUserTaskMapping(String wksTask, String form) {}
 
   /** {@code map.events: { endEvent, signal }} block. */
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawEventMappings(
       RawEndEventMapping endEvent, Map<String, RawSignalMapping> signal) {}
 
   /** {@code map.events.endEvent} entry. */
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawEndEventMapping(String stageTransition) {}
 
   /** {@code map.events.signal.<id>} entry. */
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawSignalMapping(String stageTransition) {}
 
   /**
    * {@code map.properties[]} entry. The YAML key {@code camunda:property} is colon-bearing; Jackson
    * needs an explicit {@link JsonProperty} alias.
    */
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawPropertyEmissionRule(
       @JsonProperty("on") String on,
       @JsonProperty("camunda:property") String camundaProperty,
       RawEmits emits) {}
 
   /** {@code emits: { type, scope }} block inside a property emission rule. */
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawEmits(String type, String scope) {}
 }

--- a/backend/src/test/java/com/wkspower/platform/architecture/BackendAdapterPortIsolationTest.java
+++ b/backend/src/test/java/com/wkspower/platform/architecture/BackendAdapterPortIsolationTest.java
@@ -2,9 +2,15 @@ package com.wkspower.platform.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -69,6 +75,137 @@ class BackendAdapterPortIsolationTest {
                 + "would silently break the single-routing-surface guarantee — adding one "
                 + "requires a deliberate edit of this test, surfacing the change to reviewers.")
         .check(CLASSES);
+  }
+
+  /**
+   * Story 4.3.1 AC7 — extend the single-subscriber rule to non-direct-call discovery vectors:
+   *
+   * <ul>
+   *   <li>{@code ApplicationContext.getBeansOfType(BackendSignalHandler.class)} — Spring lookup
+   *   <li>{@code @Autowired List<BackendSignalHandler>} — collection injection (broadcasts to all)
+   *   <li>{@code Method.invoke(...)} on a {@code BackendSignalHandler} method — reflective dispatch
+   * </ul>
+   *
+   * <p>The original rule only catches direct bytecode method calls; an attacker (or a well-meaning
+   * dev adding metrics) could circumvent it via any of the three above. Each surfaces a Story 4.3.1
+   * AC7 violation in the build.
+   */
+  @Test
+  void backendSignalHandlerHasNoIndirectSubscribers() {
+    String handlerFqn = "com.wkspower.platform.domain.port.BackendSignalHandler";
+    String routerFqn = "com.wkspower.platform.domain.service.BackendSignalRouter";
+    String binderFqn = "com.wkspower.platform.domain.service.BackendAdapterBinder";
+
+    ArchCondition<JavaClass> noBeansOfType =
+        new ArchCondition<>("not call ApplicationContext.getBeansOfType(BackendSignalHandler)") {
+          @Override
+          public void check(JavaClass clazz, ConditionEvents events) {
+            if (clazz.getFullName().equals(routerFqn) || clazz.getFullName().equals(binderFqn)) {
+              return;
+            }
+            for (JavaMethodCall call : clazz.getMethodCallsFromSelf()) {
+              String tgt = call.getTarget().getFullName();
+              if ((tgt.contains("ApplicationContext.getBeansOfType")
+                      || tgt.contains("ListableBeanFactory.getBeansOfType")
+                      || tgt.contains("BeanFactory.getBeansOfType"))
+                  && callMentionsHandler(call, handlerFqn)) {
+                events.add(
+                    SimpleConditionEvent.violated(
+                        clazz,
+                        clazz.getFullName()
+                            + " calls getBeansOfType(BackendSignalHandler.class) — Story 4.3.1 AC7"
+                            + " forbids non-direct-call subscribers to the single-routing surface"));
+              }
+            }
+          }
+        };
+
+    ArchCondition<JavaClass> noListInjection =
+        new ArchCondition<>("not declare a field of type List<BackendSignalHandler>") {
+          @Override
+          public void check(JavaClass clazz, ConditionEvents events) {
+            if (clazz.getFullName().equals(routerFqn) || clazz.getFullName().equals(binderFqn)) {
+              return;
+            }
+            for (JavaField field : clazz.getFields()) {
+              String desc = field.getDescriptor();
+              // Generic erasure loses the type-parameter; signature carries it.
+              String sig = field.getDescriptor() == null ? "" : field.getDescriptor();
+              // Best-effort: any field whose erased type is List/Collection/Set AND whose
+              // declaring source mentions BackendSignalHandler in the field name OR the
+              // generic-signature attribute (which JavaClass exposes via the raw descriptor).
+              boolean isCollection =
+                  desc != null
+                      && (desc.contains("Ljava/util/List;")
+                          || desc.contains("Ljava/util/Collection;")
+                          || desc.contains("Ljava/util/Set;"));
+              if (isCollection
+                  && (field.getName().toLowerCase().contains("backendsignalhandler")
+                      || field.getName().toLowerCase().contains("signalhandler")
+                      || sig.contains("BackendSignalHandler"))) {
+                events.add(
+                    SimpleConditionEvent.violated(
+                        field,
+                        clazz.getFullName()
+                            + "."
+                            + field.getName()
+                            + " appears to be a List<BackendSignalHandler> collection injection —"
+                            + " Story 4.3.1 AC7 forbids broadcast subscribers to the single"
+                            + " routing surface"));
+              }
+            }
+          }
+        };
+
+    ArchCondition<JavaClass> noReflectiveInvoke =
+        new ArchCondition<>("not call Method.invoke on BackendSignalHandler methods") {
+          @Override
+          public void check(JavaClass clazz, ConditionEvents events) {
+            if (clazz.getFullName().equals(routerFqn) || clazz.getFullName().equals(binderFqn)) {
+              return;
+            }
+            // Conservative heuristic: any class that BOTH (a) imports BackendSignalHandler AND
+            // (b) calls java.lang.reflect.Method.invoke is suspect. We can't statically prove the
+            // invoke target is the handler method, so we report the suspicious combination and
+            // let reviewers check.
+            boolean importsHandler =
+                clazz.getDirectDependenciesFromSelf().stream()
+                    .anyMatch(d -> d.getTargetClass().getFullName().equals(handlerFqn));
+            if (!importsHandler) {
+              return;
+            }
+            for (JavaMethodCall call : clazz.getMethodCallsFromSelf()) {
+              if (call.getTarget().getFullName().equals("java.lang.reflect.Method.invoke")) {
+                events.add(
+                    SimpleConditionEvent.violated(
+                        clazz,
+                        clazz.getFullName()
+                            + " imports BackendSignalHandler AND calls Method.invoke — Story"
+                            + " 4.3.1 AC7 forbids reflective dispatch to the single routing"
+                            + " surface; review for non-direct-call subscriber pattern"));
+              }
+            }
+          }
+        };
+
+    noClasses()
+        .that()
+        .resideInAPackage("com.wkspower.platform..")
+        .should(noBeansOfType)
+        .andShould(noListInjection)
+        .andShould(noReflectiveInvoke)
+        .because(
+            "Story 4.3.1 AC7: the single-subscriber invariant must catch indirect subscriber"
+                + " patterns — getBeansOfType, List<BackendSignalHandler> collection injection,"
+                + " and reflective Method.invoke — not just direct bytecode calls. Adding any"
+                + " such pattern requires a deliberate edit of this test.")
+        .check(CLASSES);
+  }
+
+  private static boolean callMentionsHandler(JavaMethodCall call, String handlerFqn) {
+    return call.getTarget().getRawParameterTypes().stream()
+            .anyMatch(t -> t.getFullName().contains("BackendSignalHandler"))
+        || call.getTarget().getFullName().contains("BackendSignalHandler");
   }
 
   @Test

--- a/backend/src/test/java/com/wkspower/platform/domain/config/model/MappingDefinitionTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/config/model/MappingDefinitionTest.java
@@ -53,8 +53,8 @@ class MappingDefinitionTest {
   void backendSignalKindIsReusedForPropertyEmission() {
     PropertyEmissionRule rule =
         new PropertyEmissionRule(
-            "userTask:t1", "status", BackendSignalKind.USER_TASK_PROPERTY, "stage:underwriting");
-    assertThat(rule.emits()).isEqualTo(BackendSignalKind.USER_TASK_PROPERTY);
+            "userTask:t1", "status", BackendSignalKind.USER_TASK_STATUS, "stage:underwriting");
+    assertThat(rule.emits()).isEqualTo(BackendSignalKind.USER_TASK_STATUS);
     assertThat(rule.emitScope()).isEqualTo("stage:underwriting");
   }
 

--- a/backend/src/test/java/com/wkspower/platform/domain/model/AuditSourceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/model/AuditSourceTest.java
@@ -37,11 +37,23 @@ class AuditSourceTest {
   }
 
   @Test
-  void backendUnmappedAdapterRendersExactly() {
-    // The router uses adapterName "unmapped" when no rule matches — pin that exact wire string.
-    AuditSource source = new AuditSource.Backend("unmapped");
+  void backendUnmappedSentinelRendersUnspoofably() {
+    // Story 4.3.1 AC6 — miss-sentinel uses the BackendUnmapped sub-record. Real adapters with
+    // adapterName="unmapped" render as backend(unmapped); the miss sentinel renders distinguishably
+    // as backend(unmapped:<originAdapter>) so the audit string is never collidable.
+    AuditSource collidingRealAdapter = new AuditSource.Backend("unmapped");
+    AuditSource missSentinel = new AuditSource.BackendUnmapped("unmapped");
 
-    assertThat(source.toString()).isEqualTo("backend(unmapped)");
+    assertThat(collidingRealAdapter.toString()).isEqualTo("backend(unmapped)");
+    assertThat(missSentinel.toString()).isEqualTo("backend(unmapped:unmapped)");
+    assertThat(missSentinel.toString()).isNotEqualTo(collidingRealAdapter.toString());
+  }
+
+  @Test
+  void backendUnmappedCarriesOriginAdapter() {
+    AuditSource missSentinel = new AuditSource.BackendUnmapped("bpmn");
+
+    assertThat(missSentinel.toString()).isEqualTo("backend(unmapped:bpmn)");
   }
 
   @Test
@@ -50,6 +62,8 @@ class AuditSourceTest {
     assertThatThrownBy(() -> new AuditSource.AutoRule(null))
         .isInstanceOf(NullPointerException.class);
     assertThatThrownBy(() -> new AuditSource.Backend(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new AuditSource.BackendUnmapped(null))
         .isInstanceOf(NullPointerException.class);
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/domain/port/BackendAdapterComplianceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/port/BackendAdapterComplianceTest.java
@@ -160,7 +160,8 @@ public abstract class BackendAdapterComplianceTest {
         EnumSet.of(
             BackendSignalKind.END_EVENT,
             BackendSignalKind.NAMED_SIGNAL,
-            BackendSignalKind.USER_TASK_PROPERTY,
+            BackendSignalKind.USER_TASK_STATUS,
+            BackendSignalKind.USER_TASK_COMPLETE,
             BackendSignalKind.OUTCOME);
     assertThat(kinds).allMatch(declared::contains);
   }

--- a/backend/src/test/java/com/wkspower/platform/domain/service/BackendSignalRouterIT.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/BackendSignalRouterIT.java
@@ -213,12 +213,12 @@ class BackendSignalRouterIT {
                     new PropertyEmissionRule(
                         "userTask:review",
                         "status",
-                        BackendSignalKind.USER_TASK_PROPERTY,
+                        BackendSignalKind.USER_TASK_STATUS,
                         "stage:stage1")))));
 
     fake.emit(
         new BackendSignal(
-            BackendSignalKind.USER_TASK_PROPERTY,
+            BackendSignalKind.USER_TASK_STATUS,
             ADAPTER_NAME,
             new CaseInstanceRef(caseRow.id(), caseType),
             "review",
@@ -232,7 +232,7 @@ class BackendSignalRouterIT {
         .satisfies(
             e -> {
               assertThat(e.source().toString()).isEqualTo("backend(fake)");
-              assertThat(e.kind()).isEqualTo(BackendSignalKind.USER_TASK_PROPERTY);
+              assertThat(e.kind()).isEqualTo(BackendSignalKind.USER_TASK_STATUS);
             });
   }
 
@@ -265,7 +265,7 @@ class BackendSignalRouterIT {
 
     fake.emit(
         new BackendSignal(
-            BackendSignalKind.USER_TASK_PROPERTY,
+            BackendSignalKind.USER_TASK_STATUS,
             ADAPTER_NAME,
             new CaseInstanceRef(caseRow.id(), caseType),
             "review",
@@ -280,7 +280,7 @@ class BackendSignalRouterIT {
         .satisfies(
             e -> {
               assertThat(e.errorCode()).isEqualTo("WKS-MAP-404");
-              assertThat(e.source().toString()).isEqualTo("backend(unmapped)");
+              assertThat(e.source().toString()).isEqualTo("backend(unmapped:fake)");
               assertThat(e.detail()).containsEntry("originAdapter", ADAPTER_NAME);
             });
   }
@@ -322,7 +322,7 @@ class BackendSignalRouterIT {
         .satisfies(
             e -> {
               assertThat(e.errorCode()).isEqualTo("WKS-MAP-404");
-              assertThat(e.source().toString()).isEqualTo("backend(unmapped)");
+              assertThat(e.source().toString()).isEqualTo("backend(unmapped:fake)");
               assertThat(e.detail()).containsEntry("originAdapter", ADAPTER_NAME);
             });
   }
@@ -375,13 +375,13 @@ class BackendSignalRouterIT {
                     new PropertyEmissionRule(
                         "userTask:review",
                         "status",
-                        BackendSignalKind.USER_TASK_PROPERTY,
+                        BackendSignalKind.USER_TASK_STATUS,
                         "stage:stage1")))));
 
     // First: status change. Second: stage advance.
     fake.emit(
         new BackendSignal(
-            BackendSignalKind.USER_TASK_PROPERTY,
+            BackendSignalKind.USER_TASK_STATUS,
             ADAPTER_NAME,
             new CaseInstanceRef(caseRow.id(), caseType),
             "review",
@@ -399,7 +399,7 @@ class BackendSignalRouterIT {
     assertThat(after.status()).isEqualTo("approved");
     assertThat(after.currentStageId()).isEqualTo("stage2");
     assertThat(events.routed()).hasSize(2);
-    assertThat(events.routed().get(0).kind()).isEqualTo(BackendSignalKind.USER_TASK_PROPERTY);
+    assertThat(events.routed().get(0).kind()).isEqualTo(BackendSignalKind.USER_TASK_STATUS);
     assertThat(events.routed().get(1).kind()).isEqualTo(BackendSignalKind.END_EVENT);
   }
 
@@ -495,10 +495,51 @@ class BackendSignalRouterIT {
 
     Case after = caseRepository.findById(caseRow.id()).orElseThrow();
     assertThat(after.currentStageId()).isEqualTo("stage1");
-    // No success audit; only failure audit if propagated, but per AC8 only WksMappingMiss is
-    // caught. The router does not emit BackendSignalRouted on uncaught exceptions — that's the
-    // engine's territory. Assert no success-audit was published.
-    assertThat(events.routed()).noneMatch(e -> e.errorCode() == null);
+    // Story 4.3.1 AC4 — the router now emits a synchronous failure-audit BEFORE the rollback
+    // rethrow. Operators must see a BackendSignalRouted event with errorCode set (the WKS code
+    // from the underlying domain exception, or WKS-RTM-500 fallback) and source =
+    // backend(<adapter>).
+    assertThat(events.routed())
+        .singleElement()
+        .satisfies(
+            e -> {
+              assertThat(e.errorCode()).isNotNull();
+              assertThat(e.errorCode()).isNotEqualTo("WKS-MAP-404");
+              assertThat(e.source().toString()).isEqualTo("backend(fake)");
+              assertThat(e.detail()).containsEntry("originAdapter", ADAPTER_NAME);
+              assertThat(e.detail()).containsKey("reason");
+            });
+  }
+
+  // ---------- Story 4.3.1 AC5 — case-not-found emits WKS-MAP-405 audit row -----
+
+  @Test
+  void caseNotFoundEmitsMap405AuditRow() {
+    // No case is created — caseRepository.findById returns empty. The router must publish a
+    // BackendSignalRouted with errorCode = WKS-MAP-405 and source = backend(<adapter>).
+    UUID phantomCaseId = UUID.randomUUID();
+    CaseTypeRef caseType = new CaseTypeRef("phantom-ct", "1");
+    fake.attach(caseType, AttachmentScope.ofCase());
+
+    fake.emit(
+        new BackendSignal(
+            BackendSignalKind.END_EVENT,
+            ADAPTER_NAME,
+            new CaseInstanceRef(phantomCaseId, caseType),
+            "end_1",
+            Map.of()));
+    flushClear();
+
+    assertThat(events.routed())
+        .singleElement()
+        .satisfies(
+            e -> {
+              assertThat(e.errorCode()).isEqualTo("WKS-MAP-405");
+              assertThat(e.caseId()).isEqualTo(phantomCaseId);
+              assertThat(e.source().toString()).isEqualTo("backend(fake)");
+              assertThat(e.detail()).containsEntry("originAdapter", ADAPTER_NAME);
+              assertThat(e.detail()).containsKey("reason");
+            });
   }
 
   // ---------- helpers ----------------------------------------------------

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceMappingRegistryTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceMappingRegistryTest.java
@@ -1,0 +1,281 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.DeployResult;
+import com.wkspower.platform.domain.config.RegistrationResult;
+import com.wkspower.platform.domain.config.ValidationResult;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition.EndEventMapping;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.domain.port.BpmnValidationService;
+import com.wkspower.platform.domain.port.CaseTypeReader;
+import com.wkspower.platform.domain.port.CaseTypeRef;
+import com.wkspower.platform.domain.port.CaseTypeRegistrar;
+import com.wkspower.platform.domain.port.CaseTypeSource;
+import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.WorkflowEngine;
+import com.wkspower.platform.domain.workflow.BpmnValidationResult;
+import com.wkspower.platform.domain.workflow.DeploymentInfo;
+import com.wkspower.platform.domain.workflow.DeploymentRequest;
+import com.wkspower.platform.domain.workflow.DeploymentResult;
+import com.wkspower.platform.testsupport.FakeCaseTypeVersionRegistry;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 4.3.1 AC1 + AC2 — pin the C1 fix from the Sprint 1-3 retroactive code review. {@link
+ * ConfigService#validateAndRegister(String, byte[], String)} (startup-loader path) and {@link
+ * ConfigService#deploy(byte[], byte[], String)} (admin-deploy path) must both register the
+ * validated {@link MappingDefinition} into {@link MappingRegistry} keyed by the registry-overridden
+ * {@code (caseTypeId, version)} — not the empty mapping the 2-arg {@code
+ * ValidationResult.ok(versioned, warnings)} overload silently produces, and not the author-supplied
+ * version that {@code yamlResult.config()} carries before the version-registry override.
+ */
+class ConfigServiceMappingRegistryTest {
+
+  private static final byte[] YAML_BYTES = "id: app".getBytes();
+  private static final byte[] BPMN_BYTES = "<bpmn/>".getBytes();
+
+  // ---------- AC1 — startup-loader path ----------
+
+  @Test
+  void validateAndRegisterPreservesMappingDefinitionThroughRegistryRebuild() {
+    CaseTypeConfig cfg = caseType(1);
+    MappingDefinition mapping =
+        new MappingDefinition(
+            List.of(
+                new AttachmentDefinition(
+                    "bpmn",
+                    "x.bpmn",
+                    "case",
+                    Optional.empty(),
+                    Map.of(),
+                    Optional.of(new EndEventMapping("stage1 -> stage2")),
+                    Map.of(),
+                    List.of())));
+    ValidationResult validatorOutput = ValidationResult.ok(cfg, List.of(), mapping);
+    StubSource source = new StubSource(validatorOutput);
+    StubRegistrar registrar = new StubRegistrar();
+    MappingRegistry mappingRegistry = new MappingRegistry();
+    ConfigService svc =
+        new ConfigService(
+            source,
+            registrar,
+            new StubReader(),
+            new StubBpmn(BpmnValidationResult.ok("noop")),
+            new StubEngine(),
+            new RecordingPublisher(),
+            new FakeCaseTypeVersionRegistry(),
+            mappingRegistry);
+
+    svc.validateAndRegister("app.yaml", YAML_BYTES);
+
+    Optional<MappingDefinition> resolved =
+        mappingRegistry.resolve(new CaseTypeRef(cfg.id(), "1"), "1");
+    assertThat(resolved)
+        .as("AC1: MappingRegistry must hold the validated mapping, not empty()")
+        .isPresent();
+    assertThat(resolved.get().attachments()).hasSize(1);
+    assertThat(resolved.get().attachments().get(0).endEventMapping())
+        .isPresent()
+        .get()
+        .extracting(EndEventMapping::stageTransition)
+        .isEqualTo("stage1 -> stage2");
+  }
+
+  // ---------- AC2 — admin-deploy path with version override ----------
+
+  @Test
+  void deployRegistersMappingUnderRegistryAssignedVersionNotAuthorVersion() {
+    // Author declares version=5, but the version registry assigns version=1 (first deploy).
+    CaseTypeConfig authorCfg = caseType(5);
+    MappingDefinition mapping =
+        new MappingDefinition(
+            List.of(
+                new AttachmentDefinition(
+                    "bpmn",
+                    "x.bpmn",
+                    "case",
+                    Optional.empty(),
+                    Map.of(),
+                    Optional.of(new EndEventMapping("stage1 -> stage2")),
+                    Map.of(),
+                    List.of())));
+    ValidationResult validatorOutput = ValidationResult.ok(authorCfg, List.of(), mapping);
+    StubSource source = new StubSource(validatorOutput);
+    StubRegistrar registrar = new StubRegistrar();
+    MappingRegistry mappingRegistry = new MappingRegistry();
+    ConfigService svc =
+        new ConfigService(
+            source,
+            registrar,
+            new StubReader(),
+            new StubBpmn(BpmnValidationResult.ok("appProc")),
+            new StubEngine(),
+            new RecordingPublisher(),
+            new FakeCaseTypeVersionRegistry(),
+            mappingRegistry);
+
+    DeployResult result = svc.deploy(YAML_BYTES, BPMN_BYTES, "ops@x");
+
+    assertThat(result.isInvalid()).isFalse();
+    // The caseType returned to callers carries version=1 (registry override).
+    assertThat(result.caseType()).isPresent();
+    assertThat(result.caseType().get().version()).isEqualTo(1);
+
+    // AC2 — MappingRegistry MUST be keyed by version "1" (registry-assigned), not "5" (author).
+    assertThat(mappingRegistry.resolve(new CaseTypeRef(authorCfg.id(), "1"), "1"))
+        .as("AC2: mapping registered under registry-assigned version 1")
+        .isPresent();
+    assertThat(mappingRegistry.resolve(new CaseTypeRef(authorCfg.id(), "5"), "5"))
+        .as("AC2: must NOT be registered under the author-supplied version 5")
+        .isEmpty();
+  }
+
+  // ---------- helpers ----------
+
+  private static CaseTypeConfig caseType(int version) {
+    return new CaseTypeConfig(
+        "app",
+        "App",
+        version,
+        null,
+        new WorkflowRef("app.bpmn"),
+        List.<FieldDefinition>of(),
+        List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+        List.of(),
+        List.of(new RoleDefinition("admin", List.of())));
+  }
+
+  private static final class StubSource implements CaseTypeSource {
+    private final ValidationResult result;
+
+    StubSource(ValidationResult result) {
+      this.result = result;
+    }
+
+    @Override
+    public ValidationResult load(Path file) {
+      return result;
+    }
+
+    @Override
+    public ValidationResult loadBytes(String s, byte[] b) {
+      return result;
+    }
+  }
+
+  private static final class StubBpmn implements BpmnValidationService {
+    private final BpmnValidationResult result;
+
+    StubBpmn(BpmnValidationResult result) {
+      this.result = result;
+    }
+
+    @Override
+    public BpmnValidationResult validate(byte[] xml, CaseTypeConfig ct) {
+      return result;
+    }
+  }
+
+  private static final class StubRegistrar implements CaseTypeRegistrar {
+    final Map<String, CaseTypeConfig> byId = new HashMap<>();
+
+    @Override
+    public RegistrationResult register(CaseTypeConfig cfg) {
+      byId.put(cfg.id(), cfg);
+      return RegistrationResult.registered();
+    }
+
+    @Override
+    public void remove(String id) {
+      byId.remove(id);
+    }
+  }
+
+  private static final class StubReader implements CaseTypeReader {
+    @Override
+    public Optional<CaseTypeConfig> find(String id) {
+      return Optional.empty();
+    }
+
+    @Override
+    public java.util.Collection<CaseTypeConfig> all() {
+      return List.of();
+    }
+
+    @Override
+    public Optional<CaseTypeConfig> findVersion(String id, int version) {
+      return Optional.empty();
+    }
+  }
+
+  private static final class StubEngine implements WorkflowEngine {
+    @Override
+    public DeploymentResult deploy(DeploymentRequest req) {
+      return new DeploymentResult(
+          "dep-1", req.processDefinitionKey(), "procDef-1", 1, Instant.now());
+    }
+
+    @Override
+    public Optional<DeploymentInfo> latestDeployment(String key) {
+      return Optional.empty();
+    }
+
+    @Override
+    public String startProcessInstance(String key, Map<String, Object> vars) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<com.wkspower.platform.domain.model.Task> findTask(String taskId) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void completeTask(String taskId, Map<String, Object> variables) {}
+
+    @Override
+    public void claimTask(String taskId, java.util.UUID userId) {}
+
+    @Override
+    public void signalTransition(String pid, String action, Map<String, Object> vars) {}
+
+    @Override
+    public List<com.wkspower.platform.domain.model.Task> findTasksByCase(java.util.UUID caseId) {
+      return List.of();
+    }
+
+    @Override
+    public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+      return null;
+    }
+  }
+
+  private static final class RecordingPublisher implements EventPublisher {
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public synchronized void publish(Object event) {
+      events.add(event);
+    }
+  }
+
+  private static ErrorDetail err(String code, String msg) {
+    return ErrorDetail.of(code, msg);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingDiffTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingDiffTest.java
@@ -60,7 +60,7 @@ class MappingDiffTest {
   void appendClass_newPropertyRuleAdded() {
     PropertyEmissionRule rule =
         new PropertyEmissionRule(
-            "userTask:t1", "status", BackendSignalKind.USER_TASK_PROPERTY, "case");
+            "userTask:t1", "status", BackendSignalKind.USER_TASK_STATUS, "case");
     AttachmentDefinition before = baseAttachment(Map.of(), List.of());
     AttachmentDefinition after = baseAttachment(Map.of(), List.of(rule));
     assertThat(

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingValidatorTest.java
@@ -344,6 +344,98 @@ class MappingValidatorTest {
     assertThat(attachment.propertyEmissionRules()).hasSize(1);
   }
 
+  // ---- Story 4.3.1 AC3 — WKS-MAP-002 precedence-collision detection ----
+
+  @Test
+  void wksMap002_endEventAndSignalTargetingSameStageTransitionCollide() {
+    // endEvent and a signal both produce the SAME stageTransition tuple — Phase-0 disallows.
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      events:\n"
+            + "        endEvent: { stageTransition: \"intake -> completed\" }\n"
+            + "        signal:\n"
+            + "          claim-escalated: { stageTransition: \"intake -> completed\" }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).contains("WKS-MAP-002");
+  }
+
+  @Test
+  void wksMap002_endEventAndSignalTargetingDifferentStageTransitionsAreLegal() {
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      events:\n"
+            + "        endEvent: { stageTransition: \"intake -> completed\" }\n"
+            + "        signal:\n"
+            + "          claim-escalated: { stageTransition: \"intake -> skipped\" }\n";
+    var raw = parseYaml(yaml);
+    var result =
+        validator.validate(
+            raw, Set.of("intake"), Map.of("x.bpmn", BPMN_WITH_REVIEW_AND_END.getBytes()));
+    assertCodes(result.errors()).doesNotContain("WKS-MAP-002");
+  }
+
+  // ---- Story 4.3.1 AC8 — WKS-MAP-008 unknown YAML key ----
+
+  @Test
+  void wksMap008_unknownKeyInMappingSubtreeIsRejected() {
+    // Typo: "signl" instead of "signal" inside events block.
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      events:\n"
+            + "        signl:\n"
+            + "          claim-escalated: { stageTransition: \"intake -> completed\" }\n";
+    var loader = new CaseTypeYamlLoader();
+    var read = loader.readBytes("test", yaml.getBytes(StandardCharsets.UTF_8));
+    assertThat(read.isParsed()).as("loader must REJECT unknown mapping key").isFalse();
+    assertThat(read.errors())
+        .as("AC8: unknown mapping subtree key surfaces as WKS-MAP-008")
+        .anyMatch(e -> "WKS-MAP-008".equals(e.code()));
+  }
+
+  @Test
+  void wksMap008_unknownKeyInEmitsBlockIsRejected() {
+    // Typo: "typ" instead of "type" inside emits block.
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      properties:\n"
+            + "        - on: userTask:review-claim\n"
+            + "          camunda:property: status\n"
+            + "          emits: { typ: status, scope: case }\n";
+    var loader = new CaseTypeYamlLoader();
+    var read = loader.readBytes("test", yaml.getBytes(StandardCharsets.UTF_8));
+    assertThat(read.isParsed()).isFalse();
+    assertThat(read.errors()).anyMatch(e -> "WKS-MAP-008".equals(e.code()));
+  }
+
+  // ---- Story 4.3.1 AC9 — WKS-MAP-009 duplicate YAML key ----
+
+  @Test
+  void wksMap009_duplicateMapKeyIsRejected() {
+    // userTasks declares the same key twice — silent last-wins is forbidden.
+    String yaml =
+        GREEN_HEAD
+            + "\nattachments:\n"
+            + "  - type: bpmn\n    file: x.bpmn\n    scope: case\n"
+            + "    map:\n      userTasks:\n"
+            + "        review-claim: { wksTask: \"First\" }\n"
+            + "        review-claim: { wksTask: \"Second\" }\n";
+    var loader = new CaseTypeYamlLoader();
+    var read = loader.readBytes("test", yaml.getBytes(StandardCharsets.UTF_8));
+    assertThat(read.isParsed()).as("loader must REJECT duplicate keys").isFalse();
+    assertThat(read.errors()).anyMatch(e -> "WKS-MAP-009".equals(e.code()));
+  }
+
   // ---- helpers ----
 
   private static org.assertj.core.api.AbstractListAssert<?, List<? extends String>, String, ?>

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -30,7 +30,7 @@ The enum currently uses seven prefixes:
 | --- | --- | --- |
 | `WKS-API` | 001–005, 401, 403, 404, 413, plus security 050–054 (literals) | Transport / request-shape / auth |
 | `WKS-CFG` | 000–099 | CaseType + BPMN deploy-time validation aggregate |
-| `WKS-MAP` | 001–007, 404 | Mapping Layer validation (Story 4.2) + runtime miss (Story 4.3) |
+| `WKS-MAP` | 001–009, 404, 405 | Mapping Layer validation (Story 4.2 + 4.3.1) + runtime miss (Story 4.3 + 4.3.1) |
 | `WKS-STG` | 001–011, 099 | Stage lifecycle runtime + stage-scoped status sets |
 | `WKS-VER` | 001–099 | CaseType Version Registry (Story 3.4 / Decision 20) |
 | `WKS-RTM` | 409, 500 | Runtime conflict / last-resort |
@@ -122,20 +122,23 @@ Reserved gap at 014–019 — do not renumber. 011 is reserved for the registry 
 
 ---
 
-## WKS-MAP — Mapping Layer (Stories 4.2 AC2 + 4.3 runtime)
+## WKS-MAP — Mapping Layer (Stories 4.2 AC2 + 4.3 runtime + 4.3.1 hotfix)
 
-Epic-namespaced sibling band. Codes 001–006 are emitted by `MappingValidator` at deploy time; 007 is reserved-and-not-emitted as an alias of `WKS-CFG-028` so Story 4.6's Admin UI Mapping Inspector can surface a Mapping-namespaced label without changing the wire string. `WKS-MAP-404` is runtime-only (Story 4.3) and does not appear at deploy time.
+Epic-namespaced sibling band. Codes 001–006 are emitted by `MappingValidator` at deploy time; 007 is reserved-and-not-emitted as an alias of `WKS-CFG-028` so Story 4.6's Admin UI Mapping Inspector can surface a Mapping-namespaced label without changing the wire string. `WKS-MAP-008` and `-009` are deploy-time strict-schema codes added by Story 4.3.1. `WKS-MAP-404` and `WKS-MAP-405` are runtime-only.
 
 | Code | Meaning | Thrower(s) |
 | --- | --- | --- |
 | `WKS-MAP-001` | Mapping references a BPMN element id (non-userTask) that does not exist in the attached BPMN. | `infrastructure/config/MappingValidator.java` |
-| `WKS-MAP-002` | Two mappings target the same `(stage, status)` from different BPMN events without an explicit precedence declaration. | `infrastructure/config/MappingValidator.java` (path exists; emit site referenced in Javadoc) |
+| `WKS-MAP-002` | Two rules from different `BackendSignalKind`s target the same `(stage, status)` (i.e. the same stage-transition tuple) without an explicit precedence declaration. Story 4.3.1 AC3 — Phase-0 disallows last-wins ambiguity. | `infrastructure/config/MappingValidator.java` |
 | `WKS-MAP-003` | Mapping `scope: stage:<id>` (or `emits.scope: stage:<id>`) references a stage absent from the CaseType. | `infrastructure/config/MappingValidator.java` |
 | `WKS-MAP-004` | `attachments[].type` is not a known adapter kind (Phase-0 allows only `bpmn`). | `infrastructure/config/MappingValidator.java` |
 | `WKS-MAP-005` | `attachments[].file` is missing, unreadable, or fails BPMN 2.0 sniff when `type: bpmn`. | `infrastructure/config/MappingValidator.java` |
 | `WKS-MAP-006` | Two `attachments` declare the same `scope`. | `infrastructure/config/MappingValidator.java` |
 | `WKS-MAP-007` | RESERVED-AND-NOT-EMITTED. Functional alias of `WKS-CFG-028`; reserved for the Admin UI label. Per `feedback_error_codes_are_wire_contract.md`, may never be reused for a different meaning. | (reserved — no thrower) |
+| `WKS-MAP-008` | Story 4.3.1 AC8 — mapping YAML carries an unknown key (typo). Surfaces with file path + JSON pointer + offending key. Mapping subtree records (`RawAttachment`, `RawAttachmentMap`, `RawUserTaskMapping`, etc.) drop `@JsonIgnoreProperties(ignoreUnknown = true)` and the YAMLMapper enables `FAIL_ON_UNKNOWN_PROPERTIES`. | `infrastructure/config/CaseTypeYamlLoader.java` |
+| `WKS-MAP-009` | Story 4.3.1 AC9 — duplicate map key inside the mapping subtree (e.g. `userTasks.<id>` declared twice). Default Jackson last-wins is silent and catastrophic; `STRICT_DUPLICATE_DETECTION` raises this code instead. Top-level duplicates remain `WKS-CFG-099` to preserve that wire contract. | `infrastructure/config/CaseTypeYamlLoader.java` |
 | `WKS-MAP-404` | Runtime — `BackendSignalRouter` could not match an incoming `BackendSignal` to a rule in the active `MappingDefinition`, OR the CaseInstance's pinned `(caseTypeId, version)` is missing from `MappingRegistry`, OR a property emission attempted to drive a stage transition (Story 4.3 AC2 / AC4 / AC9). The `404` number intentionally mirrors HTTP not-found semantics for "rule not found." Distinct from deploy-time `WKS-MAP-001..006`. | `domain/service/BackendSignalRouter.java`, `domain/exception/WksMappingMissException.java` |
+| `WKS-MAP-405` | Story 4.3.1 AC5 — runtime: `BackendSignalRouter.onSignal` received a signal for a `caseId` no longer present in the case repository (purged, hot-reload, race). Distinct from `-404` (rule miss); audited via `BackendSignalRouted` with `source = backend(<adapter>)` rather than silently dropped. | `domain/service/BackendSignalRouter.java` |
 
 ---
 


### PR DESCRIPTION
## Summary

Sprint 1-3 retroactive code review hotfix. The mapping layer was effectively non-functional in production before this PR — both `ConfigService.validateAndRegister` and `ConfigService.deploy` registered `MappingRegistry` entries under the wrong key (or empty), causing every backend signal to hit `WKS-MAP-404` despite tests passing. Twelve ACs traceable to findings C1, C2, I1-I4, I14-I17.

Precondition for Story 4.4 (BPMN Adapter Implementation) — gates Sprint 4 Wave 2.

## Acceptance Criteria

| AC | Status | Notes |
|----|--------|-------|
| AC1 — `validateAndRegister` preserves `mappingDefinition` through registry rebuild | ✓ | Uses 3-arg `ValidationResult.ok(versioned, warnings, mapping)`. Pinned by `ConfigServiceMappingRegistryTest#validateAndRegisterPreservesMappingDefinitionThroughRegistryRebuild`. |
| AC2 — `deploy()` registers under registry-assigned version | ✓ | Rebuilds `yamlResult` around the version-overridden `caseType`. Pinned by `ConfigServiceMappingRegistryTest#deployRegistersMappingUnderRegistryAssignedVersionNotAuthorVersion`. |
| AC3 — `MappingValidator` emits WKS-MAP-002 on precedence collision | ✓ | endEvent + signal targeting same stageTransition tuple. New code path `detectPrecedenceCollisions(...)`. |
| AC4 — synchronous failure-audit on rollback | ✓ | Router catches `RuntimeException` (non-`WksMappingMissException`), publishes `BackendSignalRouted` with extracted WKS code or `WKS-RTM-500`, then rethrows. |
| AC5 — case-not-found emits WKS-MAP-405 audit row | ✓ | New wire code; pinned by `BackendSignalRouterIT#caseNotFoundEmitsMap405AuditRow`. |
| AC6 — `AuditSource.BackendUnmapped` collision protection | ✓ | New sealed sub-record renders `backend(unmapped:<originAdapter>)`; pinned by `AuditSourceTest`. |
| AC7 — ArchUnit catches indirect subscribers | ✓ | New `backendSignalHandlerHasNoIndirectSubscribers` rule covering `getBeansOfType`, `List<BackendSignalHandler>` injection, reflective `Method.invoke`. |
| AC8 — WKS-MAP-008 unknown YAML key | ✓ | Mapping subtree records drop `@JsonIgnoreProperties(ignoreUnknown=true)`; YAMLMapper enables `FAIL_ON_UNKNOWN_PROPERTIES`; loader catches `UnrecognizedPropertyException`. |
| AC9 — WKS-MAP-009 duplicate YAML key | ✓ | Scoped to mapping subtree via `JsonMappingException.getPath()`. Top-level duplicates remain WKS-CFG-099 (wire contract preserved). |
| AC10 — `BackendSignalKind` split | ✓ | `USER_TASK_PROPERTY` → `USER_TASK_STATUS` + `USER_TASK_COMPLETE` (option a). MappingDiff no longer collapses the two shapes. |
| AC11 — WKS-MAP-007 doc/code mismatch | ✓ | Already consistent post-PR-#394; verified — no changes needed. |
| AC12 — wire codes added to registry | ✓ | `ErrorCode.java` + `docs/error-codes.md`. `architecture.md` is a 13-line stub post-shard; band table lives only in `docs/error-codes.md` per PR #394. |

## CI parity (local replication, per Match CI Locally memory)

| Job | Status | Notes |
|-----|--------|-------|
| backend (`mvn -B verify`) | ✓ green | 398 unit + 87 IT all green; spotless clean. |
| frontend (`npm ci` + lint + format:check + test + build + woff2 count) | ✓ green | 251 tests; 4 woff2 files in dist. |
| tenant-invariant | ✓ green | `backend/.ci/check-tenant-invariant.sh` and operator-surface scan. |
| deploy-runbook | ✓ green | shellcheck + envsubst + `docker compose config -q`. |
| docker-build | ✓ green | `docker buildx build` against `docker/Dockerfile`. |
| production-profile-smoke | ⊘ unrunnable-locally | 10-min CI job booting full container stack with secrets fixtures + health probes. Deferred to CI. |

## Collision-rebase notes

- 3-4-1 also touches `ConfigService.java` but on `applyVersionRegistry`; this PR scopes to `validateAndRegister` + `deploy`. Last-merger rebases trivially.
- 3-4-1 also adds `ErrorCode.java` entries; no overlap with `-008`/`-009`/`-405`. Last-merger rebases trivially.
- 4.4 starts AFTER this merges — output is its precondition.

## Deviations from spec

- **AC11 / AC12** — story spec called for updates to `architecture.md` error-code band table. The current `architecture.md` is a 13-line shard-residual stub with no error-code section. Canonical registry is `docs/error-codes.md` (post-PR #394). Documented this in the commit message; recommend updating the story spec to drop the architecture.md reference for future stories.
- **AC9 scoping** — duplicate-key detection at top level (e.g. `id: a; id: b`) preserves the existing `WKS-CFG-099` wire contract pinned by `ConfigValidatorTest.wksCfg099_duplicateTopLevelKey`. WKS-MAP-009 is scoped to duplicates inside the `attachments` subtree by inspecting `JsonMappingException.getPath()`. The story spec is consistent with this scoping ("userTasks.review-claim" example).

## Test plan

- [x] Backend `mvn -B verify` green
- [x] Frontend `npm ci && npm run lint && npm run format:check && npm test && npm run build` green
- [x] Tenant invariant scan green
- [x] Deploy-runbook shellcheck + compose render green
- [x] Docker buildx build green
- [ ] Production-profile-smoke (CI only)
- [ ] CI gauntlet on the open PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)