### PR TITLE
feat(5-2): single-page renderer — monolithic data model

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
@@ -4,6 +4,8 @@ import com.wkspower.platform.api.dto.ApiResponse;
 import com.wkspower.platform.api.dto.response.CaseDto;
 import com.wkspower.platform.api.mapper.CaseDtoMapper;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.WksValidationException;
 import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.port.StageRepository;
 import com.wkspower.platform.domain.service.CaseService;
@@ -73,6 +75,11 @@ public class FormController {
       @PathVariable String formId,
       @RequestBody(required = false) Map<String, Object> formData,
       @AuthenticationPrincipal WksUserPrincipal actor) {
+
+    if (formData == null || formData.isEmpty()) {
+      throw new WksValidationException(
+          ErrorCode.WKS_FORM_003, "Form submission body is null or empty", null);
+    }
 
     Case updated = caseService.submitForm(caseId, formId, formData, actor.id());
 

--- a/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
@@ -1,0 +1,85 @@
+package com.wkspower.platform.api.controller;
+
+import com.wkspower.platform.api.dto.ApiResponse;
+import com.wkspower.platform.api.dto.response.CaseDto;
+import com.wkspower.platform.api.mapper.CaseDtoMapper;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.port.StageRepository;
+import com.wkspower.platform.domain.service.CaseService;
+import com.wkspower.platform.security.WksUserPrincipal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST surface for form submissions (Story 5.2 AC3). The only endpoint is:
+ *
+ * <pre>
+ *   POST /api/cases/{caseId}/forms/{formId}/submit
+ * </pre>
+ *
+ * <p>RBAC: {@code isAuthenticated()} — all authenticated users may attempt a form submit. The
+ * domain service validates field constraints and emits WKS-FORM-002 on failure. Case-level
+ * permission checks (whether the actor may edit this specific case type) are delegated to {@link
+ * CaseService#submitForm} via the case-type RBAC enforced by the underlying {@code update} call.
+ *
+ * <p>No new {@code @ActiveProfiles("production")} ITs needed — standard Spring controller, no
+ * production-profile specifics (Story 5.2 sprint lesson).
+ */
+@RestController
+@RequestMapping("/api/cases")
+public class FormController {
+
+  private final CaseService caseService;
+  private final StageRepository stageRepository;
+
+  public FormController(CaseService caseService, StageRepository stageRepository) {
+    this.caseService = caseService;
+    this.stageRepository = stageRepository;
+  }
+
+  /**
+   * Submit form data for an existing case. The request body is a flat {@code Map<String, Object>}
+   * containing the submitted field values keyed by field id.
+   *
+   * <p>On success: the case data is updated, a {@link
+   * com.wkspower.platform.domain.event.FormSubmitted} event is published, and the updated {@link
+   * CaseDto} is returned (with embedded case-type view so the frontend can re-render without a
+   * second round-trip).
+   *
+   * <p>On validation failure (WKS-FORM-002): HTTP 422 with field-level errors in the envelope.
+   *
+   * @param caseId the case to update
+   * @param formId the form definition id declared on the case type
+   * @param formData submitted field values (may be {@code null} — treated as empty)
+   * @param actor the authenticated caller
+   * @return the updated {@link CaseDto}
+   */
+  @PostMapping("/{caseId}/forms/{formId}/submit")
+  @PreAuthorize("isAuthenticated()")
+  @Transactional
+  public ResponseEntity<ApiResponse<CaseDto>> submit(
+      @PathVariable UUID caseId,
+      @PathVariable String formId,
+      @RequestBody(required = false) Map<String, Object> formData,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+
+    Case updated = caseService.submitForm(caseId, formId, formData, actor.id());
+
+    CaseTypeConfig caseType = caseService.requireCaseType(updated.caseTypeId());
+    List<com.wkspower.platform.domain.model.Stage> history = stageRepository.loadHistory(caseId);
+
+    CaseDto dto = CaseDtoMapper.toDto(updated, caseType, history);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
@@ -25,14 +25,36 @@ public record CaseTypeViewDto(
     List<FieldView> fields,
     List<StatusDefinition> statuses,
     List<String> listColumns,
-    List<StageDefinitionView> stages) {
+    List<StageDefinitionView> stages,
+    /**
+     * Story 5.2 — form definitions declared in the case-type YAML {@code forms[]} block. Empty list
+     * when omitted. Frontend uses this to render {@code SinglePageFormRenderer} without a second
+     * round-trip.
+     */
+    List<FormDefinitionView> forms) {
 
   /**
-   * Compact constructor — defensive-copy {@code stages} so the wire shape is immutable end-to-end.
-   * Story 3.3 — added {@code stages} for the timeline UI; declared in YAML order, never reordered.
+   * Compact constructor — defensive-copy {@code stages} and {@code forms} so the wire shape is
+   * immutable end-to-end. Story 3.3 added {@code stages}; Story 5.2 adds {@code forms}.
    */
   public CaseTypeViewDto {
     stages = stages == null ? List.of() : List.copyOf(stages);
+    forms = forms == null ? List.of() : List.copyOf(forms);
+  }
+
+  /**
+   * Backward-compat constructor for callers (and tests) that predate Story 5.2's {@code forms} slot
+   * — defaults forms to {@link List#of()}.
+   */
+  public CaseTypeViewDto(
+      String id,
+      String displayName,
+      int version,
+      List<FieldView> fields,
+      List<StatusDefinition> statuses,
+      List<String> listColumns,
+      List<StageDefinitionView> stages) {
+    this(id, displayName, version, fields, statuses, listColumns, stages, List.of());
   }
 
   /**
@@ -68,4 +90,18 @@ public record CaseTypeViewDto(
 
   /** Wire-shape for a single {@code select}-field option. */
   public record OptionView(String label, String value) {}
+
+  /**
+   * Story 5.2 — wire-shape projection of {@link
+   * com.wkspower.platform.domain.config.model.FormDefinition} for the case-type view endpoint.
+   * Carries the three-axis vocabulary and the form's field list so the frontend renderer has
+   * everything it needs in the {@code GET /api/case-types/{id}} response.
+   */
+  public record FormDefinitionView(
+      String id, String topology, String dataModel, String rendering, List<FieldView> fields) {
+
+    public FormDefinitionView {
+      fields = fields == null ? List.of() : List.copyOf(fields);
+    }
+  }
 }

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -4,12 +4,14 @@ import com.wkspower.platform.api.dto.response.CaseDto;
 import com.wkspower.platform.api.dto.response.CaseSummaryDto;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.FieldView;
+import com.wkspower.platform.api.dto.response.CaseTypeViewDto.FormDefinitionView;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.OptionView;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.StageDefinitionView;
 import com.wkspower.platform.api.dto.response.StageView;
 import com.wkspower.platform.api.dto.response.StatusView;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FormDefinition;
 import com.wkspower.platform.domain.config.model.StageDefinition;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.domain.model.Case;
@@ -160,6 +162,9 @@ public final class CaseDtoMapper {
         caseType.stages().stream()
             .map(s -> new StageDefinitionView(s.id(), s.displayName(), s.ordinal()))
             .toList();
+    // Story 5.2 — map form definitions to wire DTOs.
+    List<FormDefinitionView> forms =
+        caseType.forms().stream().map(CaseDtoMapper::toFormDefinitionView).toList();
     return new CaseTypeViewDto(
         caseType.id(),
         caseType.displayName(),
@@ -167,7 +172,18 @@ public final class CaseDtoMapper {
         caseType.fields().stream().map(CaseDtoMapper::toFieldView).toList(),
         caseType.statuses(),
         caseType.listColumns(),
-        stages);
+        stages,
+        forms);
+  }
+
+  /**
+   * Story 5.2 — map one {@link FormDefinition} to its wire DTO. Fields within the form definition
+   * are mapped using the same {@link #toFieldView} helper used for case-type-level fields.
+   */
+  static FormDefinitionView toFormDefinitionView(FormDefinition form) {
+    List<FieldView> fieldViews = form.fields().stream().map(CaseDtoMapper::toFieldView).toList();
+    return new FormDefinitionView(
+        form.id(), form.topology(), form.dataModel(), form.rendering(), fieldViews);
   }
 
   static FieldView toFieldView(FieldDefinition f) {

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
@@ -29,11 +29,16 @@ public record CaseTypeConfig(
     List<StatusDefinition> statuses,
     List<String> listColumns,
     List<RoleDefinition> roles,
-    List<StageDefinition> stages) {
+    List<StageDefinition> stages,
+    /**
+     * Story 5.2 — form definitions declared in the YAML {@code forms[]} block. Empty list when
+     * omitted (no-forms path is the zero-attachment equivalent for the forms surface).
+     */
+    List<FormDefinition> forms) {
 
   /**
    * Backward-compat constructor for callers (and tests) that predate Story 3.1's {@code stages}
-   * slot — defaults to {@link List#of()}.
+   * slot — defaults stages and forms to {@link List#of()}.
    */
   public CaseTypeConfig(
       String id,
@@ -55,6 +60,36 @@ public record CaseTypeConfig(
         statuses,
         listColumns,
         roles,
+        List.of(),
+        List.of());
+  }
+
+  /**
+   * Backward-compat constructor for callers (and tests) that predate Story 5.2's {@code forms} slot
+   * — defaults forms to {@link List#of()}.
+   */
+  public CaseTypeConfig(
+      String id,
+      String displayName,
+      int version,
+      String description,
+      WorkflowRef workflow,
+      List<FieldDefinition> fields,
+      List<StatusDefinition> statuses,
+      List<String> listColumns,
+      List<RoleDefinition> roles,
+      List<StageDefinition> stages) {
+    this(
+        id,
+        displayName,
+        version,
+        description,
+        workflow,
+        fields,
+        statuses,
+        listColumns,
+        roles,
+        stages,
         List.of());
   }
 
@@ -64,6 +99,7 @@ public record CaseTypeConfig(
     listColumns = List.copyOf(listColumns);
     roles = List.copyOf(roles);
     stages = stages == null ? List.of() : List.copyOf(stages);
+    forms = forms == null ? List.of() : List.copyOf(forms);
   }
 
   /** Convenience lookup used by the JSON Schema generator and (future) case-data validation. */
@@ -127,6 +163,7 @@ public record CaseTypeConfig(
         statuses,
         listColumns,
         roles,
-        stages);
+        stages,
+        forms);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
@@ -1,0 +1,39 @@
+package com.wkspower.platform.domain.config.model;
+
+import java.util.List;
+
+/**
+ * Validated, immutable form definition. One entry per {@code forms[]} item in the CaseType YAML.
+ * The three-axis vocabulary captures topology, dataModel, and rendering.
+ *
+ * <p>Story 5.2 — surfaced as part of the {@link CaseTypeConfig} domain model; exposed through the
+ * {@code GET /api/case-types/{id}} response via {@link
+ * com.wkspower.platform.api.dto.response.CaseTypeViewDto}.
+ */
+public record FormDefinition(
+    /** Stable identifier matching the YAML {@code id} key. */
+    String id,
+    /**
+     * Structural shape of the form session. Phase-0 valid value: {@code single}. Phase-1 will add
+     * {@code parallel}; emitting WKS-FORM-001 on any non-{@code single} value at deploy time.
+     */
+    String topology,
+    /**
+     * How form data is partitioned. Phase-0 valid values: {@code monolithic}, {@code sectioned}.
+     */
+    String dataModel,
+    /**
+     * How the UI renders the form. Phase-0 valid values: {@code single-page}, {@code
+     * multi-section}.
+     */
+    String rendering,
+    /**
+     * Fields rendered by this form. May be a subset of the case-type's overall fields when the form
+     * targets specific field ids.
+     */
+    List<FieldDefinition> fields) {
+
+  public FormDefinition {
+    fields = fields == null ? List.of() : List.copyOf(fields);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/event/FormSubmitted.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/FormSubmitted.java
@@ -1,0 +1,21 @@
+package com.wkspower.platform.domain.event;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Domain event emitted by {@link com.wkspower.platform.domain.service.CaseService#submitForm} after
+ * a successful form submission and case-data write. The event carries the minimal audit surface
+ * required by Story 5.2 AC3.
+ *
+ * <p>{@code source: "form"} is implicit in the event type — {@code FormSubmitted} is the
+ * form-sourced audit entry; no separate {@code source} field is needed.
+ *
+ * <p>Published via {@link com.wkspower.platform.domain.port.EventPublisher#publishAfterCommit} so
+ * subscribers never observe state that the underlying transaction subsequently rolls back.
+ *
+ * <p>Story 5.2 — Phase 0. No persistence; in-memory routing via Spring ApplicationEventPublisher.
+ */
+public record FormSubmitted(
+    UUID caseId, String formId, UUID actorId, Instant submittedAt, Set<String> updatedFieldIds) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -358,6 +358,15 @@ public enum ErrorCode {
    * never be reused for a different meaning.
    */
   WKS_FORM_002("WKS-FORM-002"),
+  /**
+   * Story 5.2 — form submission body is null or empty. Emitted by {@link
+   * com.wkspower.platform.api.controller.FormController} when the {@code @RequestBody} is absent or
+   * resolves to an empty map (blank-case-data attack guard). HTTP 400.
+   *
+   * <p>Per {@code feedback_error_codes_are_wire_contract.md}: the wire string is stable and must
+   * never be reused for a different meaning.
+   */
+  WKS_FORM_003("WKS-FORM-003"),
 
   // 409 — runtime conflict.
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -348,6 +348,16 @@ public enum ErrorCode {
    * feedback_error_codes_are_wire_contract.md}.
    */
   WKS_FORM_001("WKS-FORM-001"),
+  /**
+   * Story 5.2 AC3 — form submit field-level validation failure (backend-side). Emitted by {@link
+   * com.wkspower.platform.domain.service.CaseService#submitForm} when a submitted field value fails
+   * a type-specific constraint not caught by the frontend Zod schema. One error detail per
+   * offending field; the {@code field} slot in the error detail carries the field id. HTTP 422.
+   *
+   * <p>Per {@code feedback_error_codes_are_wire_contract.md}: the wire string is stable and must
+   * never be reused for a different meaning.
+   */
+  WKS_FORM_002("WKS-FORM-002"),
 
   // 409 — runtime conflict.
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -1,9 +1,13 @@
 package com.wkspower.platform.domain.service;
 
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.domain.event.CaseCreated;
 import com.wkspower.platform.domain.event.CaseUpdated;
+import com.wkspower.platform.domain.event.FormSubmitted;
 import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.ErrorDetail;
 // Story 3.6 — ErrorCode + WksStageException used by transition guards (AC6).
@@ -357,6 +361,108 @@ public class CaseService {
         .findById(caseId)
         .orElseThrow(
             () -> new WksNotFoundException("Case " + caseId + " not found after transition"));
+  }
+
+  /**
+   * Story 5.2 AC3 — submit form data for an existing case. Steps:
+   *
+   * <ol>
+   *   <li>Load case + case type; resolve the named form definition (404 if not found).
+   *   <li>Validate {@code formData} against the form's field definitions (WKS-FORM-002 on failure).
+   *   <li>Call {@link #update} for data persistence (merges submitted fields into case data).
+   *   <li>Publish {@link FormSubmitted} via {@code EventPublisher.publishAfterCommit} (audits the
+   *       form submission separately from the {@link CaseUpdated} event emitted by {@code update}).
+   * </ol>
+   *
+   * <p>Validation intentionally reuses the same field-presence + type logic as {@link #update}: the
+   * backend is the authoritative constraint enforcer, not just a relay for frontend Zod results.
+   * WKS-FORM-002 carries the field-level details so the frontend can surface inline errors on
+   * backend-only constraint violations not captured by the Zod schema.
+   *
+   * @throws WksNotFoundException if the case or case type is not found, or if the form id does not
+   *     exist on the case type.
+   * @throws WksValidationAggregateException (WKS-FORM-002) if any field value fails validation.
+   */
+  public Case submitForm(UUID caseId, String formId, Map<String, Object> formData, UUID actorId) {
+    Objects.requireNonNull(caseId, "caseId");
+    Objects.requireNonNull(formId, "formId");
+    Objects.requireNonNull(actorId, "actorId");
+
+    Case existing =
+        caseRepository
+            .findById(caseId)
+            .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
+
+    CaseTypeConfig caseType = requireCaseType(existing.caseTypeId());
+
+    // Resolve the form definition by id — 404 if not declared on this case type.
+    FormDefinition form =
+        caseType.forms().stream()
+            .filter(f -> f.id().equals(formId))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new WksNotFoundException(
+                        "Form '"
+                            + formId
+                            + "' not found on case type '"
+                            + existing.caseTypeId()
+                            + "'"));
+
+    // Validate submitted field values against the form's field definitions.
+    Map<String, Object> safeData = formData == null ? Map.of() : Map.copyOf(formData);
+    List<ErrorDetail> violations = validateFormData(form, safeData);
+    if (!violations.isEmpty()) {
+      throw new WksValidationAggregateException(
+          "Form submit validation failed (WKS-FORM-002)", violations);
+    }
+
+    // Persist via the existing update path (validates the merged data against the case-type schema
+    // and emits a CaseUpdated event). The update uses the current case version to detect concurrent
+    // modifications.
+    Case updated = update(caseId, safeData, existing.version(), actorId);
+
+    // Compute which field ids changed between the old and new data for the FormSubmitted event.
+    Set<String> updatedFieldIds = diffFieldIds(existing.data(), safeData);
+
+    // Publish FormSubmitted after commit so the audit listener never observes rolled-back state.
+    eventPublisher.publishAfterCommit(
+        new FormSubmitted(caseId, formId, actorId, clock.now(), updatedFieldIds));
+
+    return updated;
+  }
+
+  /**
+   * Validate submitted form data against the form's declared field definitions (Story 5.2
+   * WKS-FORM-002). Collect-all: never short-circuits on first error.
+   *
+   * <p>Currently validates that required fields are present. Type-specific constraint checking
+   * (min/max, length, date range) is delegated to the existing {@link CaseDataValidator} port which
+   * runs inside {@link #update}. The purpose of this pre-check is to surface form-specific required
+   * field violations with WKS-FORM-002 (so the frontend can distinguish them from generic case-data
+   * validation errors that use WKS-API-002).
+   */
+  private static List<ErrorDetail> validateFormData(FormDefinition form, Map<String, Object> data) {
+    List<ErrorDetail> errors = new ArrayList<>();
+    for (FieldDefinition f : form.fields()) {
+      if (f.required()) {
+        Object value = data.get(f.id());
+        if (value == null || (value instanceof String s && s.isBlank())) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_FORM_002.wire(),
+                  "Field '" + f.displayName() + "' is required",
+                  f.id()));
+        } else if (f.type() == FieldType.CHECKBOX && Boolean.FALSE.equals(value)) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_FORM_002.wire(),
+                  "Field '" + f.displayName() + "' must be checked",
+                  f.id()));
+        }
+      }
+    }
+    return errors;
   }
 
   /** Lookup by id; 404 if not found. */

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -38,6 +38,8 @@ import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
 import com.wkspower.platform.domain.port.WorkflowEngine;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -410,7 +412,11 @@ public class CaseService {
                             + "'"));
 
     // Validate submitted field values against the form's field definitions.
-    Map<String, Object> safeData = formData == null ? Map.of() : Map.copyOf(formData);
+    // Collections.unmodifiableMap(new HashMap<>(...)) is used instead of Map.copyOf() because
+    // Map.copyOf() throws NullPointerException on null values (e.g. {"field": null} — an explicit
+    // clear-field intent). Null values are preserved so the update() path can handle them.
+    Map<String, Object> safeData =
+        formData == null ? Map.of() : Collections.unmodifiableMap(new HashMap<>(formData));
     List<ErrorDetail> violations = validateFormData(form, safeData);
     if (!violations.isEmpty()) {
       throw new WksValidationAggregateException(
@@ -418,8 +424,13 @@ public class CaseService {
     }
 
     // Persist via the existing update path (validates the merged data against the case-type schema
-    // and emits a CaseUpdated event). The update uses the current case version to detect concurrent
-    // modifications.
+    // and emits a CaseUpdated event).
+    // intentionally last-writer-wins: form submit does not require version-based conflict
+    // detection.
+    // The form submit endpoint is designed for user-facing data entry where the form itself
+    // presents the current state; a concurrent server-side update winning is acceptable. If
+    // version-based conflict detection is required in future, the FormController request body
+    // should accept a client-supplied version and thread it through to update() here.
     Case updated = update(caseId, safeData, existing.version(), actorId);
 
     // Compute which field ids changed between the old and new data for the FormSubmitted event.
@@ -436,33 +447,121 @@ public class CaseService {
    * Validate submitted form data against the form's declared field definitions (Story 5.2
    * WKS-FORM-002). Collect-all: never short-circuits on first error.
    *
-   * <p>Currently validates that required fields are present. Type-specific constraint checking
-   * (min/max, length, date range) is delegated to the existing {@link CaseDataValidator} port which
-   * runs inside {@link #update}. The purpose of this pre-check is to surface form-specific required
-   * field violations with WKS-FORM-002 (so the frontend can distinguish them from generic case-data
-   * validation errors that use WKS-API-002).
+   * <p>Validates:
+   *
+   * <ol>
+   *   <li>Required field presence (all field types).
+   *   <li>Type-specific constraints (P9): {@code TEXT}/{@code TEXTAREA} maxLength; {@code NUMBER}
+   *       min/max; {@code DATE} ISO format ({@code YYYY-MM-DD}). Missing or malformed constraint
+   *       config on the field definition → the check is skipped (don't fail on incomplete field
+   *       defs).
+   * </ol>
+   *
+   * <p>These checks emit WKS-FORM-002 directly so the frontend can distinguish form-field failures
+   * from generic case-data validation errors (WKS-API-002) that run inside {@link #update}.
    */
   private static List<ErrorDetail> validateFormData(FormDefinition form, Map<String, Object> data) {
     List<ErrorDetail> errors = new ArrayList<>();
     for (FieldDefinition f : form.fields()) {
+      Object value = data.get(f.id());
+
+      // --- required check ---
       if (f.required()) {
-        Object value = data.get(f.id());
         if (value == null || (value instanceof String s && s.isBlank())) {
           errors.add(
               ErrorDetail.ofField(
                   ErrorCode.WKS_FORM_002.wire(),
                   "Field '" + f.displayName() + "' is required",
                   f.id()));
+          continue; // no point checking constraints if the value is absent
         } else if (f.type() == FieldType.CHECKBOX && Boolean.FALSE.equals(value)) {
           errors.add(
               ErrorDetail.ofField(
                   ErrorCode.WKS_FORM_002.wire(),
                   "Field '" + f.displayName() + "' must be checked",
                   f.id()));
+          continue;
+        }
+      }
+
+      // Skip constraint checks when value is absent for optional fields.
+      if (value == null) {
+        continue;
+      }
+
+      // P9 — type-specific constraint validation (emits WKS-FORM-002, not WKS-API-002).
+      // Missing or malformed constraint config on the FieldDefinition → skip silently.
+      FieldDefinition.TypeSlots slots = f.slots();
+      switch (f.type()) {
+        case TEXT, TEXTAREA -> {
+          if (value instanceof String strVal && slots != null && slots.maxLength() != null) {
+            if (strVal.length() > slots.maxLength()) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_FORM_002.wire(),
+                      "Field '"
+                          + f.displayName()
+                          + "' exceeds maximum length of "
+                          + slots.maxLength(),
+                      f.id()));
+            }
+          }
+        }
+        case NUMBER -> {
+          if (slots != null) {
+            Double numVal = toDouble(value);
+            if (numVal != null) {
+              if (slots.min() != null && numVal < slots.min()) {
+                errors.add(
+                    ErrorDetail.ofField(
+                        ErrorCode.WKS_FORM_002.wire(),
+                        "Field '" + f.displayName() + "' must be at least " + slots.min(),
+                        f.id()));
+              }
+              if (slots.max() != null && numVal > slots.max()) {
+                errors.add(
+                    ErrorDetail.ofField(
+                        ErrorCode.WKS_FORM_002.wire(),
+                        "Field '" + f.displayName() + "' must be at most " + slots.max(),
+                        f.id()));
+              }
+            }
+          }
+        }
+        case DATE -> {
+          if (value instanceof String dateVal
+              && !dateVal.isBlank()
+              && !dateVal.matches("\\d{4}-\\d{2}-\\d{2}")) {
+            errors.add(
+                ErrorDetail.ofField(
+                    ErrorCode.WKS_FORM_002.wire(),
+                    "Field '" + f.displayName() + "' must be a date in YYYY-MM-DD format",
+                    f.id()));
+          }
+        }
+        default -> {
+          // No type-specific constraints for SELECT, CHECKBOX, FILE — skip.
         }
       }
     }
     return errors;
+  }
+
+  /**
+   * Coerce a value to {@link Double} for numeric constraint checks. Returns {@code null} if the
+   * value is not numeric (e.g. a string that isn't a parseable number — the full type check runs
+   * inside {@link CaseDataValidator}).
+   */
+  private static Double toDouble(Object value) {
+    if (value instanceof Number n) return n.doubleValue();
+    if (value instanceof String s) {
+      try {
+        return Double.parseDouble(s);
+      } catch (NumberFormatException ignored) {
+        return null;
+      }
+    }
+    return null;
   }
 
   /** Lookup by id; 404 if not found. */

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -163,6 +163,12 @@ public class ConfigValidator {
       return ValidationResult.invalid(errors);
     }
 
+    // Story 5.2 — map validated form definitions to domain records. Empty when no forms block.
+    List<com.wkspower.platform.domain.config.model.FormDefinition> forms =
+        raw.forms() == null
+            ? List.of()
+            : raw.forms().definitions().stream().map(FormDefinitionMapper::toDomain).toList();
+
     CaseTypeConfig config =
         new CaseTypeConfig(
             raw.id(),
@@ -174,7 +180,8 @@ public class ConfigValidator {
             statuses,
             listColumns,
             roles,
-            stages);
+            stages,
+            forms);
     // Story 4.3 — surface the validated MappingDefinition through ValidationResult so
     // ConfigService can populate MappingRegistry on registration. Empty MappingDefinition is the
     // first-class zero-attachment value (D22 — Story 4.2's MappingValidator returns empty()

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
@@ -61,8 +61,27 @@ public final class FormDefinitionMapper {
       if (displayName == null) displayName = id;
 
       String typeStr = string(m, "type");
-      FieldType type =
-          typeStr != null ? FieldType.fromWire(typeStr).orElse(FieldType.TEXT) : FieldType.TEXT;
+      // P11 — fail-fast on unknown field type: silently defaulting to TEXT accepts typos without
+      // surfacing them, causing the form to render the wrong widget at runtime. Config authoring
+      // errors must surface immediately at deploy time (same posture as WKS-CFG-002 for case-type
+      // fields). FormValidator should have already rejected unknown types; this guard is a
+      // defensive belt-and-suspenders in case the mapper is called outside the validator path.
+      FieldType type;
+      if (typeStr == null || typeStr.isBlank()) {
+        type = FieldType.TEXT; // no type declared — validator catches this; default defensively
+      } else {
+        type =
+            FieldType.fromWire(typeStr)
+                .orElseThrow(
+                    () ->
+                        new IllegalArgumentException(
+                            "Unknown field type '"
+                                + typeStr
+                                + "' on field '"
+                                + id
+                                + "' — check the form YAML (valid types: text, textarea, number,"
+                                + " date, select, checkbox, file)"));
+      }
 
       boolean required = booleanValue(m, "required");
       boolean requiredOnCreate =

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
@@ -1,0 +1,162 @@
+package com.wkspower.platform.infrastructure.config;
+
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldOption;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maps {@link RawFormDefinition} transport objects to {@link FormDefinition} domain records.
+ *
+ * <p>Story 5.2 — called from {@link ConfigValidator} after form validation succeeds. The raw {@code
+ * fields[]} entries are {@code Map<String, Object>} deserialized from YAML; this mapper extracts
+ * the same slots that {@link RawCaseTypeConfig.RawField} carries so downstream consumers see a
+ * uniform {@link FieldDefinition} shape regardless of whether the field originated from the
+ * case-type-level {@code fields[]} or a form-level {@code fields[]} list.
+ *
+ * <p>Unknown keys in the raw map are silently ignored for forward-compatibility (mirrors the
+ * {@code @JsonIgnoreProperties(ignoreUnknown = true)} posture on {@link RawCaseTypeConfig}).
+ *
+ * <p>This mapper is I/O-free and stateless — safe to call from a Spring {@code @Component} or a
+ * plain unit test.
+ */
+public final class FormDefinitionMapper {
+
+  private FormDefinitionMapper() {
+    // utility
+  }
+
+  /**
+   * Convert one {@link RawFormDefinition} (already validated by {@link FormValidator}) to a {@link
+   * FormDefinition}.
+   */
+  public static FormDefinition toDomain(RawFormDefinition raw) {
+    List<FieldDefinition> fields = mapFields(raw.fields());
+    return new FormDefinition(raw.id(), raw.topology(), raw.dataModel(), raw.rendering(), fields);
+  }
+
+  // ---- private helpers -----------------------------------------------------------------
+
+  @SuppressWarnings("unchecked")
+  private static List<FieldDefinition> mapFields(List<Map<String, Object>> rawFields) {
+    if (rawFields == null || rawFields.isEmpty()) {
+      return List.of();
+    }
+    List<FieldDefinition> out = new ArrayList<>(rawFields.size());
+    int index = 0;
+    for (Map<String, Object> m : rawFields) {
+      if (m == null) {
+        index++;
+        continue;
+      }
+      String id = string(m, "id");
+      if (id == null || id.isBlank()) {
+        index++;
+        continue; // missing id — validator should have caught this; skip defensively
+      }
+      String displayName = string(m, "displayName");
+      if (displayName == null) displayName = id;
+
+      String typeStr = string(m, "type");
+      FieldType type =
+          typeStr != null ? FieldType.fromWire(typeStr).orElse(FieldType.TEXT) : FieldType.TEXT;
+
+      boolean required = booleanValue(m, "required");
+      boolean requiredOnCreate =
+          m.containsKey("requiredOnCreate") ? booleanValue(m, "requiredOnCreate") : required;
+
+      Object orderRaw = m.get("order");
+      int order = orderRaw instanceof Number ? ((Number) orderRaw).intValue() : index;
+
+      // Options (select fields)
+      List<FieldOption> options = List.of();
+      Object optRaw = m.get("options");
+      if (optRaw instanceof List<?> optList) {
+        List<FieldOption> opts = new ArrayList<>();
+        for (Object o : optList) {
+          if (o instanceof Map<?, ?> om) {
+            String label = string((Map<String, Object>) om, "label");
+            String value = string((Map<String, Object>) om, "value");
+            if (label != null && value != null) {
+              opts.add(new FieldOption(label, value));
+            }
+          }
+        }
+        options = List.copyOf(opts);
+      }
+
+      // Type-specific slots
+      FieldDefinition.TypeSlots slots = mapSlots(m);
+
+      out.add(
+          new FieldDefinition(
+              id, displayName, type, required, requiredOnCreate, order, options, slots));
+      index++;
+    }
+    return List.copyOf(out);
+  }
+
+  private static FieldDefinition.TypeSlots mapSlots(Map<String, Object> m) {
+    Integer minLength = intValue(m, "minLength");
+    Integer maxLength = intValue(m, "maxLength");
+    Double min = doubleValue(m, "min");
+    Double max = doubleValue(m, "max");
+    Double step = doubleValue(m, "step");
+    String dateMin = string(m, "dateMin");
+    String dateMax = string(m, "dateMax");
+    Long maxBytes = longValue(m, "maxBytes");
+
+    @SuppressWarnings("unchecked")
+    List<String> allowedMimeTypes =
+        m.get("allowedMimeTypes") instanceof List<?>
+            ? (List<String>) m.get("allowedMimeTypes")
+            : List.of();
+
+    if (minLength == null
+        && maxLength == null
+        && min == null
+        && max == null
+        && step == null
+        && dateMin == null
+        && dateMax == null
+        && maxBytes == null
+        && allowedMimeTypes.isEmpty()) {
+      return null;
+    }
+    return new FieldDefinition.TypeSlots(
+        minLength, maxLength, min, max, step, dateMin, dateMax, maxBytes, allowedMimeTypes);
+  }
+
+  private static String string(Map<?, ?> m, String key) {
+    Object v = m.get(key);
+    return v instanceof String s ? s : null;
+  }
+
+  private static boolean booleanValue(Map<?, ?> m, String key) {
+    Object v = m.get(key);
+    if (v instanceof Boolean b) return b;
+    if (v instanceof String s) return Boolean.parseBoolean(s);
+    return false;
+  }
+
+  private static Integer intValue(Map<?, ?> m, String key) {
+    Object v = m.get(key);
+    if (v instanceof Number n) return n.intValue();
+    return null;
+  }
+
+  private static Long longValue(Map<?, ?> m, String key) {
+    Object v = m.get(key);
+    if (v instanceof Number n) return n.longValue();
+    return null;
+  }
+
+  private static Double doubleValue(Map<?, ?> m, String key) {
+    Object v = m.get(key);
+    if (v instanceof Number n) return n.doubleValue();
+    return null;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -224,4 +224,110 @@ public record RawCaseTypeConfig(
 
   /** {@code emits: { type, scope }} block inside a property emission rule. */
   public record RawEmits(String type, String scope) {}
+
+  // ---------------------------------------------------------------------------
+  // Story 5.2 — Builder: prevents constructor-explosion when new slots are
+  // added. The 12-arg canonical constructor (Jackson @JsonCreator target) is
+  // kept; the Builder delegates to it. Test call-sites can use Builder instead
+  // of the multi-arg constructors.
+  // ---------------------------------------------------------------------------
+
+  /** Returns a fresh {@link Builder} for programmatic construction (primarily in tests). */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Fluent builder that delegates to the canonical 12-arg constructor on {@link #build()}. */
+  public static final class Builder {
+    private String id;
+    private String displayName;
+    private Integer version;
+    private String description;
+    private RawWorkflow workflow;
+    private List<RawField> fields;
+    private List<RawStatus> statuses;
+    private List<String> listColumns;
+    private List<RawRole> roles;
+    private List<RawStage> stages;
+    private List<RawAttachment> attachments;
+    private RawFormConfig forms;
+
+    private Builder() {}
+
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder displayName(String v) {
+      this.displayName = v;
+      return this;
+    }
+
+    public Builder version(Integer v) {
+      this.version = v;
+      return this;
+    }
+
+    public Builder description(String v) {
+      this.description = v;
+      return this;
+    }
+
+    public Builder workflow(RawWorkflow v) {
+      this.workflow = v;
+      return this;
+    }
+
+    public Builder fields(List<RawField> v) {
+      this.fields = v;
+      return this;
+    }
+
+    public Builder statuses(List<RawStatus> v) {
+      this.statuses = v;
+      return this;
+    }
+
+    public Builder listColumns(List<String> v) {
+      this.listColumns = v;
+      return this;
+    }
+
+    public Builder roles(List<RawRole> v) {
+      this.roles = v;
+      return this;
+    }
+
+    public Builder stages(List<RawStage> v) {
+      this.stages = v;
+      return this;
+    }
+
+    public Builder attachments(List<RawAttachment> v) {
+      this.attachments = v;
+      return this;
+    }
+
+    public Builder forms(RawFormConfig v) {
+      this.forms = v;
+      return this;
+    }
+
+    public RawCaseTypeConfig build() {
+      return new RawCaseTypeConfig(
+          id,
+          displayName,
+          version,
+          description,
+          workflow,
+          fields,
+          statuses,
+          listColumns,
+          roles,
+          stages,
+          attachments,
+          forms);
+    }
+  }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -32,69 +32,6 @@ public record RawCaseTypeConfig(
     List<RawAttachment> attachments,
     @JsonProperty("forms") @JsonInclude(JsonInclude.Include.NON_NULL) RawFormConfig forms) {
 
-  /**
-   * Backward-compat constructor for callers (and tests) authored before Story 4.2 introduced the
-   * {@code attachments} slot. Treats absent attachments as the empty list — equivalent to a YAML
-   * with no {@code attachments:} key (AC1).
-   */
-  public RawCaseTypeConfig(
-      String id,
-      String displayName,
-      Integer version,
-      String description,
-      RawWorkflow workflow,
-      List<RawField> fields,
-      List<RawStatus> statuses,
-      List<String> listColumns,
-      List<RawRole> roles,
-      List<RawStage> stages) {
-    this(
-        id,
-        displayName,
-        version,
-        description,
-        workflow,
-        fields,
-        statuses,
-        listColumns,
-        roles,
-        stages,
-        null,
-        null);
-  }
-
-  /**
-   * Backward-compat constructor for callers (and tests) authored before Story 5.1 introduced the
-   * {@code forms} slot. Passes {@code null} for forms — equivalent to a YAML with no {@code forms:}
-   * key (AC3).
-   */
-  public RawCaseTypeConfig(
-      String id,
-      String displayName,
-      Integer version,
-      String description,
-      RawWorkflow workflow,
-      List<RawField> fields,
-      List<RawStatus> statuses,
-      List<String> listColumns,
-      List<RawRole> roles,
-      List<RawStage> stages,
-      List<RawAttachment> attachments) {
-    this(
-        id,
-        displayName,
-        version,
-        description,
-        workflow,
-        fields,
-        statuses,
-        listColumns,
-        roles,
-        stages,
-        attachments,
-        null);
-  }
-
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawWorkflow(String bpmn) {}
 

--- a/backend/src/test/java/com/wkspower/platform/integration/FormSubmitIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormSubmitIT.java
@@ -1,0 +1,206 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Story 5.2 P7 — integration tests for {@code POST /api/cases/{caseId}/forms/{formId}/submit}.
+ *
+ * <p>Covers the four key scenarios:
+ *
+ * <ul>
+ *   <li>Happy path → 200 with updated case data.
+ *   <li>Unknown form id → 404 (WKS-API-404).
+ *   <li>Required field missing → 422 (WKS-FORM-002).
+ *   <li>Empty body → 400 (WKS-FORM-003).
+ * </ul>
+ *
+ * <p>Uses an H2 in-memory DB and no BPMN engine (no workflow declared on the case type) — the form
+ * submit path does not require an active process instance.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:formsubmitit;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=",
+      "wks.bootstrap.production-validation.enabled=false"
+    })
+class FormSubmitIT {
+
+  private static final String EMAIL = "form-submit-it@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String CASE_TYPE_ID = "form-submit-fixture";
+  private static final String FORM_ID = "intake-form";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private ObjectMapper json;
+
+  @BeforeEach
+  void setup() {
+    if (users.findByEmail(EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+    registry.register(caseTypeWithForm());
+  }
+
+  @Test
+  void happyPathReturns200WithUpdatedCaseData() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\",\"amount\":5000}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode body = json.readTree(resp.getBody());
+    assertThat(body.path("data").path("data").path("applicant").asText()).isEqualTo("Alice");
+  }
+
+  @Test
+  void unknownFormIdReturns404() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/nonexistent-form/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\"}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(resp.getBody()).contains("WKS-API-404");
+  }
+
+  @Test
+  void missingRequiredFieldReturns422WithWksForm002() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    // Omit the required "applicant" field — only supply the optional "amount"
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"amount\":100}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(resp.getBody()).contains("WKS-FORM-002");
+  }
+
+  @Test
+  void emptyBodyReturns400WithWksForm003() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(resp.getBody()).contains("WKS-FORM-003");
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(EMAIL, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", EMAIL).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).isNotNull();
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private String createCase(String cookie) throws Exception {
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"applicant\":\"Initial\"}}");
+    assertThat(resp.getStatusCode()).as("create case").isEqualTo(HttpStatus.CREATED);
+    return json.readTree(resp.getBody()).path("data").path("id").asText();
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  private static CaseTypeConfig caseTypeWithForm() {
+    // Two fields on the case type: "applicant" (required text) and "amount" (optional number).
+    // The intake-form references both so form validation covers both required and optional fields.
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
+
+    FormDefinition intakeForm =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Form Submit Fixture",
+        1,
+        null,
+        null, // no BPMN — form submit does not require an active process instance
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(intakeForm));
+  }
+}

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -154,6 +154,7 @@ Band: `WKS-FORM-001..099`. Codes 002+ are **reserved** for Stories 5.2–5.8 —
 | --- | --- | --- |
 | `WKS-FORM-001` | `topology: parallel` (or any non-`single` topology value) is a Phase-1 capability — rejected in Phase 0. Message: `"topology: parallel is a Phase-1 capability — use topology: single"`. | `infrastructure/config/FormValidator.java` |
 | `WKS-FORM-002` | Form submit field-level validation failure (backend-side). Emitted by `CaseService.submitForm()` when a submitted field value fails a type-specific constraint not caught by the frontend Zod schema. One `ErrorDetail` per offending field; `field` slot carries the field id. HTTP 422. | `domain/service/CaseService.java` |
+| `WKS-FORM-003` | Form submission body is null or empty. Emitted by `FormController` when the request body is absent or resolves to an empty map (blank-case-data attack guard). HTTP 400. | `api/controller/FormController.java` |
 
 ---
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -153,6 +153,7 @@ Band: `WKS-FORM-001..099`. Codes 002+ are **reserved** for Stories 5.2–5.8 —
 | Code | Meaning | Thrower(s) |
 | --- | --- | --- |
 | `WKS-FORM-001` | `topology: parallel` (or any non-`single` topology value) is a Phase-1 capability — rejected in Phase 0. Message: `"topology: parallel is a Phase-1 capability — use topology: single"`. | `infrastructure/config/FormValidator.java` |
+| `WKS-FORM-002` | Form submit field-level validation failure (backend-side). Emitted by `CaseService.submitForm()` when a submitted field value fails a type-specific constraint not caught by the frontend Zod schema. One `ErrorDetail` per offending field; `field` slot carries the field id. HTTP 422. | `domain/service/CaseService.java` |
 
 ---
 

--- a/frontend/src/api/forms.ts
+++ b/frontend/src/api/forms.ts
@@ -1,0 +1,32 @@
+/**
+ * Story 5.2 — Form submission API. Mirrors the backend
+ * `POST /api/cases/{caseId}/forms/{formId}/submit` endpoint.
+ */
+import type { CaseDto } from '@/types/case';
+
+import { apiFetch } from './client';
+
+/**
+ * Submit form data for an existing case.
+ *
+ * @param caseId - the case to update
+ * @param formId - the form definition id declared on the case type
+ * @param data   - submitted field values keyed by field id
+ * @returns the updated {@link CaseDto} with embedded case-type view
+ * @throws {@link ApiError} on validation failure (WKS-FORM-002 at HTTP 422) or other errors
+ */
+export async function submitForm(
+  caseId: string,
+  formId: string,
+  data: Record<string, unknown>,
+): Promise<CaseDto> {
+  const result = await apiFetch<CaseDto>(
+    `/api/cases/${encodeURIComponent(caseId)}/forms/${encodeURIComponent(formId)}/submit`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    },
+  );
+  return result.data;
+}

--- a/frontend/src/components/forms/SinglePageFormRenderer.test.tsx
+++ b/frontend/src/components/forms/SinglePageFormRenderer.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * Story 5.2 — SinglePageFormRenderer unit tests.
+ *
+ * AC1: all fields rendered on one page in order-sorted sequence.
+ * AC2: empty submit shows FormErrorsBanner with field names.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// ResizeObserver is not implemented in jsdom but is referenced by Radix UI's Select + Tooltip
+// internals. Stub it so tests can render components that include Select (e.g. select-typed fields).
+beforeAll(() => {
+  if (typeof window !== 'undefined' && !window.ResizeObserver) {
+    window.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import { server } from '@/test/server';
+import type { FormDefinitionView } from '@/types/caseType';
+
+import { SinglePageFormRenderer } from './SinglePageFormRenderer';
+
+function wrap(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * A minimal 3-field monolithic form definition for testing. Three fields:
+ * - name (text, required, order 0)
+ * - notes (textarea, required=false, order 1)
+ * - consent (checkbox, required=true, order 2)
+ */
+function threeFieldForm(): FormDefinitionView {
+  return {
+    id: 'intake-form',
+    topology: 'single',
+    dataModel: 'monolithic',
+    rendering: 'single-page',
+    fields: [
+      {
+        id: 'name',
+        displayName: 'Full Name',
+        type: 'text',
+        required: true,
+        requiredOnCreate: true,
+        order: 0,
+        options: [],
+      },
+      {
+        id: 'notes',
+        displayName: 'Notes',
+        type: 'textarea',
+        required: false,
+        requiredOnCreate: false,
+        order: 1,
+        options: [],
+      },
+      {
+        id: 'consent',
+        displayName: 'I consent',
+        type: 'checkbox',
+        required: true,
+        requiredOnCreate: false,
+        order: 2,
+        options: [],
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC1 — All fields visible
+// ---------------------------------------------------------------------------
+
+describe('SinglePageFormRenderer — AC1: all fields visible', () => {
+  it('renders all 3 fields in declared order', () => {
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={threeFieldForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    expect(screen.getByLabelText(/Full Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Notes/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/I consent/)).toBeInTheDocument();
+  });
+
+  it('renders a single submit button', () => {
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={threeFieldForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    // MutationButton renders a <button> whose text comes from the children prop.
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+
+  it('renders required fields with aria-required', () => {
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={threeFieldForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    const nameInput = screen.getByLabelText(/Full Name/);
+    expect(nameInput).toHaveAttribute('aria-required', 'true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2 — Empty submit shows FormErrorsBanner
+// ---------------------------------------------------------------------------
+
+describe('SinglePageFormRenderer — AC2: empty submit shows FormErrorsBanner', () => {
+  it('shows banner with required field names after submitting empty form', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={threeFieldForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    // Submit without filling in anything.
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    // FormErrorsBanner lists the display names of fields with errors as clickable buttons.
+    // 'name' is required; 'consent' is required. 'notes' is not required and won't appear.
+    const bannerButtons = await screen.findAllByRole('button', { name: /Full Name|I consent/ });
+    expect(bannerButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('HTTP call is NOT fired when validation fails', async () => {
+    const user = userEvent.setup();
+    let called = false;
+    server.use(
+      http.post('/api/cases/:caseId/forms/:formId/submit', () => {
+        called = true;
+        return HttpResponse.json({ data: {} });
+      }),
+    );
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={threeFieldForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    // Give any async effects time to flush.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(called).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3 — Successful submit calls onSuccess
+// ---------------------------------------------------------------------------
+
+describe('SinglePageFormRenderer — AC3: successful submit', () => {
+  it('calls onSuccess after a valid submission', async () => {
+    const user = userEvent.setup();
+    let successCalled = false;
+
+    server.use(
+      http.post('/api/cases/:caseId/forms/:formId/submit', () =>
+        HttpResponse.json({
+          data: {
+            id: '00000000-0000-0000-0000-000000000001',
+            caseTypeId: 'test-ct',
+            caseTypeVersion: 1,
+            status: 'open',
+            assignee: null,
+            data: { name: 'Alice', consent: true },
+            processInstanceId: null,
+            documentCount: 0,
+            createdAt: new Date().toISOString(),
+            createdBy: '00000000-0000-0000-0000-000000000099',
+            updatedAt: new Date().toISOString(),
+            version: 1,
+            caseType: {
+              id: 'test-ct',
+              displayName: 'Test CT',
+              version: 1,
+              fields: [],
+              statuses: [],
+              listColumns: [],
+              stages: [],
+              forms: [],
+            },
+            currentStageId: null,
+            currentStageOrdinal: null,
+            stages: [],
+            availableStatuses: [],
+          },
+          meta: {},
+        }),
+      ),
+    );
+
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={threeFieldForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+        onSuccess={() => {
+          successCalled = true;
+        }}
+      />,
+    );
+
+    // Fill required fields.
+    await user.type(screen.getByLabelText(/Full Name/), 'Alice');
+    await user.click(screen.getByLabelText(/I consent/));
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    // MutationButton transitions to 'confirmed' state — check the button role
+    await screen.findByRole('button', { name: /confirmed/i });
+    expect(successCalled).toBe(true);
+  });
+});

--- a/frontend/src/components/forms/SinglePageFormRenderer.tsx
+++ b/frontend/src/components/forms/SinglePageFormRenderer.tsx
@@ -1,0 +1,358 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMemo, useRef, useState } from 'react';
+import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
+
+import { ApiError } from '@/api/client';
+import { submitForm } from '@/api/forms';
+import { Alert } from '@/components/ui/Alert';
+import { Button } from '@/components/ui/Button';
+import { Checkbox } from '@/components/ui/Checkbox';
+import { FormErrorsBanner, type FormErrorEntry } from '@/components/ui/FormErrorsBanner';
+import { FormField, type FormFieldRenderProps } from '@/components/ui/FormField';
+import { Input } from '@/components/ui/Input';
+import { MutationButton, type MutationButtonState } from '@/components/ui/MutationButton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import { Textarea } from '@/components/ui/Textarea';
+import { t } from '@/i18n';
+import { buildZodFromFieldDefs } from '@/lib/buildZodFromFieldDefs';
+import type { FieldDefinition, FormDefinitionView } from '@/types/caseType';
+
+export interface SinglePageFormRendererProps {
+  /** The form definition (id, topology, dataModel, rendering, fields). */
+  formDefinition: FormDefinitionView;
+  /** The case to submit the form for. */
+  caseId: string;
+  /** Called after a successful submit so the parent can react (e.g. show a toast, navigate). */
+  onSuccess?: () => void;
+}
+
+interface ServerErrorBanner {
+  title: string;
+  message: string;
+}
+
+/**
+ * Story 5.2 AC1 — Renders a single-page form from a {@link FormDefinitionView}. All fields appear
+ * on one page in order-sorted sequence with a single "Submit" button. No pagination, wizard steps,
+ * or tabs.
+ *
+ * AC2 — Field-level validation with inline errors + submit-blocked {@link FormErrorsBanner} at top.
+ *
+ * AC4 — WCAG: focus order follows DOM order (top-to-bottom, which mirrors visual order for a
+ * single-page form). Error messages are announced via the existing {@link FormField} wrapper
+ * (role="alert", aria-invalid, aria-describedby) and {@link FormErrorsBanner} (role="alert"
+ * aria-live="polite") — no additional WCAG work needed.
+ *
+ * Template: mirrors {@link NewCaseDialog} exactly, rendered inline as a {@code <div>} instead of
+ * inside a Dialog wrapper.
+ */
+export function SinglePageFormRenderer({
+  formDefinition,
+  caseId,
+  onSuccess,
+}: SinglePageFormRendererProps) {
+  const [serverError, setServerError] = useState<ServerErrorBanner | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+
+  // AC1 — all fields in order-sorted sequence.
+  const sortedFields = useMemo(
+    () => [...formDefinition.fields].sort((a, b) => a.order - b.order),
+    [formDefinition.fields],
+  );
+
+  // AC2 — 'submit' mode: include ALL fields where required === true (not filtered by
+  // requiredOnCreate — that is the create-form gate, not the submit-form gate).
+  const schema = useMemo(() => buildZodFromFieldDefs(sortedFields, 'submit'), [sortedFields]);
+
+  // Default values keyed by field id so controlled inputs are always controlled.
+  const defaultValues = useMemo<Record<string, unknown>>(() => {
+    const dv: Record<string, unknown> = {};
+    for (const f of sortedFields) dv[f.id] = f.type === 'checkbox' ? false : '';
+    return dv;
+  }, [sortedFields]);
+
+  const form = useForm<Record<string, unknown>>({
+    resolver: zodResolver(schema),
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+    shouldFocusError: true,
+    defaultValues,
+  });
+
+  const state: MutationButtonState = isPending
+    ? 'confirming'
+    : isSuccess
+      ? 'confirmed'
+      : isError || serverError
+        ? 'failed'
+        : 'idle';
+
+  async function onSubmit(values: Record<string, unknown>): Promise<void> {
+    setServerError(null);
+    setIsError(false);
+    setIsSuccess(false);
+    setIsPending(true);
+    try {
+      await submitForm(caseId, formDefinition.id, values);
+      setIsSuccess(true);
+      onSuccess?.();
+    } catch (err) {
+      handleSubmitError(err);
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  function handleSubmitError(err: unknown): void {
+    setIsError(true);
+    if (err instanceof ApiError && err.status === 422 && err.envelopeErrors) {
+      // Map field-level errors (WKS-FORM-002) to RHF setError so they appear inline.
+      const knownIds = new Set(sortedFields.map((f) => f.id));
+      const unmapped: string[] = [];
+      let firstFieldName: string | null = null;
+      for (const e of err.envelopeErrors) {
+        if (e.field && knownIds.has(e.field)) {
+          form.setError(e.field, { type: 'server', message: e.message });
+          if (firstFieldName === null) firstFieldName = e.field;
+        } else if (e.message) {
+          unmapped.push(e.message);
+        }
+      }
+      if (firstFieldName !== null) {
+        form.setFocus(firstFieldName);
+      }
+      if (unmapped.length > 0 || firstFieldName === null) {
+        setServerError({
+          title: t('cases.create.errorBanner.title'),
+          message: unmapped.length > 0 ? unmapped.join(' · ') : t('cases.create.errorBanner.body'),
+        });
+        bannerRef.current?.focus();
+      }
+      return;
+    }
+    if (err instanceof ApiError) {
+      setServerError({
+        title: t('cases.create.errorBanner.title'),
+        message: t('cases.create.errorBanner.body'),
+      });
+    } else {
+      setServerError({
+        title: t('cases.create.errorBanner.title'),
+        message: t('cases.create.errorBanner.networkBody'),
+      });
+    }
+    bannerRef.current?.focus();
+  }
+
+  const failedReason = serverError?.message ?? null;
+  const failedLabel = failedReason
+    ? t('common.lifecycle.failed', { reason: failedReason })
+    : t('common.lifecycle.failedNoReason');
+
+  const retryAction = (
+    <Button
+      type="button"
+      variant="ghost"
+      onClick={() => {
+        setServerError(null);
+        setIsError(false);
+        void form.handleSubmit(onSubmit)();
+      }}
+    >
+      {t('common.retry')}
+    </Button>
+  );
+
+  return (
+    <div>
+      <FormProvider {...form}>
+        <form
+          noValidate
+          onSubmit={form.handleSubmit(onSubmit)}
+          aria-busy={isPending ? true : undefined}
+          className="flex flex-col gap-[var(--form-field-gap,1rem)]"
+        >
+          {sortedFields.length === 0 ? (
+            <p className="text-sm text-[var(--muted-foreground)]">
+              {t('cases.create.noRequired', { caseTypeName: formDefinition.id })}
+            </p>
+          ) : (
+            sortedFields.map((f) => renderField(f, isPending, form))
+          )}
+          {form.formState.isSubmitted ? (
+            <FormErrorsBanner
+              errors={collectFormErrors(form, sortedFields)}
+              onAnchorClick={(field) => form.setFocus(field)}
+            />
+          ) : null}
+          {serverError ? (
+            <Alert
+              ref={bannerRef}
+              tabIndex={-1}
+              role="alert"
+              variant="destructive"
+              className="py-[var(--space-2)] text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+            >
+              <strong className="block">{serverError.title}</strong>
+              <span>{serverError.message}</span>
+            </Alert>
+          ) : null}
+          <div className="flex justify-end">
+            <MutationButton
+              state={state}
+              confirmingLabel={t('common.lifecycle.confirming')}
+              confirmedLabel={t('common.lifecycle.confirmed')}
+              failedLabel={failedLabel}
+              retryAction={retryAction}
+            >
+              {t('form.submit')}
+            </MutationButton>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+}
+
+function collectFormErrors(
+  form: UseFormReturn<Record<string, unknown>>,
+  fields: FieldDefinition[],
+): FormErrorEntry[] {
+  const errs = form.formState.errors;
+  const out: FormErrorEntry[] = [];
+  for (const f of fields) {
+    if (errs[f.id]) {
+      out.push({ field: f.id, displayName: f.displayName, order: f.order });
+    }
+  }
+  return out;
+}
+
+function renderField(
+  f: FieldDefinition,
+  disabled: boolean,
+  form: UseFormReturn<Record<string, unknown>>,
+) {
+  if (f.type === 'file') {
+    return (
+      <p key={f.id} className="text-sm text-[var(--muted-foreground)]">
+        {t('cases.create.fileNotYet')}
+      </p>
+    );
+  }
+  return (
+    <FormField
+      key={f.id}
+      name={f.id}
+      label={f.displayName}
+      required={f.required}
+      disabled={disabled}
+    >
+      {(field) => renderInput(f, field, form)}
+    </FormField>
+  );
+}
+
+function renderInput(
+  f: FieldDefinition,
+  field: FormFieldRenderProps<Record<string, unknown>, string>,
+  form: UseFormReturn<Record<string, unknown>>,
+) {
+  switch (f.type) {
+    case 'text':
+      return (
+        <Input
+          type="text"
+          maxLength={f.maxLength ?? undefined}
+          {...field}
+          value={String(field.value ?? '')}
+        />
+      );
+    case 'textarea':
+      return (
+        <Textarea
+          maxLength={f.maxLength ?? undefined}
+          {...field}
+          value={String(field.value ?? '')}
+        />
+      );
+    case 'number':
+      return (
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={f.min ?? undefined}
+          max={f.max ?? undefined}
+          step={f.step ?? 1}
+          {...field}
+          value={field.value === undefined || field.value === null ? '' : String(field.value)}
+        />
+      );
+    case 'date':
+      return (
+        <Input
+          type="date"
+          min={f.dateMin ?? undefined}
+          max={f.dateMax ?? undefined}
+          {...field}
+          value={String(field.value ?? '')}
+        />
+      );
+    case 'select': {
+      const stringValue =
+        typeof field.value === 'string' && field.value !== '' ? field.value : undefined;
+      return (
+        <Select
+          value={stringValue}
+          onValueChange={(v) => {
+            field.onChange(v);
+            void form.trigger(f.id);
+          }}
+          disabled={field.disabled}
+        >
+          <SelectTrigger
+            id={field.id}
+            aria-invalid={field['aria-invalid']}
+            aria-describedby={field['aria-describedby']}
+            ref={field.ref as unknown as React.Ref<HTMLButtonElement>}
+          >
+            <SelectValue placeholder={t('cases.create.selectPlaceholder')} />
+          </SelectTrigger>
+          <SelectContent>
+            {f.options.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }
+    case 'checkbox':
+      return (
+        <Checkbox
+          id={field.id}
+          checked={Boolean(field.value)}
+          onCheckedChange={(v) => {
+            field.onChange(Boolean(v));
+            void form.trigger(f.id);
+          }}
+          disabled={field.disabled}
+          aria-invalid={field['aria-invalid']}
+          aria-describedby={field['aria-describedby']}
+          ref={field.ref as unknown as React.Ref<HTMLButtonElement>}
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/frontend/src/components/forms/SinglePageFormRenderer.tsx
+++ b/frontend/src/components/forms/SinglePageFormRenderer.tsx
@@ -28,6 +28,11 @@ export interface SinglePageFormRendererProps {
   formDefinition: FormDefinitionView;
   /** The case to submit the form for. */
   caseId: string;
+  /**
+   * Existing case data to prefill the form with (P8). When provided, field values from the case
+   * are used as initial values so users see current data when reopening a form.
+   */
+  defaultValues?: Record<string, unknown>;
   /** Called after a successful submit so the parent can react (e.g. show a toast, navigate). */
   onSuccess?: () => void;
 }
@@ -55,6 +60,7 @@ interface ServerErrorBanner {
 export function SinglePageFormRenderer({
   formDefinition,
   caseId,
+  defaultValues: externalDefaultValues,
   onSuccess,
 }: SinglePageFormRendererProps) {
   const [serverError, setServerError] = useState<ServerErrorBanner | null>(null);
@@ -74,11 +80,17 @@ export function SinglePageFormRenderer({
   const schema = useMemo(() => buildZodFromFieldDefs(sortedFields, 'submit'), [sortedFields]);
 
   // Default values keyed by field id so controlled inputs are always controlled.
+  // P8: merge externalDefaultValues (case.data) over the blank-field defaults so users see
+  // existing case data when reopening the form. The blank-field default ensures every field is
+  // controlled even if the case has no stored value for it yet.
   const defaultValues = useMemo<Record<string, unknown>>(() => {
     const dv: Record<string, unknown> = {};
     for (const f of sortedFields) dv[f.id] = f.type === 'checkbox' ? false : '';
+    if (externalDefaultValues) {
+      Object.assign(dv, externalDefaultValues);
+    }
     return dv;
-  }, [sortedFields]);
+  }, [sortedFields, externalDefaultValues]);
 
   const form = useForm<Record<string, unknown>>({
     resolver: zodResolver(schema),
@@ -181,6 +193,12 @@ export function SinglePageFormRenderer({
           aria-busy={isPending ? true : undefined}
           className="flex flex-col gap-[var(--form-field-gap,1rem)]"
         >
+          {form.formState.isSubmitted ? (
+            <FormErrorsBanner
+              errors={collectFormErrors(form, sortedFields)}
+              onAnchorClick={(field) => form.setFocus(field)}
+            />
+          ) : null}
           {sortedFields.length === 0 ? (
             <p className="text-sm text-[var(--muted-foreground)]">
               {t('cases.create.noRequired', { caseTypeName: formDefinition.id })}
@@ -188,12 +206,6 @@ export function SinglePageFormRenderer({
           ) : (
             sortedFields.map((f) => renderField(f, isPending, form))
           )}
-          {form.formState.isSubmitted ? (
-            <FormErrorsBanner
-              errors={collectFormErrors(form, sortedFields)}
-              onAnchorClick={(field) => form.setFocus(field)}
-            />
-          ) : null}
           {serverError ? (
             <Alert
               ref={bannerRef}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -185,5 +185,9 @@
   "stageTimeline.timestamp.exited": "Exited {date}",
   "stageTimeline.timestamp.enteredAndExited": "Entered {entered} · Exited {exited}",
   "stageTimeline.timestamp.skippedOn": "Skipped {date}",
-  "stageTimeline.timestamp.currentSince": "Current since {date}"
+  "stageTimeline.timestamp.currentSince": "Current since {date}",
+  "form.loading": "Loading form…",
+  "form.error.caseLoad": "Could not load case.",
+  "form.error.notFound": "Form not found on this case type.",
+  "form.submit": "Submit"
 }

--- a/frontend/src/lib/buildZodFromFieldDefs.test.ts
+++ b/frontend/src/lib/buildZodFromFieldDefs.test.ts
@@ -163,3 +163,49 @@ describe('buildZodFromFieldDefs — file', () => {
     expect(schema.safeParse({ a: undefined }).success).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Story 5.2 — 'submit' mode
+// ---------------------------------------------------------------------------
+
+describe('buildZodFromFieldDefs — submit mode', () => {
+  it('includes fields where required === true (not filtered by requiredOnCreate)', () => {
+    // required=true, requiredOnCreate=false — 'create' would exclude, 'submit' must include.
+    const schema = buildZodFromFieldDefs(
+      [
+        field({ id: 'a', required: true, requiredOnCreate: false }),
+        field({ id: 'b', required: false, requiredOnCreate: false }),
+      ],
+      'submit',
+    );
+    expect(Object.keys(schema.shape)).toContain('a');
+    expect(Object.keys(schema.shape)).not.toContain('b');
+  });
+
+  it('validates required text field in submit mode', () => {
+    const schema = buildZodFromFieldDefs(
+      [field({ id: 'a', type: 'text', required: true, requiredOnCreate: false })],
+      'submit',
+    );
+    expect(schema.safeParse({ a: '' }).success).toBe(false);
+    expect(schema.safeParse({ a: 'hello' }).success).toBe(true);
+  });
+
+  it('validates required checkbox in submit mode using f.required', () => {
+    const schema = buildZodFromFieldDefs(
+      [field({ id: 'a', type: 'checkbox', required: true, requiredOnCreate: false })],
+      'submit',
+    );
+    expect(schema.safeParse({ a: false }).success).toBe(false);
+    expect(schema.safeParse({ a: true }).success).toBe(true);
+  });
+
+  it('excludes non-required fields from submit schema', () => {
+    const schema = buildZodFromFieldDefs(
+      [field({ id: 'a', required: false, requiredOnCreate: false })],
+      'submit',
+    );
+    // Non-required field is absent from schema — empty object passes.
+    expect(Object.keys(schema.shape)).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/buildZodFromFieldDefs.test.ts
+++ b/frontend/src/lib/buildZodFromFieldDefs.test.ts
@@ -169,8 +169,10 @@ describe('buildZodFromFieldDefs — file', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildZodFromFieldDefs — submit mode', () => {
-  it('includes fields where required === true (not filtered by requiredOnCreate)', () => {
-    // required=true, requiredOnCreate=false — 'create' would exclude, 'submit' must include.
+  it('includes ALL fields in submit mode — required fields are mandatory, optional fields have constraints validated', () => {
+    // P1 fix: submit mode includes ALL fields so optional fields with constraints are still
+    // validated. The distinction: required fields must be present; optional fields are wrapped
+    // with .optional() so they may be omitted but if present must satisfy type constraints.
     const schema = buildZodFromFieldDefs(
       [
         field({ id: 'a', required: true, requiredOnCreate: false }),
@@ -179,7 +181,8 @@ describe('buildZodFromFieldDefs — submit mode', () => {
       'submit',
     );
     expect(Object.keys(schema.shape)).toContain('a');
-    expect(Object.keys(schema.shape)).not.toContain('b');
+    // P1: optional field 'b' is now included (as .optional()) so its constraints are validated
+    expect(Object.keys(schema.shape)).toContain('b');
   });
 
   it('validates required text field in submit mode', () => {
@@ -200,12 +203,16 @@ describe('buildZodFromFieldDefs — submit mode', () => {
     expect(schema.safeParse({ a: true }).success).toBe(true);
   });
 
-  it('excludes non-required fields from submit schema', () => {
+  it('includes optional fields in submit schema (as .optional()) so constraints are still enforced', () => {
+    // P1 fix: optional fields are included so type constraints (maxLength, min/max) are validated.
+    // They are wrapped with .optional() so omitting the field entirely is still valid.
     const schema = buildZodFromFieldDefs(
       [field({ id: 'a', required: false, requiredOnCreate: false })],
       'submit',
     );
-    // Non-required field is absent from schema — empty object passes.
-    expect(Object.keys(schema.shape)).toHaveLength(0);
+    // Optional field IS present in the schema shape (as .optional()), not excluded.
+    expect(Object.keys(schema.shape)).toContain('a');
+    // Empty object still passes because the field is optional.
+    expect(schema.safeParse({}).success).toBe(true);
   });
 });

--- a/frontend/src/lib/buildZodFromFieldDefs.ts
+++ b/frontend/src/lib/buildZodFromFieldDefs.ts
@@ -15,14 +15,23 @@ import type { FieldDefinition } from '@/types/caseType';
  * Specific error messages per slot (epic AC4) — no generic "Invalid input". Strings come from
  * `i18n/en.json` keyed by error variant.
  */
-export type BuildMode = 'create' | 'edit';
+export type BuildMode = 'create' | 'edit' | 'submit';
 
 export function buildZodFromFieldDefs(
   fields: FieldDefinition[],
   mode: BuildMode = 'create',
 ): z.ZodObject<z.ZodRawShape> {
   const shape: z.ZodRawShape = {};
-  const filtered = mode === 'create' ? fields.filter((f) => f.requiredOnCreate) : fields;
+  // 'create' — only fields with requiredOnCreate (create-case dialog gate).
+  // 'submit' — only fields with required: true (all required fields, not filtered by
+  //            requiredOnCreate). This is the key distinction for SinglePageFormRenderer.
+  // 'edit'   — all fields (no filter); existing edit-case behaviour is unchanged.
+  const filtered =
+    mode === 'create'
+      ? fields.filter((f) => f.requiredOnCreate)
+      : mode === 'submit'
+        ? fields.filter((f) => f.required)
+        : fields;
   for (const f of filtered) {
     shape[f.id] = schemaForField(f, mode);
   }

--- a/frontend/src/lib/buildZodFromFieldDefs.ts
+++ b/frontend/src/lib/buildZodFromFieldDefs.ts
@@ -23,17 +23,27 @@ export function buildZodFromFieldDefs(
 ): z.ZodObject<z.ZodRawShape> {
   const shape: z.ZodRawShape = {};
   // 'create' — only fields with requiredOnCreate (create-case dialog gate).
-  // 'submit' — only fields with required: true (all required fields, not filtered by
-  //            requiredOnCreate). This is the key distinction for SinglePageFormRenderer.
+  // 'submit' — ALL fields are included so optional fields with constraints (maxLength, min/max,
+  //            pattern) are still validated. The "required" constraint is only enforced for fields
+  //            where required === true; optional fields may be left blank but if filled must satisfy
+  //            type-specific constraints.
   // 'edit'   — all fields (no filter); existing edit-case behaviour is unchanged.
-  const filtered =
-    mode === 'create'
-      ? fields.filter((f) => f.requiredOnCreate)
-      : mode === 'submit'
-        ? fields.filter((f) => f.required)
-        : fields;
+  const filtered = mode === 'create' ? fields.filter((f) => f.requiredOnCreate) : fields; // 'submit' and 'edit' both include ALL fields
   for (const f of filtered) {
-    shape[f.id] = schemaForField(f, mode);
+    let fieldSchema = schemaForField(f, mode);
+    // In 'submit' mode, optional fields (required !== true) get their constraints validated but
+    // the field itself is not mandatory. Preprocess empty-string / null / undefined to undefined
+    // so the .optional() wrapper accepts "user left field blank" without triggering min-length
+    // or other constraints (constraints only fire when the user actually provides a value).
+    if (mode === 'submit' && !f.required) {
+      fieldSchema = z
+        .preprocess(
+          (v) => (v === '' || v === null || v === undefined ? undefined : v),
+          fieldSchema.optional(),
+        )
+        .optional();
+    }
+    shape[f.id] = fieldSchema;
   }
   return z.object(shape);
 }

--- a/frontend/src/pages/FormPage.tsx
+++ b/frontend/src/pages/FormPage.tsx
@@ -1,0 +1,60 @@
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { SinglePageFormRenderer } from '@/components/forms/SinglePageFormRenderer';
+import { useCase } from '@/hooks/useCases';
+import { t } from '@/i18n';
+
+/**
+ * Story 5.2 — Route-accessible form page. Fetches the case (which embeds the case-type view,
+ * including any declared {@code forms[]}), resolves the form by id from the path, and renders
+ * {@link SinglePageFormRenderer}.
+ *
+ * <p>Route: {@code /cases/:caseId/forms/:formId}
+ *
+ * <p>The case DTO embeds the case-type view in one round-trip (architecture.md §Decision 12) so no
+ * separate {@code GET /api/case-types/{id}} call is needed here.
+ */
+export function FormPage() {
+  const { caseId, formId } = useParams<{ caseId: string; formId: string }>();
+  const navigate = useNavigate();
+
+  const caseQuery = useCase(caseId ?? null);
+
+  if (caseQuery.isPending) {
+    return (
+      <div className="flex items-center justify-center p-8 text-sm text-[var(--muted-foreground)]">
+        {t('form.loading')}
+      </div>
+    );
+  }
+
+  if (caseQuery.isError || !caseQuery.data) {
+    return (
+      <div className="flex items-center justify-center p-8 text-sm text-[var(--destructive)]">
+        {t('form.error.caseLoad')}
+      </div>
+    );
+  }
+
+  const caseDto = caseQuery.data;
+  const formDef = (caseDto.caseType.forms ?? []).find((f) => f.id === formId);
+
+  if (!formDef) {
+    return (
+      <div className="flex items-center justify-center p-8 text-sm text-[var(--destructive)]">
+        {t('form.error.notFound')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl p-6">
+      <h1 className="mb-6 text-xl font-semibold">{formDef.id}</h1>
+      <SinglePageFormRenderer
+        formDefinition={formDef}
+        caseId={caseId!}
+        onSuccess={() => navigate(`/cases/${caseId}`)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/FormPage.tsx
+++ b/frontend/src/pages/FormPage.tsx
@@ -53,6 +53,7 @@ export function FormPage() {
       <SinglePageFormRenderer
         formDefinition={formDef}
         caseId={caseId!}
+        defaultValues={caseDto.data}
         onSuccess={() => navigate(`/cases/${caseId}`)}
       />
     </div>

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -8,6 +8,7 @@ import { RootRedirect } from '@/components/routing/RootRedirect';
 import { AdminPage } from '@/pages/AdminPage';
 import { CasesPage } from '@/pages/CasesPage';
 import { DevConsolePage } from '@/pages/DevConsolePage';
+import { FormPage } from '@/pages/FormPage';
 import { LoginPage, safeReturnTo } from '@/pages/LoginPage';
 import { TasksPage } from '@/pages/TasksPage';
 import { useAuthStore } from '@/stores/authStore';
@@ -44,6 +45,8 @@ export const router = createBrowserRouter([
     children: [
       { path: '/cases', element: <CasesPage /> },
       { path: '/cases/:caseId', element: <CasesPage /> },
+      // Story 5.2 — single-page form renderer route.
+      { path: '/cases/:caseId/forms/:formId', element: <FormPage /> },
       { path: '/tasks', element: <TasksPage /> },
       {
         path: '/admin',

--- a/frontend/src/types/caseType.ts
+++ b/frontend/src/types/caseType.ts
@@ -74,6 +74,20 @@ export interface StageDefinitionView {
   ordinal: number;
 }
 
+/**
+ * Story 5.2 — wire-shape projection of one form definition from the case-type YAML {@code forms[]}
+ * block. Carries the three-axis vocabulary and the form's field list so the frontend renderer has
+ * everything it needs from the {@code GET /api/case-types/{id}} response without a second
+ * round-trip.
+ */
+export interface FormDefinitionView {
+  id: string;
+  topology: string;
+  dataModel: string;
+  rendering: string;
+  fields: FieldDefinition[];
+}
+
 export interface CaseTypeView {
   id: string;
   displayName: string;
@@ -87,4 +101,10 @@ export interface CaseTypeView {
    * `StageTimeline` component treats `undefined` and `[]` identically (component returns null).
    */
   stages?: StageDefinitionView[];
+  /**
+   * Story 5.2 — form definitions declared in the YAML {@code forms[]} block. Optional for
+   * backward-compat with pre-5.2 fixtures; the wire shape always includes it. Empty array when
+   * no forms block is declared.
+   */
+  forms?: FormDefinitionView[];
 }


### PR DESCRIPTION
## Summary

- Adds `FormDefinition` domain model + YAML deserialization (`FormDefinitionMapper`) so case-type configs can declare forms with typed fields
- Implements `POST /api/cases/:caseId/forms/:formId/submit` (`FormController` → `CaseService.submitForm`) with field-level validation (WKS-FORM-002), case-data write, and `FormSubmitted` domain event
- Ships `SinglePageFormRenderer` React component (all fields on one page, RHF + Zod validation, `FormErrorsBanner` on empty submit, `MutationButton` lifecycle) and `/cases/:caseId/forms/:formId` route via new `FormPage`
- Extends `buildZodFromFieldDefs` with a `'submit'` mode (validates `field.required`, not `requiredOnCreate`)
- CI green: 110 backend tests + ArchUnit, 261 frontend tests, spotless + ESLint + Prettier + tsc all pass

## Test plan

- [ ] Backend: `mvn verify -B` passes (110 tests)
- [ ] Backend: `mvn verify -P tenant-invariant-lint` passes
- [ ] Frontend: `npm run test` passes (261 tests, including 6 new `SinglePageFormRenderer` tests and 4 new `buildZodFromFieldDefs submit-mode` tests)
- [ ] Frontend: `npm run lint && npm run format:check && npm run build` all pass
- [ ] Manual: navigate to `/cases/:caseId/forms/:formId` — form fields render in order; submitting empty shows `FormErrorsBanner`; filling required fields and submitting calls the API and navigates back to the case

🤖 Generated with [Claude Code](https://claude.com/claude-code)