### PR TITLE
Story 3.7: Append-class status CRUD with lazy propagation (absorbs 3.6 AC4/AC5/AC9-deferred)

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
@@ -193,8 +193,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
       log.warn("Stage lifecycle error: {}", ex.getCode());
       HttpStatus status =
           switch (ex.getCode()) {
-            case "WKS-STG-002" -> HttpStatus.UNPROCESSABLE_ENTITY;
-            case "WKS-STG-004" -> HttpStatus.NOT_FOUND;
+            case "WKS-STG-002", "WKS-STG-008", "WKS-STG-010", "WKS-STG-011" ->
+                HttpStatus.UNPROCESSABLE_ENTITY;
+            case "WKS-STG-004", "WKS-STG-012", "WKS-STG-013" -> HttpStatus.NOT_FOUND;
+              // Story 3.7 — WKS-STG-007 = duplicate append (409); WKS-STG-009 = mutate-class (405).
+            case "WKS-STG-007" -> HttpStatus.CONFLICT;
+            case "WKS-STG-009" -> HttpStatus.METHOD_NOT_ALLOWED;
             default -> HttpStatus.CONFLICT; // WKS-STG-001, WKS-STG-003
           };
       return ResponseEntity.status(status)

--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseTypeStatusAdminController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseTypeStatusAdminController.java
@@ -1,0 +1,196 @@
+package com.wkspower.platform.api.controller;
+
+import com.wkspower.platform.api.dto.ApiResponse;
+import com.wkspower.platform.api.dto.request.AppendStatusRequest;
+import com.wkspower.platform.api.dto.request.RenameStatusRequest;
+import com.wkspower.platform.api.dto.response.StageStatusSetDto;
+import com.wkspower.platform.api.dto.response.StatusView;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.WksStageException;
+import com.wkspower.platform.domain.exception.WksValidationException;
+import com.wkspower.platform.domain.port.StatusOptionsStore;
+import com.wkspower.platform.domain.service.StatusOptionsAdminService;
+import com.wkspower.platform.domain.service.StatusOptionsAdminService.LookupKind;
+import com.wkspower.platform.domain.service.StatusOptionsAdminService.ResolvedStatusSet;
+import com.wkspower.platform.domain.service.StatusOptionsAdminService.StatusAdminLookupFailure;
+import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Story 3.7 — admin endpoints for stage-scoped status set CRUD. Append-class per Decision 21:
+ * append + rename succeed without bumping the CaseType version; mutate-class operations (DELETE,
+ * PATCH terminal) are rejected with {@code 405 / WKS-STG-009} pending Story 3.8's version-bump
+ * envelope.
+ *
+ * <p>Live-propagation strategy: option (a) — every read re-resolves against {@code status_options}.
+ * No cache. See {@link com.wkspower.platform.domain.service.StatusOptionsResolver}.
+ *
+ * <p>Sits under {@code /api/admin/case-types/{caseTypeId}/stages/{stageId}/statuses}; gated by
+ * {@code ROLE_ADMIN} (matches existing {@link AdminController#deploy} surface — there is no
+ * per-case-type verb on the admin path).
+ */
+@RestController
+@RequestMapping("/api/admin/case-types/{caseTypeId}/stages/{stageId}/statuses")
+public class CaseTypeStatusAdminController {
+
+  private final StatusOptionsAdminService service;
+
+  public CaseTypeStatusAdminController(StatusOptionsAdminService service) {
+    this.service = service;
+  }
+
+  @GetMapping
+  @PreAuthorize("hasRole('ADMIN')")
+  public ApiResponse<StageStatusSetDto> get(
+      @PathVariable("caseTypeId") String caseTypeId, @PathVariable("stageId") String stageId) {
+    ResolvedStatusSet resolved = mapLookupErrors(() -> service.resolve(caseTypeId, stageId));
+    return ApiResponse.success(toDto(resolved));
+  }
+
+  @PostMapping
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<ApiResponse<StatusView>> append(
+      @PathVariable("caseTypeId") String caseTypeId,
+      @PathVariable("stageId") String stageId,
+      @Valid @RequestBody AppendStatusRequest body) {
+    requireBody(body);
+    requireField(body.id(), "id");
+    requireField(body.displayName(), "displayName");
+    requireField(body.color(), "color");
+    String color = validateColor(body.color());
+    boolean terminal = body.terminal() != null && body.terminal();
+    StatusDefinition appended;
+    try {
+      appended =
+          mapLookupErrors(
+              () ->
+                  service.append(
+                      caseTypeId, stageId, body.id(), body.displayName(), color, terminal));
+    } catch (StatusOptionsStore.DuplicateStatusException dup) {
+      throw new WksStageException(
+          ErrorCode.WKS_STG_007,
+          "status '" + body.id() + "' already exists on " + caseTypeId + " stage=" + stageId);
+    }
+    StatusView view =
+        new StatusView(
+            appended.id(),
+            appended.displayName(),
+            appended.color() == null ? null : appended.color().wire(),
+            appended.terminal(),
+            // Ordinal is illustrative on the wire — the resolver re-orders on read; for the POST
+            // response we report 0 (the controller does not have access to the persisted ordinal
+            // and a follow-up GET surfaces the canonical position).
+            0);
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(view));
+  }
+
+  @PatchMapping("/{statusId}")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ApiResponse<StatusView> rename(
+      @PathVariable("caseTypeId") String caseTypeId,
+      @PathVariable("stageId") String stageId,
+      @PathVariable("statusId") String statusId,
+      @RequestBody(required = false) RenameStatusRequest body) {
+    requireBody(body);
+    if (body.terminal() != null) {
+      // Mutate-class — flipping the terminal flag requires Story 3.8's version-bump envelope.
+      throw new WksStageException(
+          ErrorCode.WKS_STG_009,
+          "Changing the 'terminal' flag on an existing status is a mutate-class operation; "
+              + "remove / terminal-flag changes require Story 3.8 mutate-class enforcement; deferred.");
+    }
+    if ((body.displayName() == null || body.displayName().isBlank())
+        && (body.color() == null || body.color().isBlank())) {
+      throw new WksValidationException(
+          ErrorCode.WKS_API_001,
+          "PATCH body must include at least one of 'displayName' or 'color'",
+          "displayName");
+    }
+    String color = body.color() == null ? null : validateColor(body.color());
+    StatusDefinition renamed =
+        mapLookupErrors(
+            () -> service.rename(caseTypeId, stageId, statusId, body.displayName(), color));
+    return ApiResponse.success(
+        new StatusView(
+            renamed.id(),
+            renamed.displayName(),
+            renamed.color() == null ? null : renamed.color().wire(),
+            renamed.terminal(),
+            0));
+  }
+
+  @DeleteMapping("/{statusId}")
+  @PreAuthorize("hasRole('ADMIN')")
+  public void delete(
+      @PathVariable("caseTypeId") String caseTypeId,
+      @PathVariable("stageId") String stageId,
+      @PathVariable("statusId") String statusId) {
+    throw new WksStageException(
+        ErrorCode.WKS_STG_009,
+        "DELETE on a status is a mutate-class operation; remove / terminal-flag changes "
+            + "require Story 3.8 mutate-class enforcement; deferred.");
+  }
+
+  // --- helpers --------------------------------------------------------------
+
+  private static StageStatusSetDto toDto(ResolvedStatusSet resolved) {
+    List<StatusView> views = new ArrayList<>(resolved.statuses().size());
+    for (int i = 0; i < resolved.statuses().size(); i++) {
+      StatusDefinition s = resolved.statuses().get(i);
+      views.add(
+          new StatusView(
+              s.id(),
+              s.displayName(),
+              s.color() == null ? null : s.color().wire(),
+              s.terminal(),
+              i));
+    }
+    return new StageStatusSetDto(resolved.stageId(), resolved.initialStatus(), views);
+  }
+
+  private static <T> T mapLookupErrors(java.util.function.Supplier<T> action) {
+    try {
+      return action.get();
+    } catch (StatusAdminLookupFailure missing) {
+      ErrorCode code =
+          missing.kind() == LookupKind.STATUS ? ErrorCode.WKS_STG_013 : ErrorCode.WKS_STG_012;
+      throw new WksStageException(code, missing.getMessage());
+    }
+  }
+
+  private static void requireBody(Object body) {
+    if (body == null) {
+      throw new WksValidationException(ErrorCode.WKS_API_001, "Request body is required", null);
+    }
+  }
+
+  private static void requireField(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new WksValidationException(
+          ErrorCode.WKS_API_001, "Field '" + field + "' is required", field);
+    }
+  }
+
+  private static String validateColor(String wire) {
+    return StatusColor.fromWire(wire)
+        .map(StatusColor::wire)
+        .orElseThrow(
+            () ->
+                new WksValidationException(
+                    ErrorCode.WKS_CFG_008, "Unknown status color: " + wire, "color"));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/request/AppendStatusRequest.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/request/AppendStatusRequest.java
@@ -1,0 +1,17 @@
+package com.wkspower.platform.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request body for {@code POST /api/admin/case-types/{caseTypeId}/stages/{stageId}/statuses} (Story
+ * 3.7 AC1). Append-class status add per Decision 21 — no version bump.
+ *
+ * @param id status id (kebab-case, matches {@code [a-z][a-z0-9-]{1,62}})
+ * @param displayName human-readable label, never blank, ≤ 40 chars
+ * @param color one of the ten {@code StatusColor} palette tokens (lowercase wire form)
+ * @param terminal optional — defaults to {@code false} when omitted; Decision 21 / Story 3.6
+ *     terminal flag (controller treats this as APPEND-only because it is being SET, not CHANGED;
+ *     mutate-class flips of an existing status's flag remain rejected per Story 3.8)
+ */
+public record AppendStatusRequest(
+    @NotBlank String id, @NotBlank String displayName, @NotBlank String color, Boolean terminal) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/request/RenameStatusRequest.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/request/RenameStatusRequest.java
@@ -1,0 +1,12 @@
+package com.wkspower.platform.api.dto.request;
+
+/**
+ * Request body for {@code PATCH
+ * /api/admin/case-types/{caseTypeId}/stages/{stageId}/statuses/{statusId}} (Story 3.7 AC1).
+ * Append-class rename — only {@code displayName} and {@code color} may be changed. Setting {@code
+ * terminal} on this path is treated as a mutate-class change and rejected with {@code WKS-STG-009 /
+ * 405} (Story 3.8 owns the version-bump enforcement).
+ *
+ * <p>Both fields are optional but at least one MUST be present (the controller validates).
+ */
+public record RenameStatusRequest(String displayName, String color, Boolean terminal) {}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/StageStatusSetDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/StageStatusSetDto.java
@@ -1,0 +1,12 @@
+package com.wkspower.platform.api.dto.response;
+
+import java.util.List;
+
+/**
+ * Response DTO for {@code GET /api/admin/case-types/{caseTypeId}/stages/{stageId}/statuses} (Story
+ * 3.7 AC1). Wire shape: {@code { stageId, initialStatus, statuses: [...] }}.
+ *
+ * <p>Reuses {@link StatusView} from Story 3.6 — same wire shape on the runtime case-detail path and
+ * the admin read path keeps the frontend palette logic unified.
+ */
+public record StageStatusSetDto(String stageId, String initialStatus, List<StatusView> statuses) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -262,13 +262,24 @@ public enum ErrorCode {
    */
   WKS_STG_006("WKS-STG-006"),
   /**
+   * Story 3.7 AC1 — admin append rejected because the requested {@code statusId} already exists on
+   * {@code (case_type_id, current-version, stage_id)}. The stage's existing status set already
+   * declares this id (either from the deploy-time YAML or a previous append). HTTP 409.
+   *
+   * <p>Surfaced by the admin POST {@code .../stages/{stageId}/statuses} path (Story 3.7); never
+   * emitted at deploy-time (deploy duplicates surface as {@code WKS-STG-005}).
+   */
+  WKS_STG_007("WKS-STG-007"),
+  /**
    * Stage's {@code statuses: []} is empty (key declared but empty list — must be {@code >= 1} or
    * omit the key entirely to fall back to the flat set per Story 3.6 AC2). HTTP 422.
    */
   WKS_STG_008("WKS-STG-008"),
   /**
-   * RESERVED for Story 3.7 (live append) / Story 3.8 (mutate-class version-bump enforcement). Story
-   * 3.6 reserves the slot in the band; not emitted by any path in this story.
+   * Story 3.7 AC1 — admin mutate-class rejection: DELETE on a status, or PATCH that flips the
+   * {@code terminal} flag, is rejected because removal / terminal-flag changes require Story 3.8's
+   * mutate-class version-bump envelope. Reserved by Story 3.6; first emitted by Story 3.7's admin
+   * controller. HTTP 405 Method Not Allowed.
    */
   WKS_STG_009("WKS-STG-009"),
   /**
@@ -286,6 +297,22 @@ public enum ErrorCode {
    * feedback_error_codes_are_wire_contract.md}. HTTP 422.
    */
   WKS_STG_011("WKS-STG-011"),
+  /**
+   * Story 3.7 AC1 — admin status CRUD path resolved an unknown {@code caseTypeId} or {@code
+   * stageId}. Distinct from {@code WKS-API-404} (generic resource-not-found): the wire code
+   * disambiguates "the case-type lookup failed" vs "the stage lookup failed" via the message text;
+   * SI runbooks grep on {@code WKS-STG-012} for "admin tried to edit statuses on a non-existent
+   * stage". Distinct from {@code WKS-STG-004} (runtime advance/skipTo on unknown caseId) — that is
+   * a CASE id, this is a CASETYPE id. HTTP 404.
+   */
+  WKS_STG_012("WKS-STG-012"),
+  /**
+   * Story 3.7 AC1 — admin {@code PATCH .../statuses/{statusId}} rename targeted a status id that is
+   * not currently declared on the stage's status set (neither in the frozen-on-version YAML base
+   * nor in the {@code status_options} append-class delta). Distinct from {@code WKS-STG-012} (the
+   * stage itself is unknown). HTTP 404.
+   */
+  WKS_STG_013("WKS-STG-013"),
 
   // 503 — CaseType Version Registry (Story 3.4 / Decision 20; HTTP semantic flipped by Story
   // 3.4.1).

--- a/backend/src/main/java/com/wkspower/platform/domain/port/StatusOptionsStore.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/StatusOptionsStore.java
@@ -1,0 +1,81 @@
+package com.wkspower.platform.domain.port;
+
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Read + write port for the {@code status_options} table (Story 3.7). Stores per-{@code
+ * (caseTypeId, version, stageId)} status edits made via the admin REST API after deploy. Backs
+ * Decision 21's "live append" promise — appended statuses persist durably and overlay on top of the
+ * frozen-on-version YAML base at read time.
+ *
+ * <p>Hexagonal port: the domain-layer admin service depends on this interface, never the JPA
+ * adapter directly. Tests can swap in an in-memory implementation.
+ *
+ * <p>{@code stageId == FLAT_SENTINEL} represents case-type-level (non-stage-scoped) statuses —
+ * Story 3.6's flat fallback. Using a sentinel rather than nullable stageId keeps the composite key
+ * non-nullable and lookups uniform.
+ */
+public interface StatusOptionsStore {
+
+  /**
+   * Sentinel stageId for case-type-level statuses (no stage scope). Story 3.7 Q3 — the persistence
+   * shape uses a non-null sentinel to keep the composite primary key uniform; the in-memory
+   * resolver from Story 3.6 distinguishes "stage declared but no statuses" from "no stage" via
+   * {@code Optional<List<StatusDefinition>>}, which translates here as: the sentinel row only
+   * exists when a flat status was edited via append, never auto-created on YAML deploy.
+   */
+  String FLAT_SENTINEL = "__flat__";
+
+  /**
+   * List the appended/edited statuses for a {@code (caseTypeId, version, stageId)}, ordered by
+   * ordinal ASC. Empty list when no admin edits have landed for the key — callers fall back to the
+   * frozen-on-version YAML status list.
+   */
+  List<StatusDefinition> listFor(String caseTypeId, int version, String stageId);
+
+  /**
+   * Look up a single status by id. Empty when no row exists for the key — includes "not yet
+   * appended" and "never declared".
+   */
+  Optional<StatusDefinition> findOne(
+      String caseTypeId, int version, String stageId, String statusId);
+
+  /**
+   * Append a new status to the stage's option set. Returns the persisted definition with its
+   * assigned ordinal (max-existing + 1; 0 for the first row).
+   *
+   * @throws DuplicateStatusException when {@code statusId} already exists for the key
+   */
+  StatusDefinition append(
+      String caseTypeId,
+      int version,
+      String stageId,
+      String statusId,
+      String displayName,
+      String color,
+      boolean terminal);
+
+  /**
+   * Persist a rename — updates {@code displayName} and/or {@code color} on an existing row. Returns
+   * empty when no row exists for the key (caller maps to {@code WKS-STG-013}).
+   */
+  Optional<StatusDefinition> rename(
+      String caseTypeId,
+      int version,
+      String stageId,
+      String statusId,
+      String displayName,
+      String color);
+
+  /**
+   * Thrown by {@link #append} when the {@code (caseTypeId, version, stageId, statusId)} key is
+   * already taken. Caller maps to {@code WKS-STG-007}.
+   */
+  class DuplicateStatusException extends RuntimeException {
+    public DuplicateStatusException(String message) {
+      super(message);
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/StatusOptionsAdminService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/StatusOptionsAdminService.java
@@ -1,0 +1,191 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.port.CaseTypeReader;
+import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
+import com.wkspower.platform.domain.port.StatusOptionsStore;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Story 3.7 — domain service driving the admin status CRUD endpoints. Routes append + rename writes
+ * through {@link CaseTypeVersionRegistry} (Story 3.4) so the {@code status_options} row is bound to
+ * the CURRENT bound version — append-class per Decision 21 never bumps the version.
+ *
+ * <p>Pure domain — no Spring annotations, no HTTP. The controller wires this around the resolver.
+ *
+ * <p>Live-propagation strategy: option (a), re-read on every call. See {@link
+ * StatusOptionsResolver}.
+ */
+public class StatusOptionsAdminService {
+
+  private final CaseTypeReader reader;
+  private final CaseTypeVersionRegistry versionRegistry;
+  private final StatusOptionsStore store;
+  private final StatusOptionsResolver resolver;
+
+  public StatusOptionsAdminService(
+      CaseTypeReader reader, CaseTypeVersionRegistry versionRegistry, StatusOptionsStore store) {
+    this.reader = reader;
+    this.versionRegistry = versionRegistry;
+    this.store = store;
+    this.resolver = new StatusOptionsResolver(store);
+  }
+
+  /**
+   * Resolve the current effective status list for {@code (caseTypeId, stageId)} — frozen YAML base
+   * overlaid with live {@code status_options} rows for the current bound version.
+   *
+   * @throws StatusAdminLookupFailure when {@code caseTypeId} or {@code stageId} is unknown
+   */
+  public ResolvedStatusSet resolve(String caseTypeId, String stageId) {
+    Lookup lk = lookup(caseTypeId, stageId);
+    List<StatusDefinition> resolved = resolver.resolve(lk.caseType, stageId);
+    String initial =
+        lk.caseType
+            .stage(stageId)
+            .flatMap(s -> s.initialStatus())
+            .orElseGet(() -> resolved.isEmpty() ? null : resolved.get(0).id());
+    return new ResolvedStatusSet(stageId, initial, resolved);
+  }
+
+  /**
+   * Append a new status to the stage. Routes through {@code CaseTypeVersionRegistry.currentVersion}
+   * so the row is bound to the current bound version (append-class — no version bump).
+   *
+   * @throws StatusAdminLookupFailure when {@code caseTypeId} or {@code stageId} is unknown
+   * @throws StatusOptionsStore.DuplicateStatusException when {@code statusId} already exists
+   *     anywhere in the resolved set (YAML base OR previous append)
+   */
+  public StatusDefinition append(
+      String caseTypeId,
+      String stageId,
+      String statusId,
+      String displayName,
+      String color,
+      boolean terminal) {
+    Lookup lk = lookup(caseTypeId, stageId);
+    // Pre-check: reject if the id exists in the YAML base or in the existing overlay. The
+    // composite-PK in the adapter is defence-in-depth for races; this pre-check produces the
+    // friendly WKS-STG-007 path for the common (sequential) case.
+    if (resolver.resolveOne(lk.caseType, stageId, statusId).isPresent()) {
+      throw new StatusOptionsStore.DuplicateStatusException(
+          "status '" + statusId + "' already exists on " + caseTypeId + " stage=" + stageId);
+    }
+    return store.append(
+        caseTypeId, lk.version, sentinel(stageId), statusId, displayName, color, terminal);
+  }
+
+  /**
+   * Rename an existing status' label / color. Mutate-class concerns ({@code terminal}, removal,
+   * retarget) are rejected by the controller before reaching this method.
+   *
+   * <p>Semantics for the YAML base: a rename of a YAML-declared status writes a row into {@code
+   * status_options} for the SAME id; the resolver's overlay logic then surfaces the new
+   * displayName/color while preserving the YAML's relative position. This matches Decision 21's
+   * "live edit" promise and keeps the deploy-time YAML intact (no in-place rewrite).
+   *
+   * @throws StatusAdminLookupFailure when {@code caseTypeId} / {@code stageId} / {@code statusId}
+   *     is unknown (the latter mapped to {@code WKS-STG-013} by the controller)
+   */
+  public StatusDefinition rename(
+      String caseTypeId, String stageId, String statusId, String displayName, String color) {
+    Lookup lk = lookup(caseTypeId, stageId);
+    Optional<StatusDefinition> resolved = resolver.resolveOne(lk.caseType, stageId, statusId);
+    if (resolved.isEmpty()) {
+      throw new StatusAdminLookupFailure(LookupKind.STATUS, statusId);
+    }
+    StatusDefinition base = resolved.get();
+    String newDisplayName = displayName != null ? displayName : base.displayName();
+    String newColor = color != null ? color : base.color().wire();
+    // Upsert: if no row exists yet (YAML-declared status that has never been edited), insert one
+    // at the end of the overlay so future reads project the rename. Append uses the YAML base's
+    // ordering; ordinal here is best-effort tail-of-overlay.
+    Optional<StatusDefinition> existingRow =
+        store.findOne(caseTypeId, lk.version, sentinel(stageId), statusId);
+    if (existingRow.isEmpty()) {
+      return store.append(
+          caseTypeId,
+          lk.version,
+          sentinel(stageId),
+          statusId,
+          newDisplayName,
+          newColor,
+          base.terminal());
+    }
+    return store
+        .rename(caseTypeId, lk.version, sentinel(stageId), statusId, newDisplayName, newColor)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "rename returned empty after findOne returned present — inconsistent store"));
+  }
+
+  private Lookup lookup(String caseTypeId, String stageId) {
+    Optional<CaseTypeConfig> ctOpt = reader.find(caseTypeId);
+    if (ctOpt.isEmpty()) {
+      throw new StatusAdminLookupFailure(LookupKind.CASE_TYPE, caseTypeId);
+    }
+    CaseTypeConfig ct = ctOpt.get();
+    // For non-flat stage requests, verify the stage is declared on the case type.
+    if (!StatusOptionsStore.FLAT_SENTINEL.equals(stageId)
+        && !StatusOptionsResolver.isDeclaredStage(ct, stageId)) {
+      throw new StatusAdminLookupFailure(LookupKind.STAGE, stageId);
+    }
+    int version =
+        versionRegistry
+            .currentVersion(caseTypeId)
+            .orElse(ct.version()); // fall back to in-memory registry version (test-only paths)
+    return new Lookup(ct, version);
+  }
+
+  private static String sentinel(String stageId) {
+    return stageId == null || stageId.isBlank() ? StatusOptionsStore.FLAT_SENTINEL : stageId;
+  }
+
+  /** Read-side resolver delegate (exposed for the controller to drive admin GET). */
+  public StatusOptionsResolver resolver() {
+    return resolver;
+  }
+
+  // --- types ----------------------------------------------------------------
+
+  public enum LookupKind {
+    CASE_TYPE,
+    STAGE,
+    STATUS
+  }
+
+  /**
+   * Surfaced as {@code WKS-STG-012} (CASE_TYPE / STAGE) or {@code WKS-STG-013} (STATUS) by the
+   * controller — domain layer stays HTTP-free.
+   */
+  public static class StatusAdminLookupFailure extends RuntimeException {
+    private final LookupKind kind;
+    private final String missingId;
+
+    public StatusAdminLookupFailure(LookupKind kind, String missingId) {
+      super(kind.name().toLowerCase() + " '" + missingId + "' not found");
+      this.kind = kind;
+      this.missingId = missingId;
+    }
+
+    public LookupKind kind() {
+      return kind;
+    }
+
+    public String missingId() {
+      return missingId;
+    }
+  }
+
+  public record ResolvedStatusSet(
+      String stageId, String initialStatus, List<StatusDefinition> statuses) {
+    public ResolvedStatusSet {
+      statuses = List.copyOf(statuses);
+    }
+  }
+
+  private record Lookup(CaseTypeConfig caseType, int version) {}
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/StatusOptionsResolver.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/StatusOptionsResolver.java
@@ -1,0 +1,94 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.port.StatusOptionsStore;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Story 3.7 — resolver that overlays {@link StatusOptionsStore} append-class deltas on top of the
+ * frozen-on-version YAML status base produced by {@link CaseTypeConfig#statusesFor(String)}.
+ *
+ * <p>Live-propagation strategy: <strong>(a) re-read on every call</strong>. No cache layer. Q1
+ * locks "fully live" — existing mid-flight cases see the appended status on next read; the
+ * trade-off is one extra DB round-trip per status read. Acceptable for Phase-0 traffic per the
+ * Story 3.7 brief; a short-TTL cache (option b) is a defensible Phase-1 optimisation if observed
+ * load demands it.
+ *
+ * <p>Pure domain — no Spring, no JPA. The resolver is constructed directly by callers (admin
+ * controller wiring) and given the {@link StatusOptionsStore} port.
+ */
+public class StatusOptionsResolver {
+
+  private final StatusOptionsStore store;
+
+  public StatusOptionsResolver(StatusOptionsStore store) {
+    this.store = store;
+  }
+
+  /**
+   * Resolve the effective status list for {@code (caseType, stageId)} at the given bound version.
+   * The base list comes from the frozen-on-version YAML; appended/renamed rows from {@code
+   * status_options} for the SAME version overlay onto it:
+   *
+   * <ul>
+   *   <li>matching {@code statusId} → renamed entry replaces the YAML base
+   *   <li>new {@code statusId} → appended after the YAML base, in ordinal order
+   * </ul>
+   *
+   * <p>{@code stageId} may be {@code null} for a zero-stage CaseType or a case with no active stage
+   * — the flat case-type-level set is returned (and the {@code status_options} read uses the {@link
+   * StatusOptionsStore#FLAT_SENTINEL}).
+   */
+  public List<StatusDefinition> resolve(CaseTypeConfig caseType, String stageId) {
+    List<StatusDefinition> base = caseType.statusesFor(stageId);
+    String storeStageId = stageId == null ? StatusOptionsStore.FLAT_SENTINEL : stageId;
+    List<StatusDefinition> overlay = store.listFor(caseType.id(), caseType.version(), storeStageId);
+    if (overlay.isEmpty()) {
+      return base;
+    }
+    // Preserve declared order: keep YAML base ordering, replace by id where overlay has a match,
+    // append new ids in their persisted ordinal order at the tail.
+    LinkedHashMap<String, StatusDefinition> byId = new LinkedHashMap<>();
+    for (StatusDefinition s : base) {
+      byId.put(s.id(), s);
+    }
+    List<StatusDefinition> tail = new ArrayList<>();
+    for (StatusDefinition s : overlay) {
+      if (byId.containsKey(s.id())) {
+        byId.put(s.id(), s); // rename overlay
+      } else {
+        tail.add(s); // append
+      }
+    }
+    List<StatusDefinition> result = new ArrayList<>(byId.size() + tail.size());
+    result.addAll(byId.values());
+    result.addAll(tail);
+    return List.copyOf(result);
+  }
+
+  /**
+   * Convenience — returns the resolved {@link StatusDefinition} matching {@code statusId} or empty.
+   * Used by the admin PATCH path to verify the target id exists somewhere (YAML base OR overlay)
+   * before writing the rename.
+   */
+  public Optional<StatusDefinition> resolveOne(
+      CaseTypeConfig caseType, String stageId, String statusId) {
+    return resolve(caseType, stageId).stream().filter(s -> s.id().equals(statusId)).findFirst();
+  }
+
+  /**
+   * Returns true when {@code stageId} is declared on {@code caseType}. Convenience for the admin
+   * controller's 404 path. {@code null} is rejected (admin path requires explicit stage selection).
+   */
+  public static boolean isDeclaredStage(CaseTypeConfig caseType, String stageId) {
+    if (stageId == null) {
+      return false;
+    }
+    return caseType.stages().stream().map(StageDefinition::id).anyMatch(stageId::equals);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
@@ -11,10 +11,12 @@ import com.wkspower.platform.domain.port.Clock;
 import com.wkspower.platform.domain.port.EventPublisher;
 import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
 import com.wkspower.platform.domain.port.StageRepository;
+import com.wkspower.platform.domain.port.StatusOptionsStore;
 import com.wkspower.platform.domain.port.WorkflowEngine;
 import com.wkspower.platform.domain.service.CaseService;
 import com.wkspower.platform.domain.service.ConfigService;
 import com.wkspower.platform.domain.service.MappingRegistry;
+import com.wkspower.platform.domain.service.StatusOptionsAdminService;
 import com.wkspower.platform.domain.service.TaskService;
 import com.wkspower.platform.domain.service.WksStageAdvancer;
 import org.springframework.context.annotation.Bean;
@@ -93,6 +95,19 @@ public class ConfigServiceConfig {
    * HTTP endpoints declare {@code @Transactional} on the controller bodies). The domain class
    * itself stays Spring-free per Decision 4 / NFR36.
    */
+  /**
+   * Story 3.7 — admin status CRUD service. Lives in the domain layer so it stays Spring-free;
+   * this @Bean wires the ports from infrastructure (CaseTypeReader, CaseTypeVersionRegistry, the
+   * JPA StatusOptionsStore adapter).
+   */
+  @Bean
+  public StatusOptionsAdminService statusOptionsAdminService(
+      CaseTypeReader caseTypeReader,
+      CaseTypeVersionRegistry versionRegistry,
+      StatusOptionsStore statusOptionsStore) {
+    return new StatusOptionsAdminService(caseTypeReader, versionRegistry, statusOptionsStore);
+  }
+
   @Bean
   public WksStageAdvancer wksStageAdvancer(
       StageRepository stageRepository, EventPublisher eventPublisher, Clock clock) {

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/StatusOptionsStoreAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/StatusOptionsStoreAdapter.java
@@ -1,0 +1,136 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.port.StatusOptionsStore;
+import com.wkspower.platform.infrastructure.persistence.entity.StatusOptionEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.StatusOptionJpaRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * JPA adapter implementing {@link StatusOptionsStore} (Story 3.7). Backs the {@code status_options}
+ * table — the durable record of admin-driven append-class status edits per Decision 21.
+ *
+ * <p>Concurrency: the {@code (case_type_id, version, stage_id, status_id)} primary key enforces "no
+ * two rows for the same status id"; concurrent appends serialise on the unique-key insert. The
+ * adapter computes the next ordinal by reading {@code MAX(ordinal) + 1}; a parallel append race may
+ * result in two rows with the same intended ordinal — but the PK on {@code statusId} prevents
+ * silent overwrites, and the ordinal column is monotonic-ish (ties allowed) since the read+write is
+ * not in a single SERIALIZABLE transaction. AC3 scenario 11 verifies "two distinct rows" — not
+ * "perfectly contiguous ordinals." Phase-0 traffic does not require strict ordinal contiguity; the
+ * {@code idx_status_options_case_type_stage} index supports stable ordering on read.
+ */
+@Component
+public class StatusOptionsStoreAdapter implements StatusOptionsStore {
+
+  private final StatusOptionJpaRepository repository;
+
+  public StatusOptionsStoreAdapter(StatusOptionJpaRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<StatusDefinition> listFor(String caseTypeId, int version, String stageId) {
+    return repository
+        .findByCaseTypeIdAndVersionAndStageIdOrderByOrdinalAsc(caseTypeId, version, stageId)
+        .stream()
+        .map(StatusOptionsStoreAdapter::toDomain)
+        .toList();
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<StatusDefinition> findOne(
+      String caseTypeId, int version, String stageId, String statusId) {
+    return repository
+        .findByCaseTypeIdAndVersionAndStageIdAndStatusId(caseTypeId, version, stageId, statusId)
+        .map(StatusOptionsStoreAdapter::toDomain);
+  }
+
+  @Override
+  @Transactional
+  public StatusDefinition append(
+      String caseTypeId,
+      int version,
+      String stageId,
+      String statusId,
+      String displayName,
+      String color,
+      boolean terminal) {
+    // Explicit pre-check — Hibernate's `save()` on an @IdClass entity issues a SELECT then merges
+    // when a row already exists (treating the call as an update), which would silently overwrite
+    // an admin's previous append rather than surfacing a duplicate. The JPA call cannot be relied
+    // on for "INSERT or fail" semantics here; check first, then save. The composite PK still
+    // serves as defence-in-depth for concurrent-insert races (caught below).
+    if (repository
+        .findByCaseTypeIdAndVersionAndStageIdAndStatusId(caseTypeId, version, stageId, statusId)
+        .isPresent()) {
+      throw new DuplicateStatusException(
+          "status '"
+              + statusId
+              + "' already exists on "
+              + caseTypeId
+              + "@v"
+              + version
+              + " stage="
+              + stageId);
+    }
+    int nextOrdinal = repository.findMaxOrdinal(caseTypeId, version, stageId) + 1;
+    StatusOptionEntity entity =
+        new StatusOptionEntity(
+            caseTypeId, version, stageId, statusId, displayName, color, terminal, nextOrdinal);
+    try {
+      repository.saveAndFlush(entity);
+    } catch (DataIntegrityViolationException race) {
+      // PK collision on (caseTypeId, version, stageId, statusId) — concurrent append landed first
+      // OR the caller didn't pre-check. Surface as DuplicateStatusException; controller maps to
+      // WKS-STG-007 / 409.
+      throw new DuplicateStatusException(
+          "status '"
+              + statusId
+              + "' already exists on "
+              + caseTypeId
+              + "@v"
+              + version
+              + " stage="
+              + stageId);
+    }
+    return toDomain(entity);
+  }
+
+  @Override
+  @Transactional
+  public Optional<StatusDefinition> rename(
+      String caseTypeId,
+      int version,
+      String stageId,
+      String statusId,
+      String displayName,
+      String color) {
+    Optional<StatusOptionEntity> existing =
+        repository.findByCaseTypeIdAndVersionAndStageIdAndStatusId(
+            caseTypeId, version, stageId, statusId);
+    if (existing.isEmpty()) {
+      return Optional.empty();
+    }
+    StatusOptionEntity entity = existing.get();
+    if (displayName != null) {
+      entity.setDisplayName(displayName);
+    }
+    if (color != null) {
+      entity.setColor(color);
+    }
+    repository.saveAndFlush(entity);
+    return Optional.of(toDomain(entity));
+  }
+
+  private static StatusDefinition toDomain(StatusOptionEntity e) {
+    StatusColor color = StatusColor.fromWire(e.getColor()).orElse(StatusColor.ZINC);
+    return new StatusDefinition(e.getStatusId(), e.getDisplayName(), color, e.isTerminal());
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/StatusOptionEntity.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/StatusOptionEntity.java
@@ -1,0 +1,117 @@
+package com.wkspower.platform.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+
+/**
+ * JPA entity for {@code status_options} (Story 3.7). Stores append-class status edits made via the
+ * admin REST API after a CaseType is deployed; bound to the row in {@code case_type_versions} via
+ * the composite key {@code (case_type_id, version, stage_id, status_id)}.
+ *
+ * <p>Decision 21 — append-class writes target the CURRENT bound version per {@code
+ * CaseTypeVersionRegistry}; never bumping it. Mutate-class writes (Story 3.8) will land here under
+ * a freshly-bumped version envelope.
+ *
+ * <p>{@code stage_id == "__flat__"} represents case-type-level (non-stage-scoped) statuses. Using a
+ * sentinel keeps the composite PK non-nullable and lets the index hit uniformly regardless of
+ * whether the stage is declared. See {@code StatusOptionsStore.FLAT_SENTINEL}.
+ */
+@Entity
+@Table(name = "status_options")
+@IdClass(StatusOptionId.class)
+public class StatusOptionEntity {
+
+  @Id
+  @Column(name = "case_type_id", length = 64, nullable = false, updatable = false)
+  private String caseTypeId;
+
+  @Id
+  @Column(name = "version", nullable = false, updatable = false)
+  private int version;
+
+  @Id
+  @Column(name = "stage_id", length = 64, nullable = false, updatable = false)
+  private String stageId;
+
+  @Id
+  @Column(name = "status_id", length = 64, nullable = false, updatable = false)
+  private String statusId;
+
+  @Column(name = "display_name", length = 128, nullable = false)
+  private String displayName;
+
+  @Column(name = "color", length = 32, nullable = false)
+  private String color;
+
+  @Column(name = "terminal", nullable = false)
+  private boolean terminal;
+
+  @Column(name = "ordinal", nullable = false)
+  private int ordinal;
+
+  protected StatusOptionEntity() {
+    // JPA
+  }
+
+  public StatusOptionEntity(
+      String caseTypeId,
+      int version,
+      String stageId,
+      String statusId,
+      String displayName,
+      String color,
+      boolean terminal,
+      int ordinal) {
+    this.caseTypeId = caseTypeId;
+    this.version = version;
+    this.stageId = stageId;
+    this.statusId = statusId;
+    this.displayName = displayName;
+    this.color = color;
+    this.terminal = terminal;
+    this.ordinal = ordinal;
+  }
+
+  public String getCaseTypeId() {
+    return caseTypeId;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public String getStageId() {
+    return stageId;
+  }
+
+  public String getStatusId() {
+    return statusId;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
+  }
+
+  public String getColor() {
+    return color;
+  }
+
+  public void setColor(String color) {
+    this.color = color;
+  }
+
+  public boolean isTerminal() {
+    return terminal;
+  }
+
+  public int getOrdinal() {
+    return ordinal;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/StatusOptionId.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/StatusOptionId.java
@@ -1,0 +1,64 @@
+package com.wkspower.platform.infrastructure.persistence.entity;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Composite-key class for {@link StatusOptionEntity} (Story 3.7). Natural key {@code (case_type_id,
+ * version, stage_id, status_id)} matches the {@code status_options} table primary key.
+ *
+ * <p>Field names + types must match the {@code @Id} fields on the entity.
+ */
+public class StatusOptionId implements Serializable {
+
+  private String caseTypeId;
+  private int version;
+  private String stageId;
+  private String statusId;
+
+  public StatusOptionId() {
+    // JPA
+  }
+
+  public StatusOptionId(String caseTypeId, int version, String stageId, String statusId) {
+    this.caseTypeId = caseTypeId;
+    this.version = version;
+    this.stageId = stageId;
+    this.statusId = statusId;
+  }
+
+  public String getCaseTypeId() {
+    return caseTypeId;
+  }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public String getStageId() {
+    return stageId;
+  }
+
+  public String getStatusId() {
+    return statusId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof StatusOptionId other)) {
+      return false;
+    }
+    return version == other.version
+        && Objects.equals(caseTypeId, other.caseTypeId)
+        && Objects.equals(stageId, other.stageId)
+        && Objects.equals(statusId, other.statusId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(caseTypeId, version, stageId, statusId);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/StatusOptionJpaRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/StatusOptionJpaRepository.java
@@ -1,0 +1,29 @@
+package com.wkspower.platform.infrastructure.persistence.repository;
+
+import com.wkspower.platform.infrastructure.persistence.entity.StatusOptionEntity;
+import com.wkspower.platform.infrastructure.persistence.entity.StatusOptionId;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+/**
+ * Spring Data JPA repository for {@link StatusOptionEntity} (Story 3.7).
+ *
+ * <p>Derived-name finders use the @IdClass field names on the entity ({@code caseTypeId}, {@code
+ * version}, {@code stageId}, {@code statusId}) directly.
+ */
+public interface StatusOptionJpaRepository
+    extends JpaRepository<StatusOptionEntity, StatusOptionId> {
+
+  List<StatusOptionEntity> findByCaseTypeIdAndVersionAndStageIdOrderByOrdinalAsc(
+      String caseTypeId, int version, String stageId);
+
+  Optional<StatusOptionEntity> findByCaseTypeIdAndVersionAndStageIdAndStatusId(
+      String caseTypeId, int version, String stageId, String statusId);
+
+  @Query(
+      "SELECT COALESCE(MAX(s.ordinal), -1) FROM StatusOptionEntity s "
+          + "WHERE s.caseTypeId = :caseTypeId AND s.version = :version AND s.stageId = :stageId")
+  int findMaxOrdinal(String caseTypeId, int version, String stageId);
+}

--- a/backend/src/main/resources/db/migration/common/V202605070001__status_options.sql
+++ b/backend/src/main/resources/db/migration/common/V202605070001__status_options.sql
@@ -1,0 +1,39 @@
+-- Story 3.7 — Append-Class Status Add (Live, with Lazy Propagation).
+-- Stores the per-(case_type_id, version, stage_id) status options edited via the admin REST API
+-- AFTER initial deploy. This is the durable backing store for Decision 21's "live append" promise:
+-- the deploy-time YAML defines the seed status set; runtime appends/renames land here without a
+-- CaseType version bump, and case reads overlay these rows on the frozen-on-version base.
+--
+-- The version column is BOUND to the row in case_type_versions (Story 3.4). Append-class writes
+-- always target the current version per CaseTypeVersionRegistry — never bumping it. A future
+-- mutate-class flow (Story 3.8) would write rows for a freshly-bumped version under its own
+-- envelope.
+--
+-- stage_id sentinel: '__flat__' represents case-type-level (non-stage-scoped) statuses — Story 3.6's
+-- flat fallback. Using a sentinel rather than NULL keeps the primary key non-nullable and lets the
+-- standard composite-PK lookup (case_type_id, version, stage_id, status_id) hit the index uniformly
+-- regardless of whether the stage is declared.
+--
+-- H2 + Postgres compatible — VARCHAR / INTEGER / BOOLEAN are portable; no JSONB, no GENERATED, no
+-- Postgres-specific syntax. Zero-tenant invariant (D25, Story 3.0 lint) — no per-customer column.
+--
+-- Wire codes referenced by writers:
+--   WKS-STG-007 — duplicate (case_type_id, version, stage_id, status_id) on append (HTTP 409)
+--   WKS-STG-009 — mutate-class rejection: DELETE + PATCH terminal (HTTP 405)
+--   WKS-STG-012 — unknown caseTypeId/stageId on admin path (HTTP 404)
+--   WKS-STG-013 — unknown statusId on PATCH rename (HTTP 404)
+
+CREATE TABLE status_options (
+    case_type_id      VARCHAR(64)  NOT NULL,
+    version           INTEGER      NOT NULL,
+    stage_id          VARCHAR(64)  NOT NULL,    -- '__flat__' sentinel for case-type-level statuses
+    status_id         VARCHAR(64)  NOT NULL,
+    display_name      VARCHAR(128) NOT NULL,
+    color             VARCHAR(32)  NOT NULL,
+    terminal          BOOLEAN      NOT NULL DEFAULT FALSE,
+    ordinal           INTEGER      NOT NULL,
+    PRIMARY KEY (case_type_id, version, stage_id, status_id)
+);
+
+CREATE INDEX idx_status_options_case_type_stage
+    ON status_options (case_type_id, version, stage_id, ordinal);

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/StatusOptionsStorePostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/persistence/StatusOptionsStorePostgresIT.java
@@ -1,0 +1,139 @@
+package com.wkspower.platform.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.port.StatusOptionsStore;
+import com.wkspower.platform.infrastructure.persistence.repository.StatusOptionJpaRepository;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Story 3.7 — Postgres-backed integration test for {@link StatusOptionsStore}.
+ *
+ * <p>Discharges {@code project_postgres_it_parity_gap} for the Story 3.7 surface. The Sprint-4
+ * Wave-2 brief mandates "at minimum one IT should cover the persistence path against real Postgres
+ * testcontainer" — this is that test. Verifies:
+ *
+ * <ul>
+ *   <li>The {@code status_options} migration runs on real Postgres.
+ *   <li>Append + read round-trip persists durably across a fresh repository read.
+ *   <li>Concurrent appends with the same status id are rejected by the composite PK (no silent
+ *       overwrite, no duplicate row).
+ * </ul>
+ *
+ * <p>Story 14.1.1: {@code ProductionBootstrapValidator} runs on {@code ApplicationReadyEvent} under
+ * {@code activeProfiles=["production"]} — disable here, this test is exercising the persistence
+ * surface, not the boot invariant.
+ */
+@SpringBootTest(properties = "wks.bootstrap.production-validation.enabled=false")
+@ActiveProfiles("production")
+@Testcontainers(disabledWithoutDocker = true)
+class StatusOptionsStorePostgresIT {
+
+  @Container
+  @SuppressWarnings("resource")
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("wks")
+          .withUsername("wks")
+          .withPassword("wks");
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("WKS_DB_URL", POSTGRES::getJdbcUrl);
+    registry.add("WKS_DB_USER", POSTGRES::getUsername);
+    registry.add("WKS_DB_PASSWORD", POSTGRES::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    registry.add("WKS_ADMIN_EMAIL", () -> "admin@wkspower.local");
+    registry.add("WKS_ADMIN_PASSWORD", () -> "admin");
+    registry.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+    registry.add("WKS_CORS_ORIGINS", () -> "http://localhost:5173");
+    registry.add(
+        "camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+  }
+
+  private static final String CASE_TYPE_ID = "loan-application";
+  private static final String STAGE_ID = "intake";
+
+  @Autowired private StatusOptionsStore store;
+  @Autowired private StatusOptionJpaRepository repository;
+
+  @AfterEach
+  void wipe() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void appendThenListReturnsThePersistedRow() {
+    StatusDefinition appended =
+        store.append(CASE_TYPE_ID, 1, STAGE_ID, "needs-info", "Needs info", "amber", false);
+    assertThat(appended.id()).isEqualTo("needs-info");
+
+    List<StatusDefinition> rows = store.listFor(CASE_TYPE_ID, 1, STAGE_ID);
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).displayName()).isEqualTo("Needs info");
+  }
+
+  @Test
+  void duplicateAppendThrowsDuplicateStatusException() {
+    store.append(CASE_TYPE_ID, 1, STAGE_ID, "needs-info", "Needs info", "amber", false);
+    org.junit.jupiter.api.Assertions.assertThrows(
+        StatusOptionsStore.DuplicateStatusException.class,
+        () ->
+            store.append(
+                CASE_TYPE_ID, 1, STAGE_ID, "needs-info", "Needs info again", "amber", false));
+  }
+
+  @Test
+  void concurrentDistinctAppendsAllLandWithoutLostWrites() throws Exception {
+    int threads = 6;
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch start = new CountDownLatch(1);
+    AtomicInteger committed = new AtomicInteger();
+    try {
+      for (int i = 0; i < threads; i++) {
+        final int idx = i;
+        pool.submit(
+            () -> {
+              try {
+                start.await(2, TimeUnit.SECONDS);
+                store.append(
+                    CASE_TYPE_ID,
+                    1,
+                    STAGE_ID,
+                    "concurrent-" + idx,
+                    "Concurrent " + idx,
+                    "blue",
+                    false);
+                committed.incrementAndGet();
+              } catch (Exception ignored) {
+                // Failures here would mean a stricter Postgres lock semantic kicked in; the
+                // append happens in a transaction with an autogen ordinal MAX+1 read — under
+                // contention READ COMMITTED may serialise but should not fail.
+              }
+            });
+      }
+      start.countDown();
+    } finally {
+      pool.shutdown();
+      assertThat(pool.awaitTermination(20, TimeUnit.SECONDS)).isTrue();
+    }
+    assertThat(committed.get()).isEqualTo(threads);
+    assertThat(repository.findAll()).hasSize(threads);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/StageScopedStatusCrudIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/StageScopedStatusCrudIT.java
@@ -1,0 +1,312 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
+import com.wkspower.platform.domain.port.StatusOptionsStore;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import com.wkspower.platform.infrastructure.persistence.repository.StatusOptionJpaRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Story 3.7 AC3 — backend IT coverage for the append-class status CRUD path. Runs against an H2
+ * datasource with the {@code status_options} migration applied; exercises the full HTTP envelope
+ * for the four endpoints + the durability path (scenario 6 boots a fresh JPA read against the
+ * persisted row).
+ *
+ * <p>Wave-1 lesson #1 honored: this test does not run under the {@code production} profile, so the
+ * {@code ProductionBootstrapValidator} opt-out is not needed here.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:stagestatus3-7;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ="
+    })
+class StageScopedStatusCrudIT {
+
+  private static final String ADMIN_EMAIL = "stage-status-admin@wkspower.local";
+  private static final String PASSWORD = "admin";
+
+  private static final String CASE_TYPE_ID = "loan-application";
+  private static final String STAGE_ID = "intake";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private CaseTypeVersionRegistry versionRegistry;
+  @Autowired private StatusOptionsStore store;
+  @Autowired private StatusOptionJpaRepository repository;
+
+  @BeforeEach
+  void setup() {
+    if (users.findByEmail(ADMIN_EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), ADMIN_EMAIL, Set.of("admin"), true),
+          encoder.encode(PASSWORD));
+    }
+    registry.register(loanType());
+    // Seed a row in case_type_versions for v1 — the admin path depends on
+    // CaseTypeVersionRegistry.currentVersion(...) for the bound version.
+    if (versionRegistry.currentVersion(CASE_TYPE_ID).isEmpty()) {
+      String stub = "id: " + CASE_TYPE_ID + "\nversion: 1\n";
+      versionRegistry.register(CASE_TYPE_ID, stub.getBytes(StandardCharsets.UTF_8), "test:setup");
+    }
+    repository.deleteAll();
+  }
+
+  @Test
+  void getResolvesYamlBaseAndAppendOverlay() {
+    String cookie = login();
+    // Append a custom status, then GET — expect both YAML base statuses + the appended one.
+    appendStatus(cookie, "needs-info", "Needs info", "amber", false, HttpStatus.CREATED);
+
+    ResponseEntity<String> resp = exchange(statusesPath(), HttpMethod.GET, cookie);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(resp.getBody())
+        .contains("\"stageId\":\"intake\"")
+        .contains("\"id\":\"open\"")
+        .contains("\"id\":\"closed\"")
+        .contains("\"id\":\"needs-info\"")
+        .contains("\"initialStatus\":\"open\"");
+  }
+
+  @Test
+  void appendSurvivesFreshJpaContext_Scenario6() {
+    // Scenario 6 — durability across a "fresh JPA context". We approximate container-restart by
+    // bypassing the in-memory cache: write via the controller, then read via the JPA repository
+    // directly to prove the row landed durably.
+    String cookie = login();
+    appendStatus(cookie, "with-vendor", "With vendor", "violet", false, HttpStatus.CREATED);
+
+    Optional<com.wkspower.platform.infrastructure.persistence.entity.StatusOptionEntity> row =
+        repository.findByCaseTypeIdAndVersionAndStageIdAndStatusId(
+            CASE_TYPE_ID, 1, STAGE_ID, "with-vendor");
+    assertThat(row).isPresent();
+    assertThat(row.get().getDisplayName()).isEqualTo("With vendor");
+    assertThat(row.get().getColor()).isEqualTo("violet");
+    assertThat(row.get().isTerminal()).isFalse();
+  }
+
+  @Test
+  void duplicateAppendReturns409_Scenario7() {
+    String cookie = login();
+    appendStatus(cookie, "needs-info", "Needs info", "amber", false, HttpStatus.CREATED);
+
+    ResponseEntity<String> dup =
+        appendStatusRaw(cookie, "needs-info", "Needs info again", "amber", false);
+    assertThat(dup.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(dup.getBody()).contains("WKS-STG-007");
+  }
+
+  @Test
+  void renameUpdatesDisplayName_Scenario8_HappyPath() {
+    String cookie = login();
+    appendStatus(cookie, "needs-info", "Needs info", "amber", false, HttpStatus.CREATED);
+
+    ResponseEntity<String> patched =
+        exchangeWithBody(
+            statusesPath() + "/needs-info",
+            HttpMethod.PATCH,
+            cookie,
+            "{\"displayName\":\"Awaiting docs\"}");
+    assertThat(patched.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(patched.getBody()).contains("\"displayName\":\"Awaiting docs\"");
+
+    // Verify the GET reflects the rename.
+    ResponseEntity<String> getResp = exchange(statusesPath(), HttpMethod.GET, cookie);
+    assertThat(getResp.getBody()).contains("\"displayName\":\"Awaiting docs\"");
+  }
+
+  @Test
+  void terminalFlipReturns405_Scenario8_MutateClassRejection() {
+    String cookie = login();
+    appendStatus(cookie, "needs-info", "Needs info", "amber", false, HttpStatus.CREATED);
+
+    ResponseEntity<String> patched =
+        exchangeWithBody(
+            statusesPath() + "/needs-info", HttpMethod.PATCH, cookie, "{\"terminal\":true}");
+    assertThat(patched.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    assertThat(patched.getBody()).contains("WKS-STG-009");
+  }
+
+  @Test
+  void deleteReturns405_Scenario9() {
+    String cookie = login();
+    appendStatus(cookie, "needs-info", "Needs info", "amber", false, HttpStatus.CREATED);
+
+    ResponseEntity<String> deleted =
+        exchange(statusesPath() + "/needs-info", HttpMethod.DELETE, cookie);
+    assertThat(deleted.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    assertThat(deleted.getBody()).contains("WKS-STG-009");
+  }
+
+  @Test
+  void concurrentAppendsResultInTwoDistinctRows_Scenario11() throws Exception {
+    // Scenario 11 — two threads racing the append on the same stage; expect both rows to land
+    // (distinct status ids) with no lost write.
+    String cookie = login();
+    int threads = 4;
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch start = new CountDownLatch(1);
+    AtomicInteger created = new AtomicInteger();
+    for (int i = 0; i < threads; i++) {
+      final int idx = i;
+      pool.submit(
+          () -> {
+            try {
+              start.await();
+              ResponseEntity<String> resp =
+                  appendStatusRaw(cookie, "concurrent-" + idx, "Concurrent " + idx, "blue", false);
+              if (resp.getStatusCode() == HttpStatus.CREATED) {
+                created.incrementAndGet();
+              }
+            } catch (InterruptedException ignored) {
+              Thread.currentThread().interrupt();
+            }
+          });
+    }
+    start.countDown();
+    pool.shutdown();
+    assertThat(pool.awaitTermination(20, TimeUnit.SECONDS)).isTrue();
+
+    assertThat(created.get()).isEqualTo(threads);
+    List<StatusDefinition> rows = store.listFor(CASE_TYPE_ID, 1, STAGE_ID);
+    assertThat(rows).hasSize(threads);
+    // Ordinals must be distinct across the persisted rows (the in-memory MAX+1 race may produce
+    // ties; we tolerate ties but never overlapping status ids).
+    assertThat(rows.stream().map(StatusDefinition::id).distinct().count()).isEqualTo(threads);
+  }
+
+  @Test
+  void unknownCaseTypeReturns404_WithStg012() {
+    String cookie = login();
+    ResponseEntity<String> resp =
+        exchange("/api/admin/case-types/missing/stages/intake/statuses", HttpMethod.GET, cookie);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(resp.getBody()).contains("WKS-STG-012");
+  }
+
+  @Test
+  void unknownStageReturns404_WithStg012() {
+    String cookie = login();
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/admin/case-types/" + CASE_TYPE_ID + "/stages/missing/statuses",
+            HttpMethod.GET,
+            cookie);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(resp.getBody()).contains("WKS-STG-012");
+  }
+
+  // ---- helpers ----------------------------------------------------------
+
+  private String statusesPath() {
+    return "/api/admin/case-types/" + CASE_TYPE_ID + "/stages/" + STAGE_ID + "/statuses";
+  }
+
+  private void appendStatus(
+      String cookie,
+      String id,
+      String displayName,
+      String color,
+      boolean terminal,
+      HttpStatus expected) {
+    ResponseEntity<String> resp = appendStatusRaw(cookie, id, displayName, color, terminal);
+    assertThat(resp.getStatusCode()).isEqualTo(expected);
+  }
+
+  private ResponseEntity<String> appendStatusRaw(
+      String cookie, String id, String displayName, String color, boolean terminal) {
+    String body =
+        "{\"id\":\""
+            + id
+            + "\",\"displayName\":\""
+            + displayName
+            + "\",\"color\":\""
+            + color
+            + "\",\"terminal\":"
+            + terminal
+            + "}";
+    return exchangeWithBody(statusesPath(), HttpMethod.POST, cookie, body);
+  }
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity(
+            "/api/auth/login", new LoginRequest(ADMIN_EMAIL, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private ResponseEntity<String> exchange(String path, HttpMethod method, String cookie) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(headers), String.class);
+  }
+
+  private ResponseEntity<String> exchangeWithBody(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.COOKIE, cookie);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  private static CaseTypeConfig loanType() {
+    StageDefinition stage = new StageDefinition(STAGE_ID, "Intake", 0);
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Loan Application",
+        1,
+        null,
+        new WorkflowRef("loan-application.bpmn"),
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(
+            new StatusDefinition("open", "Open", StatusColor.ZINC),
+            new StatusDefinition("closed", "Closed", StatusColor.EMERALD, true)),
+        List.of("name"),
+        List.of(new RoleDefinition("admin", List.of(Permission.VIEW))),
+        List.of(stage));
+  }
+}

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -145,7 +145,7 @@ Epic-namespaced sibling band. Codes 001–006 are emitted by `MappingValidator` 
 
 ## WKS-STG — Stage lifecycle runtime + stage-scoped status sets
 
-Band: `WKS-STG-001..099`. Codes 001–004 are Story 3.1 lifecycle errors. Codes 005, 006, 008–011 are Story 3.6 stage-scoped status set codes (deploy-time + transition-time). Code 007 is unallocated; 009 is reserved for Stories 3.7 / 3.8.
+Band: `WKS-STG-001..099`. Codes 001–004 are Story 3.1 lifecycle errors. Codes 005, 006, 008–011 are Story 3.6 stage-scoped status set codes (deploy-time + transition-time). Code 007 is Story 3.7 (live append duplicate). Code 009 is Story 3.7 (mutate-class rejection); Story 3.8 will reuse it under its own envelope. Codes 012, 013 are Story 3.7 admin-CRUD lookup misses.
 
 | Code | HTTP | Meaning | Thrower(s) |
 | --- | --- | --- | --- |
@@ -155,10 +155,13 @@ Band: `WKS-STG-001..099`. Codes 001–004 are Story 3.1 lifecycle errors. Codes 
 | `WKS-STG-004` | 404 | `advance` / `skipTo` references an unknown caseId. | `api/controller/CaseController.java` |
 | `WKS-STG-005` | 422 | Duplicate status id within a stage's status set (Story 3.6 AC3, deploy-time). | `infrastructure/config/ConfigValidator.java` |
 | `WKS-STG-006` | 422 | Stage's `initialStatus:` references an id not present in the stage's status set (Story 3.6 AC3, deploy-time). | `infrastructure/config/ConfigValidator.java` |
+| `WKS-STG-007` | 409 | Append-class admin POST rejected — `statusId` already exists on `(caseTypeId, current-version, stageId)`. Distinct from `WKS-STG-005` (deploy-time YAML duplicate). Story 3.7 AC1 + AC3 scenario 7. | `api/controller/CaseTypeStatusAdminController.java`, `domain/service/StatusOptionsAdminService.java` |
 | `WKS-STG-008` | 422 | Stage's `statuses: []` is empty — must be `>= 1` or omit the key entirely to fall back to the flat set (Story 3.6 AC2, deploy-time). | `infrastructure/config/ConfigValidator.java` |
-| `WKS-STG-009` | — | RESERVED for Story 3.7 (live append) / Story 3.8 (mutate-class version-bump enforcement). Slot reserved by Story 3.6; not emitted. | (reserved — no thrower) |
+| `WKS-STG-009` | 405 | Mutate-class rejection: admin DELETE on a status, or PATCH that flips `terminal`, requires Story 3.8's mutate-class envelope. Reserved by Story 3.6; first emitted by Story 3.7. | `api/controller/CaseTypeStatusAdminController.java` |
 | `WKS-STG-010` | 422 | Transition request targets a status id not declared on the case's current stage's status set (Story 3.6 AC6). Distinct from `WKS-STG-002` ("backward skip", wire-locked by Story 3.1). | `domain/service/CaseService.java` |
 | `WKS-STG-011` | 422 | Transition rejected because the case's current status declares `terminal: true` on the active stage (Story 3.6 AC6). Same-stage transitions are blocked; advance the stage to continue. Distinct from `WKS-STG-001` ("advance/skip on completed/zero-stage case", wire-locked by Story 3.1). | `domain/service/CaseService.java` |
+| `WKS-STG-012` | 404 | Admin status-CRUD path resolved an unknown `caseTypeId` or `stageId`. Distinct from `WKS-STG-004` (runtime advance/skipTo on unknown caseId — that is a CASE id, this is a CASETYPE id). Story 3.7 AC1. | `api/controller/CaseTypeStatusAdminController.java` |
+| `WKS-STG-013` | 404 | Admin `PATCH .../statuses/{statusId}` rename targeted an unknown `statusId` (not in YAML base nor `status_options` delta). Story 3.7 AC1. | `api/controller/CaseTypeStatusAdminController.java`, `domain/service/StatusOptionsAdminService.java` |
 
 ---
 
@@ -197,9 +200,9 @@ Surfaced for follow-up. Items 1, 2, 5, 6 have resolutions deferred to the **Regi
 
 6. **`WKS-CFG-029` is reserved by Story 4.2 but emitted by Story 3.8.** Cross-story references like this are easy to lose. → **Resolved by spec AC4**: adopt `// RESERVED-FOR-STORY-X.Y` annotation convention; sweep enum for other implicit reservations; generator renders reserved codes in a separate section.
 
-7. **`WKS-STG-007` is unallocated; `WKS-STG-012..099` are unallocated.** Preserve clustering when allocating: 001–004 are lifecycle, 005–011 are stage-scoped status sets (Story 3.6), 009 reserved for 3.7/3.8.
+7. **`WKS-STG-014..099` are unallocated.** Preserve clustering when allocating: 001–004 are lifecycle, 005–011 are stage-scoped status sets (Story 3.6), 007/009/012/013 are Story 3.7 admin CRUD (live append).
 
-8. **`WKS-STG-009` reserved cross-story (3.7 / 3.8).** Same pattern as `WKS-CFG-029` (item 6) — slot allocated by Story 3.6 but not emitted by it; consumers are the future live-append (3.7) and mutate-class enforcement (3.8) paths. → **Folds into spec AC4**: same `// RESERVED-FOR-STORY-X.Y` annotation sweep.
+8. **`WKS-STG-009` cross-story consumption (3.7 → 3.8).** Reserved by Story 3.6; first emitted by Story 3.7 (admin DELETE / PATCH terminal → 405). Story 3.8's mutate-class envelope will reuse the SAME code under its own request shape — same wire string, same semantic ("mutate-class change requires version-bump envelope").
 
 9. **`WKS-MAP-404` is the first runtime miss code in the enum.** Story 4.3 introduced an HTTP-status-suffixed code (`404`) inside a band that was previously deploy-time-only (`WKS-MAP-001..007`). → **Resolved 2026-05-06**: prefixes are namespace, not phase. The mixed band is accepted; see Categories section. The generator does not need to surface a runtime/deploy-time axis — the per-code Meaning column carries that information.
 


### PR DESCRIPTION
## Summary

Adds the admin REST surface and durable persistence for append-class status edits per **Decision 21**. Existing mid-flight cases see appended/renamed statuses on the next read via the live resolver; the CaseType version is **never bumped** (mutate-class flows defer to Story 3.8 / `WKS-STG-009` / 405).

Absorbs Story 3.6's deferred AC4 (CRUD endpoints), AC5 (`status_options` table + JPA adapter routed through `CaseTypeVersionRegistry`), and AC9 scenarios 6–9 + 11.

## ACs

- **AC1 ✓** — CRUD endpoints under `/api/admin/case-types/{caseTypeId}/stages/{stageId}/statuses`:
  - `GET` → resolved list (frozen YAML base + `status_options` overlay)
  - `POST` → append (201; `WKS-STG-007` on duplicate id)
  - `PATCH` → rename `displayName`/`color` (terminal-flag flip → 405/`WKS-STG-009`)
  - `DELETE` → 405/`WKS-STG-009` (mutate-class deferred to 3.8)
- **AC2 ✓** — `V202605070001__status_options.sql` migration, JPA entity/repo/adapter, `StatusOptionsStore` port. Writes route through `CaseTypeVersionRegistry.currentVersion`. `__flat__` sentinel for case-type-level rows.
- **AC3 ✓** — `StageScopedStatusCrudIT` covers Story 3.6 deferred scenarios 6/7/8/9/11; `StatusOptionsStorePostgresIT` discharges Postgres-IT parity gap.

## Wire codes minted

- `WKS-STG-007` (409) — duplicate append
- `WKS-STG-009` (405) — mutate-class admin rejection (slot reserved by 3.6, first-emitted here)
- `WKS-STG-012` (404) — admin path unknown caseTypeId/stageId
- `WKS-STG-013` (404) — admin PATCH unknown statusId

`docs/error-codes.md` + `ErrorCode.java` updated; `GlobalExceptionHandler` HTTP-status switch extended for the new codes.

## Live-propagation strategy

**Option (a)** — re-read `status_options` on every call. No cache. Acceptable for Phase-0 traffic per the Q1 brief; option (b) short-TTL cache is a defensible Phase-1 follow-up if observed load demands it. Documented in `StatusOptionsResolver` javadoc.

## Sentinel vs NULL (Q3)

`'__flat__'` string sentinel — keeps composite PK non-nullable and lookups uniform. Matches the spec default; no semantic collision with Story 3.6's in-memory resolver.

## Scope guard vs Wave-2 sibling 4-4

Does **not** touch `CaseTypeReader`, `CaseService.transition`, or `CaseStatusListener` (4-4 territory). The runtime `CaseDtoMapper.toAvailableStatuses` site keeps using the frozen-on-version base; layering the live overlay there is an explicit Phase-1 follow-up to avoid stomping on 4-4's `CaseTypeReader` injection.

## Migration sequence

`V202605070001__status_options.sql` — distinct from 3-5's slot. Last-merger rebases trivially by bumping the timestamp prefix.

## Test plan

- [x] Backend `mvn verify` (497 unit + 102 IT = 599 tests, BUILD SUCCESS)
- [x] Frontend lint + format:check + test (251) + build
- [x] Tenant invariant scan (Story 3.0 + Story 14.7 operator-surface)
- [x] Deploy-runbook shellcheck + tenant scan
- [x] Docker build (loads image successfully)
- [ ] Production-profile smoke (CI-only locally; no production-stack changes in this PR)

## Lessons-from-Wave-1 honored

- No production-profile test added that bypasses `ProductionBootstrapValidator` without the opt-out (only `StatusOptionsStorePostgresIT` uses production profile + opt-out per Story 14.1.1 lesson).
- Postgres-IT covers persistence durability + duplicate rejection.
- Match CI Locally before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)