### PR TITLE
feat(14-5): CSS theming additive — runtime override via /api/theme.css

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/ThemeController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/ThemeController.java
@@ -1,0 +1,60 @@
+package com.wkspower.platform.api.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Serves an optional runtime CSS theme override file.
+ *
+ * <p>When {@code WKS_THEME_CSS_PATH} is set, the file at that path is served as {@code text/css}.
+ * The frontend loads it via {@code <link rel="stylesheet" href="/api/theme.css">} in {@code
+ * index.html}. Because the link tag is placed after the Tailwind-bridged tokens, any SI-provided
+ * {@code :root} overrides cascade over the defaults declared in {@code tokens.css}.
+ *
+ * <p>Returns {@code 204 No Content} when no theme file is configured — the browser ignores an empty
+ * stylesheet link gracefully.
+ *
+ * <p>This endpoint is unauthenticated (it serves static CSS — no sensitive data) and is registered
+ * as {@code permitAll} in {@link com.wkspower.platform.security.SecurityConfig}.
+ */
+@RestController
+@RequestMapping("/api")
+public class ThemeController {
+
+  private final String themeCssPath;
+
+  public ThemeController(@Value("${wks.theme.css-path:}") String themeCssPath) {
+    this.themeCssPath = themeCssPath;
+  }
+
+  @GetMapping(value = "/theme.css", produces = "text/css")
+  @Operation(
+      summary = "Runtime CSS theme override",
+      description =
+          "Serves the SI-provided CSS override file (WKS_THEME_CSS_PATH). Returns 204 when not"
+              + " configured.")
+  @SecurityRequirements // public — no auth required
+  public ResponseEntity<Resource> theme() throws IOException {
+    if (themeCssPath == null || themeCssPath.isBlank()) {
+      return ResponseEntity.noContent().build();
+    }
+    Path path = Path.of(themeCssPath);
+    if (!Files.exists(path) || !Files.isReadable(path)) {
+      return ResponseEntity.noContent().build();
+    }
+    byte[] content = Files.readAllBytes(path);
+    return ResponseEntity.ok()
+        .header("Content-Type", "text/css; charset=UTF-8")
+        .body(new ByteArrayResource(content));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/api/controller/ThemeController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/ThemeController.java
@@ -2,9 +2,12 @@ package com.wkspower.platform.api.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -17,24 +20,40 @@ import org.springframework.web.bind.annotation.RestController;
  * Serves an optional runtime CSS theme override file.
  *
  * <p>When {@code WKS_THEME_CSS_PATH} is set, the file at that path is served as {@code text/css}.
- * The frontend loads it via {@code <link rel="stylesheet" href="/api/theme.css">} in {@code
- * index.html}. Because the link tag is placed after the Tailwind-bridged tokens, any SI-provided
- * {@code :root} overrides cascade over the defaults declared in {@code tokens.css}.
+ * The frontend injects it via a script that appends a {@code <link>} tag after all Vite-bundled CSS
+ * links, ensuring any SI-provided {@code :root} overrides cascade over the defaults in {@code
+ * tokens.css}.
  *
  * <p>Returns {@code 204 No Content} when no theme file is configured — the browser ignores an empty
  * stylesheet link gracefully.
  *
  * <p>This endpoint is unauthenticated (it serves static CSS — no sensitive data) and is registered
  * as {@code permitAll} in {@link com.wkspower.platform.security.SecurityConfig}.
+ *
+ * <p>Guards (I1): the path must end with {@code .css} (case-insensitive) and the file must be at
+ * most 1 MiB. Violations return 204 and are logged as warnings so operators can diagnose
+ * misconfiguration.
  */
 @RestController
 @RequestMapping("/api")
 public class ThemeController {
 
+  private static final Logger log = LoggerFactory.getLogger(ThemeController.class);
+  private static final long MAX_CSS_BYTES = 1_048_576L; // 1 MiB
+
   private final String themeCssPath;
 
   public ThemeController(@Value("${wks.theme.css-path:}") String themeCssPath) {
     this.themeCssPath = themeCssPath;
+  }
+
+  @PostConstruct
+  void logResolvedPath() {
+    if (themeCssPath == null || themeCssPath.isBlank()) {
+      log.info("ThemeController: WKS_THEME_CSS_PATH not configured — /api/theme.css returns 204");
+    } else {
+      log.info("ThemeController: resolved theme CSS path = {}", themeCssPath);
+    }
   }
 
   @GetMapping(value = "/theme.css", produces = "text/css")
@@ -48,13 +67,34 @@ public class ThemeController {
     if (themeCssPath == null || themeCssPath.isBlank()) {
       return ResponseEntity.noContent().build();
     }
+
+    // Guard I1a: path must end with .css
+    if (!themeCssPath.toLowerCase().endsWith(".css")) {
+      log.warn(
+          "ThemeController: WKS_THEME_CSS_PATH='{}' does not end with .css — returning 204",
+          themeCssPath);
+      return ResponseEntity.noContent().build();
+    }
+
     Path path = Path.of(themeCssPath);
     if (!Files.exists(path) || !Files.isReadable(path)) {
       return ResponseEntity.noContent().build();
     }
+
+    // Guard I1b: cap at 1 MiB
+    long size = Files.size(path);
+    if (size > MAX_CSS_BYTES) {
+      log.warn(
+          "ThemeController: theme file '{}' is {} bytes (> 1 MiB limit) — returning 204",
+          themeCssPath,
+          size);
+      return ResponseEntity.noContent().build();
+    }
+
     byte[] content = Files.readAllBytes(path);
     return ResponseEntity.ok()
         .header("Content-Type", "text/css; charset=UTF-8")
+        .header("Cache-Control", "public, max-age=300") // I2: 5-min browser cache
         .body(new ByteArrayResource(content));
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/security/SecurityConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/security/SecurityConfig.java
@@ -86,6 +86,8 @@ public class SecurityConfig {
                   .permitAll()
                   .requestMatchers(HttpMethod.GET, "/api/health")
                   .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/api/theme.css")
+                  .permitAll()
                   .requestMatchers(HttpMethod.POST, "/api/auth/login", "/api/auth/logout")
                   .permitAll();
               if (exposeOpenApi) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -83,6 +83,10 @@ wks:
     # Default: boot with the registered subset. Set to true for fail-fast in CI or strict
     # production rollouts.
     fail-on-invalid: ${WKS_CASE_TYPES_FAIL_ON_INVALID:false}
+  # Story 14.5 — runtime CSS theme override. When set, GET /api/theme.css serves the file at
+  # this path. Unset (default) → 204 No Content; the browser ignores the empty link gracefully.
+  theme:
+    css-path: ${WKS_THEME_CSS_PATH:}
 
 logging:
   level:

--- a/backend/src/test/java/com/wkspower/platform/api/controller/ThemeControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/ThemeControllerTest.java
@@ -2,6 +2,7 @@ package com.wkspower.platform.api.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wkspower.platform.domain.port.UserRepository;
@@ -9,6 +10,7 @@ import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
 import com.wkspower.platform.security.SecurityConfig;
 import java.net.URL;
+import java.nio.file.Paths;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +19,7 @@ import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.MapPropertySource;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -25,12 +28,16 @@ import org.springframework.test.web.servlet.MockMvc;
 /**
  * Slice tests for {@code GET /api/theme.css} (Story 14.5).
  *
- * <p>Two nested classes cover the two branches:
+ * <p>Three branches:
  *
  * <ul>
  *   <li>{@link WhenNoCssPathConfigured} — blank path → 204 No Content.
+ *   <li>{@link WhenFileIsMissing} — path configured but file absent → 204 No Content.
  *   <li>{@link WhenCssFileConfigured} — valid file path → 200 + {@code text/css} body.
  * </ul>
+ *
+ * <p>Each branch also asserts that the endpoint is reachable without authentication (M3 — {@code
+ * permitAll} guard).
  */
 class ThemeControllerTest {
 
@@ -52,15 +59,48 @@ class ThemeControllerTest {
     void returns204WhenNoThemeConfigured() throws Exception {
       mockMvc.perform(get("/api/theme.css")).andExpect(status().isNoContent());
     }
+
+    /** M3 — anonymous users must not receive 401/403 (permitAll assertion). */
+    @Test
+    @WithAnonymousUser
+    void anonymousUserIsPermitted() throws Exception {
+      mockMvc
+          .perform(get("/api/theme.css"))
+          .andExpect(
+              status().is(Matchers.not(Matchers.either(Matchers.is(401)).or(Matchers.is(403)))));
+    }
   }
 
   // ---------------------------------------------------------------------------
-  // Branch 2: WKS_THEME_CSS_PATH points to test-theme.css → 200 + CSS body
+  // Branch 2: path configured but file does not exist → 204
+  // ---------------------------------------------------------------------------
+
+  @WebMvcTest(ThemeController.class)
+  @Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+  @TestPropertySource(properties = "wks.theme.css-path=/tmp/nonexistent-99999.css")
+  static class WhenFileIsMissing {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private JwtTokenProvider jwtTokenProvider;
+    @MockitoBean private UserRepository userRepository;
+
+    @Test
+    void returns204WhenFileIsMissing() throws Exception {
+      mockMvc.perform(get("/api/theme.css")).andExpect(status().isNoContent());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Branch 3: WKS_THEME_CSS_PATH points to test-theme.css → 200 + CSS body
   // ---------------------------------------------------------------------------
 
   /**
    * Resolves the absolute filesystem path of {@code test-theme.css} from the test classpath and
    * registers it as {@code wks.theme.css-path} before the application context starts.
+   *
+   * <p>Uses {@code Paths.get(url.toURI())} (M1) instead of {@code url.getPath()} to avoid
+   * URL-encoding issues when the workspace path contains spaces.
    */
   static class TestThemePathInitializer
       implements ApplicationContextInitializer<ConfigurableApplicationContext> {
@@ -71,7 +111,12 @@ class ThemeControllerTest {
       if (url == null) {
         throw new IllegalStateException("test-theme.css not found in test classpath");
       }
-      String path = url.getPath();
+      String path;
+      try {
+        path = Paths.get(url.toURI()).toString(); // M1: safe for paths with spaces
+      } catch (java.net.URISyntaxException e) {
+        throw new IllegalStateException("Cannot resolve test-theme.css URI: " + url, e);
+      }
       ctx.getEnvironment()
           .getPropertySources()
           .addFirst(
@@ -96,7 +141,18 @@ class ThemeControllerTest {
           .perform(get("/api/theme.css"))
           .andExpect(status().isOk())
           .andExpect(content().contentTypeCompatibleWith("text/css"))
-          .andExpect(content().string(Matchers.containsString("--primary: #ff0000")));
+          .andExpect(content().string(Matchers.containsString("--primary: #ff0000")))
+          .andExpect(header().string("Cache-Control", "public, max-age=300")); // I2
+    }
+
+    /** M3 — anonymous users must receive the CSS, not a 401/403. */
+    @Test
+    @WithAnonymousUser
+    void anonymousUserReceivesCss() throws Exception {
+      mockMvc
+          .perform(get("/api/theme.css"))
+          .andExpect(
+              status().is(Matchers.not(Matchers.either(Matchers.is(401)).or(Matchers.is(403)))));
     }
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/api/controller/ThemeControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/ThemeControllerTest.java
@@ -1,0 +1,102 @@
+package com.wkspower.platform.api.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.security.JwtAuthenticationFilter;
+import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SecurityConfig;
+import java.net.URL;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Slice tests for {@code GET /api/theme.css} (Story 14.5).
+ *
+ * <p>Two nested classes cover the two branches:
+ *
+ * <ul>
+ *   <li>{@link WhenNoCssPathConfigured} — blank path → 204 No Content.
+ *   <li>{@link WhenCssFileConfigured} — valid file path → 200 + {@code text/css} body.
+ * </ul>
+ */
+class ThemeControllerTest {
+
+  // ---------------------------------------------------------------------------
+  // Branch 1: no WKS_THEME_CSS_PATH configured → 204
+  // ---------------------------------------------------------------------------
+
+  @WebMvcTest(ThemeController.class)
+  @Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+  @TestPropertySource(properties = "wks.theme.css-path=")
+  static class WhenNoCssPathConfigured {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private JwtTokenProvider jwtTokenProvider;
+    @MockitoBean private UserRepository userRepository;
+
+    @Test
+    void returns204WhenNoThemeConfigured() throws Exception {
+      mockMvc.perform(get("/api/theme.css")).andExpect(status().isNoContent());
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Branch 2: WKS_THEME_CSS_PATH points to test-theme.css → 200 + CSS body
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resolves the absolute filesystem path of {@code test-theme.css} from the test classpath and
+   * registers it as {@code wks.theme.css-path} before the application context starts.
+   */
+  static class TestThemePathInitializer
+      implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext ctx) {
+      URL url = getClass().getClassLoader().getResource("test-theme.css");
+      if (url == null) {
+        throw new IllegalStateException("test-theme.css not found in test classpath");
+      }
+      String path = url.getPath();
+      ctx.getEnvironment()
+          .getPropertySources()
+          .addFirst(
+              new MapPropertySource(
+                  "theme-test-props", java.util.Map.of("wks.theme.css-path", path)));
+    }
+  }
+
+  @WebMvcTest(ThemeController.class)
+  @Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+  @ContextConfiguration(initializers = TestThemePathInitializer.class)
+  static class WhenCssFileConfigured {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private JwtTokenProvider jwtTokenProvider;
+    @MockitoBean private UserRepository userRepository;
+
+    @Test
+    void returnsCssContentWhenThemeFileConfigured() throws Exception {
+      mockMvc
+          .perform(get("/api/theme.css"))
+          .andExpect(status().isOk())
+          .andExpect(content().contentTypeCompatibleWith("text/css"))
+          .andExpect(content().string(Matchers.containsString("--primary: #ff0000")));
+    }
+  }
+}

--- a/backend/src/test/resources/test-theme.css
+++ b/backend/src/test/resources/test-theme.css
@@ -1,0 +1,5 @@
+/* Test theme override — Story 14.5 ThemeControllerTest fixture.
+   Overrides --primary to red so the test can assert CSS content is served correctly. */
+:root {
+  --primary: #ff0000;
+}

--- a/docker/.env.production.example
+++ b/docker/.env.production.example
@@ -61,6 +61,11 @@ WKS_JWT_SECRET=<MUST-BE-ROTATED>
 # when /v3/api-docs is unauthenticated). Set true to enable.
 WKS_OPENAPI_ENABLED=false
 
+# CSS theme override — Story 14.5. Mount a CSS file and set this to its path
+# (e.g. /config/theme.css). The file is served as GET /api/theme.css and loaded
+# by the frontend at startup. Unset (default) → no override; defaults apply.
+WKS_THEME_CSS_PATH=
+
 # Keycloak/SSO seam — RESERVED forward-compat seam for Story 10.4. Setting
 # this to `true` today logs a WARN at boot (WKS-AUTH-001) and changes NOTHING
 # about auth enforcement. Built-in cookie-JWT (Story 1.2) is the sole auth

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,7 +14,9 @@
          a 204 (no file configured) is handled silently — no JS required. SI developers can
          override :root variables (--primary, --secondary, --brand-navy, --font-heading,
          --font-body) in the file served at WKS_THEME_CSS_PATH to brand the platform without
-         rebuilding the image. -->
+         rebuilding the image.
+         NOTE: the Vite plugin 'theme-link-last' (vite.config.ts) moves this link to just before
+         </head> in the production build, so it loads AFTER bundled CSS and wins the :root cascade. -->
     <link rel="stylesheet" href="/api/theme.css" />
   </head>
   <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,12 @@
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230B1437'/%3E%3Ctext x='16' y='22' font-family='system-ui,sans-serif' font-size='14' font-weight='700' fill='%2322D3EE' text-anchor='middle'%3EW%3C/text%3E%3C/svg%3E"
     />
     <title>WKS Platform v2</title>
+    <!-- Story 14.5: runtime CSS theme override. The browser fetches /api/theme.css at startup;
+         a 204 (no file configured) is handled silently — no JS required. SI developers can
+         override :root variables (--primary, --secondary, --brand-navy, --font-heading,
+         --font-body) in the file served at WKS_THEME_CSS_PATH to brand the platform without
+         rebuilding the image. -->
+    <link rel="stylesheet" href="/api/theme.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,3 +1,28 @@
+/*
+ * SI Override Surface — Story 14.5
+ * =================================
+ * The variables below are the primary brand surface. An SI developer can override
+ * any of them by mounting a CSS file at the path set by WKS_THEME_CSS_PATH. The
+ * file is served at GET /api/theme.css and loaded after these defaults, so the
+ * cascade applies automatically — no image rebuild or frontend recompile required.
+ *
+ * Minimum override set (declare as :root overrides in your theme file):
+ *   --primary        Primary brand color            default indigo  (#3b5bdb)
+ *   --secondary      Secondary accent               default cyan    (#22d3ee)
+ *   --brand-navy     Dark sidebar/header background default navy    (#0b1437)
+ *   --font-heading   Heading font-family            default Poppins
+ *   --font-body      Body font-family               default Rubik
+ *   --logo-url       Optional CSS background-image URL for a custom logo;
+ *                    not used by default components but available for
+ *                    white-label CSS rules.
+ *
+ * All variables bridged via the @theme inline block in index.css cascade
+ * automatically into Tailwind v4 utility classes (bg-primary, text-secondary,
+ * etc.) without any additional configuration.
+ *
+ * White-label deepening (logo swap, per-field overrides, label customization)
+ * is deferred to Story 15.6.
+ */
 :root {
   /* Brand + semantic colors */
   --primary: #3b5bdb;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,8 +4,31 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+/**
+ * Story 14.5 — B1: ensure the runtime theme override link loads AFTER bundled CSS.
+ *
+ * Vite injects fingerprinted <link> tags into <head> during the production build.
+ * Whatever was already in index.html ends up BEFORE those injected links, so the
+ * SI-provided :root overrides would lose the cascade to tokens.css defaults.
+ *
+ * This plugin strips the theme link from wherever Vite placed it and re-appends it
+ * just before </head>, guaranteeing last-loaded wins for equal-specificity :root rules.
+ */
+const themeLinkLast = {
+  name: 'theme-link-last',
+  transformIndexHtml(html: string): string {
+    const themeLink = '<link rel="stylesheet" href="/api/theme.css">';
+    const themeLinkSelfClosing = '<link rel="stylesheet" href="/api/theme.css" />';
+    // Remove all occurrences (Vite may or may not normalise self-closing tags)
+    html = html.split(themeLink).join('');
+    html = html.split(themeLinkSelfClosing).join('');
+    // Re-inject just before </head> so it is the last stylesheet
+    return html.replace('</head>', `  ${themeLink}\n  </head>`);
+  },
+};
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), themeLinkLast],
   build: {
     // Never inline font files as data URLs — keep them as separate
     // fingerprinted assets so the browser can cache them independently


### PR DESCRIPTION
## Summary
- New `ThemeController`: `GET /api/theme.css` serves file at `WKS_THEME_CSS_PATH` (204 when not configured)
- `SecurityConfig` permits `/api/theme.css` without auth (CSS must load before login)
- Vite `themeLinkLast` plugin re-injects the theme `<link>` after the bundled CSS in `dist/index.html` — ensures SI override wins the `:root` cascade (AC1)
- All 251 existing frontend tests pass; tokens.css values untouched (AC2)
- Overridable variable surface documented in `tokens.css` header (AC3)
- Frontend CI gauntlet: lint ✓, format:check ✓, 251 tests ✓, build ✓, 4 woff2 assets ✓ (AC4)

## Acceptance criteria
- [x] AC1 — CSS override cascades at runtime (no rebuild) — theme link confirmed last in dist/index.html
- [x] AC2 — 251 existing tests pass; tokens.css values unchanged
- [x] AC3 — overridable variable surface documented
- [x] AC4 — frontend CI gauntlet green

## Review fixes applied
- **B1 fixed**: Vite `themeLinkLast` plugin ensures `<link href="/api/theme.css">` appears after `<link href="/assets/index-*.css">` in production build
- **I1**: `.css` extension guard + 1 MiB file-size cap on `ThemeController`; startup path logging
- **I2**: `Cache-Control: public, max-age=300` on 200 response
- Test gaps closed: missing-file 204 branch, unauthenticated access, `URL.toURI()` path fix

## Merge order
Merge third (after 7-1). No cross-story dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)