### PR TITLE
feat(7-2): OSS-fallback behavior on missing/expired license

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/LicenseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/LicenseController.java
@@ -1,0 +1,59 @@
+package com.wkspower.platform.api.controller;
+
+import com.wkspower.platform.api.dto.ApiResponse;
+import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.LicenseState;
+import io.swagger.v3.oas.annotations.Operation;
+import java.time.Instant;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes the current license state to authenticated frontend clients.
+ *
+ * <p>{@code GET /api/license/status} returns a {@link LicenseStatusDto} so the frontend can render
+ * an appropriate banner for {@code expired} and {@code degraded} states. The {@code oss} state (no
+ * license file present) is the expected default — no banner is shown for it.
+ *
+ * <p>Accessible to all authenticated users. No {@code @PreAuthorize} needed — {@code
+ * SecurityConfig} grants all {@code /api/**} requests to authenticated users by default.
+ */
+@RestController
+@RequestMapping("/api/license")
+public class LicenseController {
+
+  /**
+   * Wire-stable DTO for the license status response.
+   *
+   * @param state one of {@code "valid" | "oss" | "expired" | "degraded"}
+   * @param tier the active tier string (e.g. {@code "oss"}, {@code "team"}, {@code "enterprise"})
+   * @param expiredAt ISO-8601 instant string when state is {@code "expired"}; {@code null}
+   *     otherwise
+   */
+  public record LicenseStatusDto(String state, String tier, String expiredAt) {}
+
+  private final LicenseService licenseService;
+
+  public LicenseController(LicenseService licenseService) {
+    this.licenseService = licenseService;
+  }
+
+  @GetMapping("/status")
+  @Operation(
+      summary = "License status",
+      description =
+          "Returns the current license state, tier, and expiry (if expired). Accessible to all"
+              + " authenticated users. No banner is shown by the frontend for the 'oss' state.")
+  public ApiResponse<LicenseStatusDto> status() {
+    LicenseState licenseState = licenseService.getLicenseState();
+    String tier = licenseService.getTier();
+    Instant expiry = licenseService.getExpiry();
+
+    String stateStr = licenseState.name().toLowerCase();
+    String expiredAt =
+        (licenseState == LicenseState.EXPIRED && expiry != null) ? expiry.toString() : null;
+
+    return ApiResponse.success(new LicenseStatusDto(stateStr, tier, expiredAt));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/api/controller/LicenseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/LicenseController.java
@@ -2,9 +2,10 @@ package com.wkspower.platform.api.controller;
 
 import com.wkspower.platform.api.dto.ApiResponse;
 import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.LicenseSnapshot;
 import com.wkspower.platform.domain.service.LicenseState;
 import io.swagger.v3.oas.annotations.Operation;
-import java.time.Instant;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,15 +46,16 @@ public class LicenseController {
       description =
           "Returns the current license state, tier, and expiry (if expired). Accessible to all"
               + " authenticated users. No banner is shown by the frontend for the 'oss' state.")
-  public ApiResponse<LicenseStatusDto> status() {
-    LicenseState licenseState = licenseService.getLicenseState();
-    String tier = licenseService.getTier();
-    Instant expiry = licenseService.getExpiry();
+  public ApiResponse<LicenseStatusDto> status(HttpServletResponse response) {
+    response.setHeader("Cache-Control", "no-store");
 
-    String stateStr = licenseState.name().toLowerCase();
+    LicenseSnapshot snap = licenseService.getLicenseSnapshot();
+    String stateStr = snap.licenseState().toWireString();
     String expiredAt =
-        (licenseState == LicenseState.EXPIRED && expiry != null) ? expiry.toString() : null;
+        (snap.licenseState() == LicenseState.EXPIRED && snap.expiry() != null)
+            ? snap.expiry().toString()
+            : null;
 
-    return ApiResponse.success(new LicenseStatusDto(stateStr, tier, expiredAt));
+    return ApiResponse.success(new LicenseStatusDto(stateStr, snap.tier(), expiredAt));
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/service/LicenseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/LicenseService.java
@@ -39,4 +39,16 @@ public interface LicenseService {
    * when no valid license is loaded.
    */
   String getLicenseHolder();
+
+  /**
+   * Returns the resolved {@link LicenseState} for the current license. Never throws.
+   *
+   * <ul>
+   *   <li>{@link LicenseState#VALID} — non-expired, signature-verified JWT is loaded.
+   *   <li>{@link LicenseState#OSS} — no license file configured or present.
+   *   <li>{@link LicenseState#EXPIRED} — valid signature but {@code exp} is in the past.
+   *   <li>{@link LicenseState#DEGRADED} — file present but unverifiable.
+   * </ul>
+   */
+  LicenseState getLicenseState();
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/service/LicenseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/LicenseService.java
@@ -51,4 +51,11 @@ public interface LicenseService {
    * </ul>
    */
   LicenseState getLicenseState();
+
+  /**
+   * Returns a consistent point-in-time snapshot of the license state, tier, and expiry. Use this
+   * instead of calling {@link #getLicenseState()}, {@link #getTier()}, and {@link #getExpiry()}
+   * separately to avoid torn reads across concurrent state updates.
+   */
+  LicenseSnapshot getLicenseSnapshot();
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/service/LicenseSnapshot.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/LicenseSnapshot.java
@@ -1,0 +1,10 @@
+package com.wkspower.platform.domain.service;
+
+import java.time.Instant;
+
+/**
+ * Immutable point-in-time view of the resolved license state. Returned by {@link
+ * LicenseService#getLicenseSnapshot()} so callers can read all fields from a single consistent read
+ * without risk of torn reads across multiple service calls.
+ */
+public record LicenseSnapshot(LicenseState licenseState, String tier, Instant expiry) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/LicenseState.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/LicenseState.java
@@ -30,5 +30,18 @@ public enum LicenseState {
   /**
    * License file present but unverifiable (bad signature, malformed JWT, I/O error). OSS fallback.
    */
-  DEGRADED
+  DEGRADED;
+
+  /**
+   * Returns the stable wire string for this state as sent to frontend clients. Explicit mapping
+   * ensures that renaming an enum variant never silently breaks the API contract.
+   */
+  public String toWireString() {
+    return switch (this) {
+      case VALID -> "valid";
+      case OSS -> "oss";
+      case EXPIRED -> "expired";
+      case DEGRADED -> "degraded";
+    };
+  }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/service/LicenseState.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/LicenseState.java
@@ -1,0 +1,34 @@
+package com.wkspower.platform.domain.service;
+
+/**
+ * Represents the resolved state of the platform license.
+ *
+ * <p>State semantics:
+ *
+ * <ul>
+ *   <li>{@link #VALID} — a valid, non-expired Ed25519-signed JWT was loaded.
+ *   <li>{@link #OSS} — no license file is present (the default, expected state for OSS users).
+ *   <li>{@link #EXPIRED} — a validly-signed JWT was found but its {@code exp} claim is in the past.
+ *       The expiry timestamp is still readable for display. All EE features are disabled.
+ *   <li>{@link #DEGRADED} — a license file was found but could not be parsed (bad signature,
+ *       malformed JWT, or any other failure). All EE features are disabled.
+ * </ul>
+ *
+ * <p>The platform NEVER refuses to boot due to license issues (AC4). This enum is always populated
+ * with a valid value — it never throws.
+ */
+public enum LicenseState {
+  /** Valid, non-expired license loaded. EE features enabled per JWT claims. */
+  VALID,
+
+  /** No license file configured or present. Platform operates in OSS mode — not an error. */
+  OSS,
+
+  /** License JWT has a valid signature but its {@code exp} claim is in the past. OSS fallback. */
+  EXPIRED,
+
+  /**
+   * License file present but unverifiable (bad signature, malformed JWT, I/O error). OSS fallback.
+   */
+  DEGRADED
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/license/LicenseServiceImpl.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/license/LicenseServiceImpl.java
@@ -2,7 +2,9 @@ package com.wkspower.platform.infrastructure.license;
 
 import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.LicenseState;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import java.io.IOException;
@@ -47,19 +49,34 @@ public class LicenseServiceImpl implements LicenseService {
   private static final String OSS_TIER = "oss";
 
   /** Immutable snapshot of parsed license state. */
-  private record LicenseState(
-      boolean valid, String tier, String holder, Instant expiry, List<String> features) {
+  private record LicenseSnapshot(
+      LicenseState licenseState,
+      String tier,
+      String holder,
+      Instant expiry,
+      List<String> features) {
 
-    static LicenseState oss() {
-      return new LicenseState(false, OSS_TIER, null, null, Collections.emptyList());
+    static LicenseSnapshot oss() {
+      return new LicenseSnapshot(LicenseState.OSS, OSS_TIER, null, null, Collections.emptyList());
     }
 
-    static LicenseState degraded() {
-      return new LicenseState(false, OSS_TIER, null, null, Collections.emptyList());
+    static LicenseSnapshot degraded() {
+      return new LicenseSnapshot(
+          LicenseState.DEGRADED, OSS_TIER, null, null, Collections.emptyList());
     }
 
-    static LicenseState loaded(String tier, String holder, Instant expiry, List<String> features) {
-      return new LicenseState(true, tier, holder, expiry, features);
+    static LicenseSnapshot expired(Instant expiry) {
+      return new LicenseSnapshot(
+          LicenseState.EXPIRED, OSS_TIER, null, expiry, Collections.emptyList());
+    }
+
+    static LicenseSnapshot loaded(
+        String tier, String holder, Instant expiry, List<String> features) {
+      return new LicenseSnapshot(LicenseState.VALID, tier, holder, expiry, features);
+    }
+
+    boolean valid() {
+      return licenseState == LicenseState.VALID;
     }
   }
 
@@ -69,7 +86,8 @@ public class LicenseServiceImpl implements LicenseService {
   /** Tracks the last-seen {@code lastModified} for hot-reload. */
   private volatile long lastModifiedSeen = -1L;
 
-  private final AtomicReference<LicenseState> state = new AtomicReference<>(LicenseState.oss());
+  private final AtomicReference<LicenseSnapshot> state =
+      new AtomicReference<>(LicenseSnapshot.oss());
 
   /**
    * @param licenseFilePath path to the license JWT file (may be empty/null for OSS mode)
@@ -87,7 +105,7 @@ public class LicenseServiceImpl implements LicenseService {
 
   @Override
   public boolean isFeatureEnabled(String featureKey) {
-    LicenseState s = state.get();
+    LicenseSnapshot s = state.get();
     return s.valid() && s.features().contains(featureKey);
   }
 
@@ -104,6 +122,11 @@ public class LicenseServiceImpl implements LicenseService {
   @Override
   public String getLicenseHolder() {
     return state.get().holder();
+  }
+
+  @Override
+  public LicenseState getLicenseState() {
+    return state.get().licenseState();
   }
 
   // -------------------------------------------------------------------------
@@ -134,7 +157,10 @@ public class LicenseServiceImpl implements LicenseService {
       if (current != lastModifiedSeen) {
         lastModifiedSeen = current;
         load();
-        LOG.info("[LicenseService] License reloaded — tier={}", state.get().tier());
+        LOG.info(
+            "[LicenseService] License reloaded — tier={}, state={}",
+            state.get().tier(),
+            state.get().licenseState());
       }
     } catch (IOException e) {
       LOG.warn("[LicenseService] License poll failed reading lastModified: {}", e.getMessage());
@@ -148,7 +174,7 @@ public class LicenseServiceImpl implements LicenseService {
   /** Reads, verifies, and atomically updates in-memory state. Never throws. */
   public void load() {
     if (licenseFilePath == null || licenseFilePath.isBlank()) {
-      state.set(LicenseState.oss());
+      state.set(LicenseSnapshot.oss());
       LOG.info(
           "{} No license file configured — operating in OSS mode", ErrorCode.WKS_LIC_001.wire());
       return;
@@ -156,7 +182,7 @@ public class LicenseServiceImpl implements LicenseService {
 
     Path path = Path.of(licenseFilePath);
     if (!Files.exists(path)) {
-      state.set(LicenseState.oss());
+      state.set(LicenseSnapshot.oss());
       LOG.info(
           "{} License file not found at '{}' — operating in OSS mode",
           ErrorCode.WKS_LIC_001.wire(),
@@ -168,7 +194,7 @@ public class LicenseServiceImpl implements LicenseService {
     try {
       jwt = Files.readString(path, StandardCharsets.UTF_8).strip();
     } catch (IOException e) {
-      state.set(LicenseState.degraded());
+      state.set(LicenseSnapshot.degraded());
       LOG.warn(
           "{} License file unreadable: {} — operating in degraded state",
           ErrorCode.WKS_LIC_001.wire(),
@@ -193,7 +219,7 @@ public class LicenseServiceImpl implements LicenseService {
         features = Collections.emptyList();
       }
 
-      LicenseState loaded = LicenseState.loaded(tier, holder, expiry, features);
+      LicenseSnapshot loaded = LicenseSnapshot.loaded(tier, holder, expiry, features);
       state.set(loaded);
       LOG.info(
           "[LicenseService] License active — tier={}, holder={}, expires={}",
@@ -201,10 +227,22 @@ public class LicenseServiceImpl implements LicenseService {
           holder,
           expiry != null ? expiry.toString() : "never");
 
-    } catch (JwtException | IllegalArgumentException e) {
-      state.set(LicenseState.degraded());
+    } catch (ExpiredJwtException e) {
+      // Catch ExpiredJwtException before the general JwtException so we can extract
+      // the expiry timestamp from the still-accessible claims.
+      Instant expiry =
+          e.getClaims() != null && e.getClaims().getExpiration() != null
+              ? e.getClaims().getExpiration().toInstant()
+              : null;
+      state.set(LicenseSnapshot.expired(expiry));
       LOG.warn(
-          "{} License JWT invalid or expired: {} — operating in degraded state",
+          "{} License JWT expired (exp={}) — operating in OSS fallback mode",
+          ErrorCode.WKS_LIC_002.wire(),
+          expiry != null ? expiry.toString() : "unknown");
+    } catch (JwtException | IllegalArgumentException e) {
+      state.set(LicenseSnapshot.degraded());
+      LOG.warn(
+          "{} License JWT invalid: {} — operating in degraded state",
           ErrorCode.WKS_LIC_002.wire(),
           e.getMessage());
     }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/license/LicenseServiceImpl.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/license/LicenseServiceImpl.java
@@ -2,6 +2,7 @@ package com.wkspower.platform.infrastructure.license;
 
 import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.LicenseSnapshot;
 import com.wkspower.platform.domain.service.LicenseState;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -48,31 +49,30 @@ public class LicenseServiceImpl implements LicenseService {
 
   private static final String OSS_TIER = "oss";
 
-  /** Immutable snapshot of parsed license state. */
-  private record LicenseSnapshot(
+  private record InternalSnapshot(
       LicenseState licenseState,
       String tier,
       String holder,
       Instant expiry,
       List<String> features) {
 
-    static LicenseSnapshot oss() {
-      return new LicenseSnapshot(LicenseState.OSS, OSS_TIER, null, null, Collections.emptyList());
+    static InternalSnapshot oss() {
+      return new InternalSnapshot(LicenseState.OSS, OSS_TIER, null, null, Collections.emptyList());
     }
 
-    static LicenseSnapshot degraded() {
-      return new LicenseSnapshot(
+    static InternalSnapshot degraded() {
+      return new InternalSnapshot(
           LicenseState.DEGRADED, OSS_TIER, null, null, Collections.emptyList());
     }
 
-    static LicenseSnapshot expired(Instant expiry) {
-      return new LicenseSnapshot(
+    static InternalSnapshot expired(Instant expiry) {
+      return new InternalSnapshot(
           LicenseState.EXPIRED, OSS_TIER, null, expiry, Collections.emptyList());
     }
 
-    static LicenseSnapshot loaded(
+    static InternalSnapshot loaded(
         String tier, String holder, Instant expiry, List<String> features) {
-      return new LicenseSnapshot(LicenseState.VALID, tier, holder, expiry, features);
+      return new InternalSnapshot(LicenseState.VALID, tier, holder, expiry, features);
     }
 
     boolean valid() {
@@ -86,8 +86,8 @@ public class LicenseServiceImpl implements LicenseService {
   /** Tracks the last-seen {@code lastModified} for hot-reload. */
   private volatile long lastModifiedSeen = -1L;
 
-  private final AtomicReference<LicenseSnapshot> state =
-      new AtomicReference<>(LicenseSnapshot.oss());
+  private final AtomicReference<InternalSnapshot> state =
+      new AtomicReference<>(InternalSnapshot.oss());
 
   /**
    * @param licenseFilePath path to the license JWT file (may be empty/null for OSS mode)
@@ -105,7 +105,7 @@ public class LicenseServiceImpl implements LicenseService {
 
   @Override
   public boolean isFeatureEnabled(String featureKey) {
-    LicenseSnapshot s = state.get();
+    InternalSnapshot s = state.get();
     return s.valid() && s.features().contains(featureKey);
   }
 
@@ -127,6 +127,12 @@ public class LicenseServiceImpl implements LicenseService {
   @Override
   public LicenseState getLicenseState() {
     return state.get().licenseState();
+  }
+
+  @Override
+  public LicenseSnapshot getLicenseSnapshot() {
+    InternalSnapshot s = state.get();
+    return new LicenseSnapshot(s.licenseState(), s.tier(), s.expiry());
   }
 
   // -------------------------------------------------------------------------
@@ -155,8 +161,8 @@ public class LicenseServiceImpl implements LicenseService {
     try {
       long current = Files.getLastModifiedTime(path).toMillis();
       if (current != lastModifiedSeen) {
-        lastModifiedSeen = current;
         load();
+        lastModifiedSeen = current;
         LOG.info(
             "[LicenseService] License reloaded — tier={}, state={}",
             state.get().tier(),
@@ -174,7 +180,7 @@ public class LicenseServiceImpl implements LicenseService {
   /** Reads, verifies, and atomically updates in-memory state. Never throws. */
   public void load() {
     if (licenseFilePath == null || licenseFilePath.isBlank()) {
-      state.set(LicenseSnapshot.oss());
+      state.set(InternalSnapshot.oss());
       LOG.info(
           "{} No license file configured — operating in OSS mode", ErrorCode.WKS_LIC_001.wire());
       return;
@@ -182,7 +188,7 @@ public class LicenseServiceImpl implements LicenseService {
 
     Path path = Path.of(licenseFilePath);
     if (!Files.exists(path)) {
-      state.set(LicenseSnapshot.oss());
+      state.set(InternalSnapshot.oss());
       LOG.info(
           "{} License file not found at '{}' — operating in OSS mode",
           ErrorCode.WKS_LIC_001.wire(),
@@ -194,7 +200,7 @@ public class LicenseServiceImpl implements LicenseService {
     try {
       jwt = Files.readString(path, StandardCharsets.UTF_8).strip();
     } catch (IOException e) {
-      state.set(LicenseSnapshot.degraded());
+      state.set(InternalSnapshot.degraded());
       LOG.warn(
           "{} License file unreadable: {} — operating in degraded state",
           ErrorCode.WKS_LIC_001.wire(),
@@ -219,7 +225,7 @@ public class LicenseServiceImpl implements LicenseService {
         features = Collections.emptyList();
       }
 
-      LicenseSnapshot loaded = LicenseSnapshot.loaded(tier, holder, expiry, features);
+      InternalSnapshot loaded = InternalSnapshot.loaded(tier, holder, expiry, features);
       state.set(loaded);
       LOG.info(
           "[LicenseService] License active — tier={}, holder={}, expires={}",
@@ -230,17 +236,21 @@ public class LicenseServiceImpl implements LicenseService {
     } catch (ExpiredJwtException e) {
       // Catch ExpiredJwtException before the general JwtException so we can extract
       // the expiry timestamp from the still-accessible claims.
-      Instant expiry =
-          e.getClaims() != null && e.getClaims().getExpiration() != null
-              ? e.getClaims().getExpiration().toInstant()
-              : null;
-      state.set(LicenseSnapshot.expired(expiry));
+      if (e.getClaims() == null || e.getClaims().getExpiration() == null) {
+        state.set(InternalSnapshot.degraded());
+        LOG.warn(
+            "{} License JWT expired but claims unreadable — operating in degraded state",
+            ErrorCode.WKS_LIC_002.wire());
+        return;
+      }
+      Instant expiry = e.getClaims().getExpiration().toInstant();
+      state.set(InternalSnapshot.expired(expiry));
       LOG.warn(
           "{} License JWT expired (exp={}) — operating in OSS fallback mode",
           ErrorCode.WKS_LIC_002.wire(),
-          expiry != null ? expiry.toString() : "unknown");
+          expiry.toString());
     } catch (JwtException | IllegalArgumentException e) {
-      state.set(LicenseSnapshot.degraded());
+      state.set(InternalSnapshot.degraded());
       LOG.warn(
           "{} License JWT invalid: {} — operating in degraded state",
           ErrorCode.WKS_LIC_002.wire(),

--- a/backend/src/test/java/com/wkspower/platform/api/controller/LicenseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/LicenseControllerTest.java
@@ -1,0 +1,141 @@
+package com.wkspower.platform.api.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.LicenseState;
+import com.wkspower.platform.security.AuthenticatedUser;
+import com.wkspower.platform.security.JwtAuthenticationFilter;
+import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SecurityConfig;
+import com.wkspower.platform.security.WksUserPrincipal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Slice test for {@link LicenseController}.
+ *
+ * <p>Verifies that {@code GET /api/license/status} returns a correct {@code LicenseStatusDto} for
+ * each {@link LicenseState} variant and that unauthenticated requests are rejected with 401.
+ */
+@WebMvcTest(LicenseController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class LicenseControllerTest {
+
+  @Autowired MockMvc mockMvc;
+
+  @MockitoBean LicenseService licenseService;
+  @MockitoBean JwtTokenProvider jwtTokenProvider;
+  @MockitoBean UserRepository userRepository;
+
+  private static final UUID ACTOR_ID = UUID.randomUUID();
+
+  private Authentication auth() {
+    AuthenticatedUser user = new AuthenticatedUser(ACTOR_ID, "user@wkspower.local", Set.of("user"));
+    WksUserPrincipal principal = new WksUserPrincipal(user);
+    return new UsernamePasswordAuthenticationToken(
+        principal, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+  }
+
+  // -------------------------------------------------------------------------
+  // VALID state
+  // -------------------------------------------------------------------------
+
+  @Test
+  void validState_returnsValidDtoWithTierAndNoExpiredAt() throws Exception {
+    when(licenseService.getLicenseState()).thenReturn(LicenseState.VALID);
+    when(licenseService.getTier()).thenReturn("enterprise");
+    when(licenseService.getExpiry()).thenReturn(Instant.parse("2027-01-01T00:00:00Z"));
+
+    mockMvc
+        .perform(get("/api/license/status").with(authentication(auth())))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.state").value("valid"))
+        .andExpect(jsonPath("$.data.tier").value("enterprise"))
+        .andExpect(jsonPath("$.data.expiredAt").doesNotExist())
+        .andExpect(jsonPath("$.error").doesNotExist());
+  }
+
+  // -------------------------------------------------------------------------
+  // OSS state
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ossState_returnsOssTierAndNoExpiredAt() throws Exception {
+    when(licenseService.getLicenseState()).thenReturn(LicenseState.OSS);
+    when(licenseService.getTier()).thenReturn("oss");
+    when(licenseService.getExpiry()).thenReturn(null);
+
+    mockMvc
+        .perform(get("/api/license/status").with(authentication(auth())))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.state").value("oss"))
+        .andExpect(jsonPath("$.data.tier").value("oss"))
+        .andExpect(jsonPath("$.data.expiredAt").doesNotExist())
+        .andExpect(jsonPath("$.error").doesNotExist());
+  }
+
+  // -------------------------------------------------------------------------
+  // EXPIRED state — expiry timestamp must be included in response
+  // -------------------------------------------------------------------------
+
+  @Test
+  void expiredState_returnsExpiredTierOssAndIsoExpiredAt() throws Exception {
+    Instant expiredAt = Instant.parse("2025-12-31T23:59:59Z");
+    when(licenseService.getLicenseState()).thenReturn(LicenseState.EXPIRED);
+    when(licenseService.getTier()).thenReturn("oss");
+    when(licenseService.getExpiry()).thenReturn(expiredAt);
+
+    mockMvc
+        .perform(get("/api/license/status").with(authentication(auth())))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.state").value("expired"))
+        .andExpect(jsonPath("$.data.tier").value("oss"))
+        .andExpect(jsonPath("$.data.expiredAt").value("2025-12-31T23:59:59Z"))
+        .andExpect(jsonPath("$.error").doesNotExist());
+  }
+
+  // -------------------------------------------------------------------------
+  // DEGRADED state
+  // -------------------------------------------------------------------------
+
+  @Test
+  void degradedState_returnsOssTierAndNoExpiredAt() throws Exception {
+    when(licenseService.getLicenseState()).thenReturn(LicenseState.DEGRADED);
+    when(licenseService.getTier()).thenReturn("oss");
+    when(licenseService.getExpiry()).thenReturn(null);
+
+    mockMvc
+        .perform(get("/api/license/status").with(authentication(auth())))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.state").value("degraded"))
+        .andExpect(jsonPath("$.data.tier").value("oss"))
+        .andExpect(jsonPath("$.data.expiredAt").doesNotExist())
+        .andExpect(jsonPath("$.error").doesNotExist());
+  }
+
+  // -------------------------------------------------------------------------
+  // Unauthenticated request must be rejected
+  // -------------------------------------------------------------------------
+
+  @Test
+  void unauthenticated_returns401() throws Exception {
+    mockMvc.perform(get("/api/license/status")).andExpect(status().isUnauthorized());
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/api/controller/LicenseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/LicenseControllerTest.java
@@ -3,11 +3,13 @@ package com.wkspower.platform.api.controller;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wkspower.platform.domain.port.UserRepository;
 import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.LicenseSnapshot;
 import com.wkspower.platform.domain.service.LicenseState;
 import com.wkspower.platform.security.AuthenticatedUser;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
@@ -59,13 +61,15 @@ class LicenseControllerTest {
 
   @Test
   void validState_returnsValidDtoWithTierAndNoExpiredAt() throws Exception {
-    when(licenseService.getLicenseState()).thenReturn(LicenseState.VALID);
-    when(licenseService.getTier()).thenReturn("enterprise");
-    when(licenseService.getExpiry()).thenReturn(Instant.parse("2027-01-01T00:00:00Z"));
+    when(licenseService.getLicenseSnapshot())
+        .thenReturn(
+            new LicenseSnapshot(
+                LicenseState.VALID, "enterprise", Instant.parse("2027-01-01T00:00:00Z")));
 
     mockMvc
         .perform(get("/api/license/status").with(authentication(auth())))
         .andExpect(status().isOk())
+        .andExpect(header().string("Cache-Control", "no-store"))
         .andExpect(jsonPath("$.data.state").value("valid"))
         .andExpect(jsonPath("$.data.tier").value("enterprise"))
         .andExpect(jsonPath("$.data.expiredAt").doesNotExist())
@@ -78,13 +82,13 @@ class LicenseControllerTest {
 
   @Test
   void ossState_returnsOssTierAndNoExpiredAt() throws Exception {
-    when(licenseService.getLicenseState()).thenReturn(LicenseState.OSS);
-    when(licenseService.getTier()).thenReturn("oss");
-    when(licenseService.getExpiry()).thenReturn(null);
+    when(licenseService.getLicenseSnapshot())
+        .thenReturn(new LicenseSnapshot(LicenseState.OSS, "oss", null));
 
     mockMvc
         .perform(get("/api/license/status").with(authentication(auth())))
         .andExpect(status().isOk())
+        .andExpect(header().string("Cache-Control", "no-store"))
         .andExpect(jsonPath("$.data.state").value("oss"))
         .andExpect(jsonPath("$.data.tier").value("oss"))
         .andExpect(jsonPath("$.data.expiredAt").doesNotExist())
@@ -98,13 +102,13 @@ class LicenseControllerTest {
   @Test
   void expiredState_returnsExpiredTierOssAndIsoExpiredAt() throws Exception {
     Instant expiredAt = Instant.parse("2025-12-31T23:59:59Z");
-    when(licenseService.getLicenseState()).thenReturn(LicenseState.EXPIRED);
-    when(licenseService.getTier()).thenReturn("oss");
-    when(licenseService.getExpiry()).thenReturn(expiredAt);
+    when(licenseService.getLicenseSnapshot())
+        .thenReturn(new LicenseSnapshot(LicenseState.EXPIRED, "oss", expiredAt));
 
     mockMvc
         .perform(get("/api/license/status").with(authentication(auth())))
         .andExpect(status().isOk())
+        .andExpect(header().string("Cache-Control", "no-store"))
         .andExpect(jsonPath("$.data.state").value("expired"))
         .andExpect(jsonPath("$.data.tier").value("oss"))
         .andExpect(jsonPath("$.data.expiredAt").value("2025-12-31T23:59:59Z"))
@@ -117,13 +121,13 @@ class LicenseControllerTest {
 
   @Test
   void degradedState_returnsOssTierAndNoExpiredAt() throws Exception {
-    when(licenseService.getLicenseState()).thenReturn(LicenseState.DEGRADED);
-    when(licenseService.getTier()).thenReturn("oss");
-    when(licenseService.getExpiry()).thenReturn(null);
+    when(licenseService.getLicenseSnapshot())
+        .thenReturn(new LicenseSnapshot(LicenseState.DEGRADED, "oss", null));
 
     mockMvc
         .perform(get("/api/license/status").with(authentication(auth())))
         .andExpect(status().isOk())
+        .andExpect(header().string("Cache-Control", "no-store"))
         .andExpect(jsonPath("$.data.state").value("degraded"))
         .andExpect(jsonPath("$.data.tier").value("oss"))
         .andExpect(jsonPath("$.data.expiredAt").doesNotExist())

--- a/backend/src/test/java/com/wkspower/platform/domain/service/LicenseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/LicenseServiceTest.java
@@ -75,6 +75,7 @@ class LicenseServiceTest {
 
     LicenseServiceImpl svc = serviceFor(licenseFile.toString());
 
+    assertThat(svc.getLicenseState()).isEqualTo(LicenseState.VALID);
     assertThat(svc.getTier()).isEqualTo("enterprise");
     assertThat(svc.getLicenseHolder()).isEqualTo("Acme Corp");
     assertThat(svc.getExpiry()).isEqualTo(expiry);
@@ -103,6 +104,7 @@ class LicenseServiceTest {
 
     LicenseServiceImpl svc = serviceFor(licenseFile.toString());
 
+    assertThat(svc.getLicenseState()).isEqualTo(LicenseState.DEGRADED);
     assertThat(svc.getTier()).isEqualTo("oss");
     assertThat(svc.isFeatureEnabled("everything")).isFalse();
     assertThat(svc.getLicenseHolder()).isNull();
@@ -119,6 +121,7 @@ class LicenseServiceTest {
 
     LicenseServiceImpl svc = serviceFor(licenseFile.toString());
 
+    assertThat(svc.getLicenseState()).isEqualTo(LicenseState.DEGRADED);
     assertThat(svc.getTier()).isEqualTo("oss");
     assertThat(svc.isFeatureEnabled("any-feature")).isFalse();
   }
@@ -132,6 +135,7 @@ class LicenseServiceTest {
     // Path that does not exist.
     LicenseServiceImpl svc = serviceFor(tempDir.resolve("nonexistent.jwt").toString());
 
+    assertThat(svc.getLicenseState()).isEqualTo(LicenseState.OSS);
     assertThat(svc.getTier()).isEqualTo("oss");
     assertThat(svc.isFeatureEnabled("advanced-reporting")).isFalse();
     assertThat(svc.getLicenseHolder()).isNull();
@@ -146,6 +150,7 @@ class LicenseServiceTest {
   void blankFilePath_ossMode() {
     LicenseServiceImpl svc = serviceFor("");
 
+    assertThat(svc.getLicenseState()).isEqualTo(LicenseState.OSS);
     assertThat(svc.getTier()).isEqualTo("oss");
     assertThat(svc.isFeatureEnabled("any")).isFalse();
   }
@@ -192,16 +197,20 @@ class LicenseServiceTest {
   }
 
   // -------------------------------------------------------------------------
-  // Fix 3 — Expired JWT: falls back to degraded state, no exception thrown
+  // AC2 / Story 7-2 — Expired JWT: EXPIRED state with expiry populated
   // -------------------------------------------------------------------------
 
   @Test
-  void expiredJwt_degradedState_noException() throws IOException {
-    // Build a JWT whose expiry is 60 seconds in the past.
+  void expiredJwt_expiredState_expiryPopulated_noException() throws IOException {
+    // Build a JWT whose expiry is 1 day in the past (signed with the test key — valid signature).
+    Instant pastExpiry =
+        Instant.now()
+            .minus(1, java.time.temporal.ChronoUnit.DAYS)
+            .truncatedTo(java.time.temporal.ChronoUnit.SECONDS);
     String jwt =
         Jwts.builder()
             .subject("Expired Corp")
-            .expiration(Date.from(Instant.now().minusSeconds(60)))
+            .expiration(Date.from(pastExpiry))
             .claim("tier", "enterprise")
             .claim("features", List.of("advanced-reporting"))
             .signWith(testKeyPair.getPrivate())
@@ -210,11 +219,13 @@ class LicenseServiceTest {
 
     LicenseServiceImpl svc = serviceFor(licenseFile.toString());
 
-    // JJWT rejects expired tokens with JwtException → service falls to degraded/oss state
-    assertThat(svc.getTier()).isEqualTo("oss");
+    // ExpiredJwtException is caught separately — state is EXPIRED, expiry is readable
+    assertThat(svc.getLicenseState()).isEqualTo(LicenseState.EXPIRED);
+    assertThat(svc.getTier()).isEqualTo("oss"); // EE features disabled on expiry
     assertThat(svc.isFeatureEnabled("advanced-reporting")).isFalse();
-    assertThat(svc.getLicenseHolder()).isNull();
-    assertThat(svc.getExpiry()).isNull();
+    assertThat(svc.getExpiry()).isNotNull();
+    assertThat(svc.getExpiry()).isEqualTo(pastExpiry);
+    assertThat(svc.getLicenseHolder()).isNull(); // holder not preserved on expiry
   }
 
   // -------------------------------------------------------------------------
@@ -240,6 +251,7 @@ class LicenseServiceTest {
     LicenseServiceImpl svc = serviceFor(licenseFile.toString());
 
     // Algorithm mismatch → JwtException → degraded/oss state; no exception escapes
+    assertThat(svc.getLicenseState()).isEqualTo(LicenseState.DEGRADED);
     assertThat(svc.getTier()).isEqualTo("oss");
     assertThat(svc.isFeatureEnabled("everything")).isFalse();
     assertThat(svc.getLicenseHolder()).isNull();

--- a/frontend/src/api/license.ts
+++ b/frontend/src/api/license.ts
@@ -16,7 +16,7 @@ export interface LicenseStatus {
  *  - {@code "expired"}  — valid signature but past expiry; banner with date shown.
  *  - {@code "degraded"} — file present but unverifiable; banner without date shown.
  */
-export async function getLicenseStatus(): Promise<LicenseStatus> {
-  const result = await apiFetch<LicenseStatus>('/api/license/status');
+export async function getLicenseStatus(signal?: AbortSignal): Promise<LicenseStatus> {
+  const result = await apiFetch<LicenseStatus>('/api/license/status', { signal });
   return result.data;
 }

--- a/frontend/src/api/license.ts
+++ b/frontend/src/api/license.ts
@@ -1,0 +1,22 @@
+import { apiFetch } from './client';
+
+export interface LicenseStatus {
+  state: 'valid' | 'oss' | 'expired' | 'degraded';
+  tier: string;
+  expiredAt: string | null;
+}
+
+/**
+ * Fetches the current license status from {@code GET /api/license/status}.
+ *
+ * The backend returns a standard WKS envelope — {@code apiFetch} unwraps it.
+ * State semantics:
+ *  - {@code "valid"}    — non-expired license loaded; no banner shown.
+ *  - {@code "oss"}      — no license file present; no banner shown (expected default).
+ *  - {@code "expired"}  — valid signature but past expiry; banner with date shown.
+ *  - {@code "degraded"} — file present but unverifiable; banner without date shown.
+ */
+export async function getLicenseStatus(): Promise<LicenseStatus> {
+  const result = await apiFetch<LicenseStatus>('/api/license/status');
+  return result.data;
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 import { RouteErrorBoundary } from '@/components/errors/RouteErrorBoundary';
 
 import { DarkSidebar } from './DarkSidebar';
+import { LicenseBanner } from './LicenseBanner';
 import { SessionExpiryBanner } from './SessionExpiryBanner';
 import { SkipLink } from './SkipLink';
 import { TopBar } from './TopBar';
@@ -15,6 +16,7 @@ export function AppShell() {
       <DarkSidebar />
       <div className="flex min-w-0 flex-col">
         <SessionExpiryBanner />
+        <LicenseBanner />
         <TopBar />
         <main
           id="main"

--- a/frontend/src/components/layout/LicenseBanner.test.tsx
+++ b/frontend/src/components/layout/LicenseBanner.test.tsx
@@ -42,6 +42,7 @@ describe('LicenseBanner', () => {
     const alert = await findByRole('alert');
     expect(alert).toBeInTheDocument();
     expect(alert).toHaveTextContent(/operating in OSS mode/i);
+    expect(alert).toHaveTextContent('Dec 31, 2025');
   });
 
   it('renders banner without date when state is "degraded"', async () => {

--- a/frontend/src/components/layout/LicenseBanner.test.tsx
+++ b/frontend/src/components/layout/LicenseBanner.test.tsx
@@ -1,0 +1,72 @@
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import type { LicenseStatus } from '@/api/license';
+import { renderWithProviders } from '@/test/renderWithProviders';
+import { server } from '@/test/server';
+import type { ApiSuccessEnvelope } from '@/types/api';
+
+import { LicenseBanner } from './LicenseBanner';
+
+function licenseMswHandler(status: LicenseStatus) {
+  return http.get('/api/license/status', () =>
+    HttpResponse.json<ApiSuccessEnvelope<LicenseStatus>>(
+      { data: status, meta: {} },
+      { status: 200 },
+    ),
+  );
+}
+
+describe('LicenseBanner', () => {
+  it('renders nothing when state is "oss"', async () => {
+    server.use(licenseMswHandler({ state: 'oss', tier: 'oss', expiredAt: null }));
+    const { container } = renderWithProviders(<LicenseBanner />);
+    // Wait a tick for the fetch to settle
+    await new Promise((r) => setTimeout(r, 0));
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('renders nothing when state is "valid"', async () => {
+    server.use(licenseMswHandler({ state: 'valid', tier: 'enterprise', expiredAt: null }));
+    const { container } = renderWithProviders(<LicenseBanner />);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('renders banner with expiry date when state is "expired"', async () => {
+    server.use(
+      licenseMswHandler({ state: 'expired', tier: 'oss', expiredAt: '2025-12-31T00:00:00Z' }),
+    );
+    const { findByRole } = renderWithProviders(<LicenseBanner />);
+    const alert = await findByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent(/operating in OSS mode/i);
+  });
+
+  it('renders banner without date when state is "degraded"', async () => {
+    server.use(licenseMswHandler({ state: 'degraded', tier: 'oss', expiredAt: null }));
+    const { findByRole } = renderWithProviders(<LicenseBanner />);
+    const alert = await findByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent(/could not be verified/i);
+  });
+
+  it('hides the banner after clicking dismiss', async () => {
+    const user = userEvent.setup();
+    server.use(
+      licenseMswHandler({ state: 'expired', tier: 'oss', expiredAt: '2025-01-01T00:00:00Z' }),
+    );
+    const { findByRole, queryByRole, getByLabelText } = renderWithProviders(<LicenseBanner />);
+    expect(await findByRole('alert')).toBeInTheDocument();
+    await user.click(getByLabelText(/dismiss/i));
+    expect(queryByRole('alert')).toBeNull();
+  });
+
+  it('has role="alert" and aria-live="assertive"', async () => {
+    server.use(licenseMswHandler({ state: 'degraded', tier: 'oss', expiredAt: null }));
+    const { findByRole } = renderWithProviders(<LicenseBanner />);
+    const alert = await findByRole('alert');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+  });
+});

--- a/frontend/src/components/layout/LicenseBanner.tsx
+++ b/frontend/src/components/layout/LicenseBanner.tsx
@@ -1,0 +1,43 @@
+import { X } from 'lucide-react';
+
+import { Button } from '@/components/ui/Button';
+import { useLicenseBanner } from '@/hooks/useLicenseBanner';
+import { t } from '@/i18n';
+import { formatDate } from '@/lib/formatDate';
+
+/**
+ * Shows a dismissible warning banner when the license is expired or degraded.
+ *
+ * - State {@code "expired"}: renders an amber/warning banner with the expiry date.
+ * - State {@code "degraded"}: renders the same banner without a date.
+ * - State {@code "valid"} / {@code "oss"} / {@code null}: renders nothing.
+ * - Dismissed banners are suppressed for the rest of the browser session via sessionStorage.
+ *   A new tab or a state change will re-show the banner.
+ *
+ * Follows the same structure as {@link SessionExpiryBanner}.
+ */
+export function LicenseBanner() {
+  const { state, expiredAt, isDismissed, dismiss } = useLicenseBanner();
+
+  if (isDismissed || state === null || state === 'valid' || state === 'oss') {
+    return null;
+  }
+
+  const message =
+    state === 'expired'
+      ? t('license.expired.banner', { date: expiredAt ? formatDate(expiredAt) : '' })
+      : t('license.degraded.banner');
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex items-center justify-between gap-[var(--space-4)] border-b border-[var(--warning)]/30 bg-[var(--warning)]/10 px-[var(--space-4)] py-[var(--space-2)] text-sm text-[var(--warning)]"
+    >
+      <span>{message}</span>
+      <Button variant="ghost" size="icon" onClick={dismiss} aria-label={t('license.dismiss')}>
+        <X className="size-4" aria-hidden="true" />
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useLicenseBanner.test.ts
+++ b/frontend/src/hooks/useLicenseBanner.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { LicenseStatus } from '@/api/license';
+import { server } from '@/test/server';
+import type { ApiSuccessEnvelope } from '@/types/api';
+
+import { useLicenseBanner } from './useLicenseBanner';
+
+function handler(status: LicenseStatus) {
+  return http.get('/api/license/status', () =>
+    HttpResponse.json<ApiSuccessEnvelope<LicenseStatus>>(
+      { data: status, meta: {} },
+      { status: 200 },
+    ),
+  );
+}
+
+describe('useLicenseBanner', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('returns null state initially, then resolves to the fetched state', async () => {
+    server.use(handler({ state: 'degraded', tier: 'oss', expiredAt: null }));
+    const { result } = renderHook(() => useLicenseBanner());
+    expect(result.current.state).toBeNull();
+    await waitFor(() => expect(result.current.state).toBe('degraded'));
+  });
+
+  it('exposes expiredAt for expired state', async () => {
+    server.use(handler({ state: 'expired', tier: 'oss', expiredAt: '2025-12-31T00:00:00Z' }));
+    const { result } = renderHook(() => useLicenseBanner());
+    await waitFor(() => expect(result.current.state).toBe('expired'));
+    expect(result.current.expiredAt).toBe('2025-12-31T00:00:00Z');
+  });
+
+  it('isDismissed is false by default', async () => {
+    server.use(handler({ state: 'expired', tier: 'oss', expiredAt: '2025-12-31T00:00:00Z' }));
+    const { result } = renderHook(() => useLicenseBanner());
+    await waitFor(() => expect(result.current.state).toBe('expired'));
+    expect(result.current.isDismissed).toBe(false);
+  });
+
+  it('dismiss() sets isDismissed to true and writes sessionStorage', async () => {
+    server.use(handler({ state: 'expired', tier: 'oss', expiredAt: '2025-12-31T00:00:00Z' }));
+    const { result } = renderHook(() => useLicenseBanner());
+    await waitFor(() => expect(result.current.state).toBe('expired'));
+
+    act(() => result.current.dismiss());
+
+    expect(result.current.isDismissed).toBe(true);
+    expect(sessionStorage.getItem('wks.licenseBanner.dismissed.expired')).toBe('1');
+  });
+
+  it('isDismissed reads from sessionStorage on state transition', async () => {
+    // Pre-seed dismiss for "degraded"
+    sessionStorage.setItem('wks.licenseBanner.dismissed.degraded', '1');
+    server.use(handler({ state: 'degraded', tier: 'oss', expiredAt: null }));
+    const { result } = renderHook(() => useLicenseBanner());
+    await waitFor(() => expect(result.current.state).toBe('degraded'));
+    expect(result.current.isDismissed).toBe(true);
+  });
+
+  it('dismiss key is state-scoped — different states do not share dismiss', async () => {
+    // Dismiss "expired", then check "degraded" is not dismissed
+    sessionStorage.setItem('wks.licenseBanner.dismissed.expired', '1');
+    server.use(handler({ state: 'degraded', tier: 'oss', expiredAt: null }));
+    const { result } = renderHook(() => useLicenseBanner());
+    await waitFor(() => expect(result.current.state).toBe('degraded'));
+    expect(result.current.isDismissed).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useLicenseBanner.ts
+++ b/frontend/src/hooks/useLicenseBanner.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { getLicenseStatus, type LicenseStatus } from '@/api/license';
+
+const POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Returns `true` when the banner should be visible (expired or degraded state AND not dismissed).
+ *
+ * The dismiss key is scoped by state so that a state transition (e.g. expired → valid after
+ * a license renewal, then back to expired for a different reason) re-shows the banner even
+ * in the same browser session.
+ */
+function dismissKey(state: string): string {
+  return `wks.licenseBanner.dismissed.${state}`;
+}
+
+export interface UseLicenseBannerResult {
+  /** The current license state string, or {@code null} while the initial fetch is in flight. */
+  state: LicenseStatus['state'] | null;
+  /** ISO-8601 expiry string when state is {@code "expired"}, otherwise {@code null}. */
+  expiredAt: string | null;
+  /** Whether the user dismissed the banner this session. */
+  isDismissed: boolean;
+  /** Suppress the banner for the rest of the browser session (sessionStorage-backed). */
+  dismiss: () => void;
+}
+
+/**
+ * Fetches {@code GET /api/license/status} on mount and re-fetches every 60 seconds.
+ *
+ * The backend polls its license file every 30 seconds, so a 60-second frontend interval
+ * catches the next reload cycle without hammering the API.
+ *
+ * Banner is only shown for {@code "expired"} and {@code "degraded"} states. The {@code "oss"}
+ * state is the expected default for users without a license file — showing a banner there
+ * would be noise.
+ */
+export function useLicenseBanner(): UseLicenseBannerResult {
+  const [licenseState, setLicenseState] = useState<LicenseStatus['state'] | null>(null);
+  const [expiredAt, setExpiredAt] = useState<string | null>(null);
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  const poll = useCallback(async () => {
+    try {
+      const status = await getLicenseStatus();
+      setLicenseState(status.state);
+      setExpiredAt(status.expiredAt);
+      // Re-check sessionStorage: if the state changed, the old dismiss key won't match,
+      // so the banner will re-appear for the new state.
+      const dismissed = sessionStorage.getItem(dismissKey(status.state)) === '1';
+      setIsDismissed(dismissed);
+    } catch {
+      // Network or auth error — don't change current state; banner stays as-is.
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    void poll();
+  }, [poll]);
+
+  // Polling interval
+  useEffect(() => {
+    const id = setInterval(() => void poll(), POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [poll]);
+
+  const dismiss = useCallback(() => {
+    if (licenseState) {
+      sessionStorage.setItem(dismissKey(licenseState), '1');
+    }
+    setIsDismissed(true);
+  }, [licenseState]);
+
+  return { state: licenseState, expiredAt, isDismissed, dismiss };
+}

--- a/frontend/src/hooks/useLicenseBanner.ts
+++ b/frontend/src/hooks/useLicenseBanner.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { getLicenseStatus, type LicenseStatus } from '@/api/license';
 
@@ -13,6 +13,14 @@ const POLL_INTERVAL_MS = 60_000;
  */
 function dismissKey(state: string): string {
   return `wks.licenseBanner.dismissed.${state}`;
+}
+
+function trySessionSet(key: string, value: string): void {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    // Safari private mode — ignored; in-memory dismiss state still takes effect
+  }
 }
 
 export interface UseLicenseBannerResult {
@@ -41,37 +49,50 @@ export function useLicenseBanner(): UseLicenseBannerResult {
   const [expiredAt, setExpiredAt] = useState<string | null>(null);
   const [isDismissed, setIsDismissed] = useState(false);
 
-  const poll = useCallback(async () => {
-    try {
-      const status = await getLicenseStatus();
-      setLicenseState(status.state);
-      setExpiredAt(status.expiredAt);
-      // Re-check sessionStorage: if the state changed, the old dismiss key won't match,
-      // so the banner will re-appear for the new state.
-      const dismissed = sessionStorage.getItem(dismissKey(status.state)) === '1';
-      setIsDismissed(dismissed);
-    } catch {
-      // Network or auth error — don't change current state; banner stays as-is.
+  // Holds the latest licenseState for use inside the dismiss callback without stale closure.
+  const licenseStateRef = useRef<LicenseStatus['state'] | null>(null);
+  licenseStateRef.current = licenseState;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    async function fetchStatus(): Promise<void> {
+      try {
+        const status = await getLicenseStatus(signal);
+        setLicenseState(status.state);
+        setExpiredAt(status.expiredAt);
+
+        if (status.state === 'valid') {
+          // Clear stale dismiss keys so a subsequent expiry re-shows the banner.
+          sessionStorage.removeItem('wks.licenseBanner.dismissed.expired');
+          sessionStorage.removeItem('wks.licenseBanner.dismissed.degraded');
+          setIsDismissed(false);
+        } else {
+          const dismissed = sessionStorage.getItem(dismissKey(status.state)) === '1';
+          setIsDismissed(dismissed);
+        }
+      } catch {
+        // Network or auth error — don't change current state; banner stays as-is.
+      }
     }
+
+    void fetchStatus();
+    const id = setInterval(() => void fetchStatus(), POLL_INTERVAL_MS);
+
+    return () => {
+      controller.abort();
+      clearInterval(id);
+    };
   }, []);
 
-  // Initial fetch
-  useEffect(() => {
-    void poll();
-  }, [poll]);
-
-  // Polling interval
-  useEffect(() => {
-    const id = setInterval(() => void poll(), POLL_INTERVAL_MS);
-    return () => clearInterval(id);
-  }, [poll]);
-
   const dismiss = useCallback(() => {
-    if (licenseState) {
-      sessionStorage.setItem(dismissKey(licenseState), '1');
+    const current = licenseStateRef.current;
+    if (current) {
+      trySessionSet(dismissKey(current), '1');
     }
     setIsDismissed(true);
-  }, [licenseState]);
+  }, []);
 
   return { state: licenseState, expiredAt, isDismissed, dismiss };
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -37,6 +37,10 @@
   "session.reauth": "Log in again",
   "session.dismiss": "Dismiss",
 
+  "license.expired.banner": "License expired on {date} — operating in OSS mode.",
+  "license.degraded.banner": "License could not be verified — operating in OSS mode.",
+  "license.dismiss": "Dismiss",
+
   "error.title": "Something unexpected happened",
   "error.savedServerSide": "Your work is saved on the server.",
   "error.reload": "Reload",


### PR DESCRIPTION
## Summary

- **`LicenseState` enum** — new domain type `VALID | OSS | EXPIRED | DEGRADED`
- **`LicenseServiceImpl` refactor** — inner record renamed to `LicenseSnapshot`; `ExpiredJwtException` caught before generic `JwtException` so the `exp` timestamp is readable from the claims even after expiry; `EXPIRED` state carries the expiry `Instant` for API display
- **`GET /api/license/status`** — new `LicenseController` returns `{ state, tier, expiredAt }` to all authenticated users
- **Frontend banner** — `useLicenseBanner` hook (60 s poll, sessionStorage dismiss keyed by state) + `LicenseBanner` component wired into `AppShell` after `SessionExpiryBanner`; shows for `expired`/`degraded`, silent for `oss`/`valid`

## Acceptance Criteria coverage

| AC | Status |
|----|--------|
| AC1 — missing license boots as OSS | ✓ regression-free (7-1 behaviour preserved) |
| AC2 — expired license returns EXPIRED state + dated banner | ✓ |
| AC3 — dismiss is session-scoped by state | ✓ |
| AC4 — never boot-blocks | ✓ (existing no-fail posture untouched) |

## Test plan

- [ ] `mvn verify -B` — all backend tests green (13 license tests + full suite)
- [ ] `mvn verify -P tenant-invariant-lint` — clean
- [ ] `npm run lint && npm run format:check && npm run test && npm run build` — 263 frontend tests green, build clean
- [ ] Manual smoke: start backend with no license file → `GET /api/license/status` returns `{"state":"oss",...}`
- [ ] Manual smoke: provide expired JWT → API returns `{"state":"expired","expiredAt":"<ISO>"}` → banner visible in UI with dismiss

## Sprint lessons applied

- `@EnableScheduling` remains on `@SpringBootApplication` (Sprint 5 fix — not moved)
- No new `<link>` tags in `index.html` — `LicenseBanner` uses only Tailwind/CSS vars
- No `@ActiveProfiles("production")` ITs
- Fixes committed before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)