### PR TITLE
feat(5-3): multi-section form renderer — sectioned data model + MultiSectionFormRenderer

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
@@ -96,11 +96,30 @@ public record CaseTypeViewDto(
    * com.wkspower.platform.domain.config.model.FormDefinition} for the case-type view endpoint.
    * Carries the three-axis vocabulary and the form's field list so the frontend renderer has
    * everything it needs in the {@code GET /api/case-types/{id}} response.
+   *
+   * <p>Story 5.3 — adds {@code sections[]} for {@code dataModel: sectioned} forms.
    */
   public record FormDefinitionView(
-      String id, String topology, String dataModel, String rendering, List<FieldView> fields) {
+      String id,
+      String topology,
+      String dataModel,
+      String rendering,
+      List<FieldView> fields,
+      List<FormSectionView> sections) {
 
     public FormDefinitionView {
+      fields = fields == null ? List.of() : List.copyOf(fields);
+      sections = sections == null ? List.of() : List.copyOf(sections);
+    }
+  }
+
+  /**
+   * Story 5.3 — wire-shape for one section in a {@code dataModel: sectioned} form. Groups a set of
+   * fields under a labelled expandable panel on the frontend.
+   */
+  public record FormSectionView(String id, String label, List<FieldView> fields) {
+
+    public FormSectionView {
       fields = fields == null ? List.of() : List.copyOf(fields);
     }
   }

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -5,6 +5,7 @@ import com.wkspower.platform.api.dto.response.CaseSummaryDto;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.FieldView;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.FormDefinitionView;
+import com.wkspower.platform.api.dto.response.CaseTypeViewDto.FormSectionView;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.OptionView;
 import com.wkspower.platform.api.dto.response.CaseTypeViewDto.StageDefinitionView;
 import com.wkspower.platform.api.dto.response.StageView;
@@ -12,6 +13,7 @@ import com.wkspower.platform.api.dto.response.StatusView;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.config.model.FieldDefinition;
 import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.FormSection;
 import com.wkspower.platform.domain.config.model.StageDefinition;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.domain.model.Case;
@@ -179,11 +181,21 @@ public final class CaseDtoMapper {
   /**
    * Story 5.2 — map one {@link FormDefinition} to its wire DTO. Fields within the form definition
    * are mapped using the same {@link #toFieldView} helper used for case-type-level fields.
+   *
+   * <p>Story 5.3 — also maps {@code sections[]} for {@code dataModel: sectioned} forms.
    */
   static FormDefinitionView toFormDefinitionView(FormDefinition form) {
     List<FieldView> fieldViews = form.fields().stream().map(CaseDtoMapper::toFieldView).toList();
+    List<FormSectionView> sectionViews =
+        form.sections().stream().map(CaseDtoMapper::toFormSectionView).toList();
     return new FormDefinitionView(
-        form.id(), form.topology(), form.dataModel(), form.rendering(), fieldViews);
+        form.id(), form.topology(), form.dataModel(), form.rendering(), fieldViews, sectionViews);
+  }
+
+  /** Story 5.3 — map one {@link FormSection} to its wire DTO. */
+  static FormSectionView toFormSectionView(FormSection section) {
+    List<FieldView> fieldViews = section.fields().stream().map(CaseDtoMapper::toFieldView).toList();
+    return new FormSectionView(section.id(), section.label(), fieldViews);
   }
 
   static FieldView toFieldView(FieldDefinition f) {

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
@@ -31,9 +31,29 @@ public record FormDefinition(
      * Fields rendered by this form. May be a subset of the case-type's overall fields when the form
      * targets specific field ids.
      */
-    List<FieldDefinition> fields) {
+    List<FieldDefinition> fields,
+    /**
+     * Story 5.3 — sections declared for {@code dataModel: sectioned} forms. Empty for monolithic
+     * forms.
+     */
+    List<FormSection> sections) {
 
   public FormDefinition {
     fields = fields == null ? List.of() : List.copyOf(fields);
+    sections = sections == null ? List.of() : List.copyOf(sections);
+  }
+
+  /**
+   * Backward-compat constructor for callers that pre-date Story 5.3's {@code sections} slot.
+   * Defaults {@code sections} to {@link List#of()}, preserving the contract that monolithic forms
+   * never have sections.
+   */
+  public FormDefinition(
+      String id,
+      String topology,
+      String dataModel,
+      String rendering,
+      List<FieldDefinition> fields) {
+    this(id, topology, dataModel, rendering, fields, List.of());
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/FormSection.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/FormSection.java
@@ -1,0 +1,15 @@
+package com.wkspower.platform.domain.config.model;
+
+import java.util.List;
+
+/**
+ * One section entry in a {@link FormDefinition} with {@code dataModel: sectioned}. Immutable.
+ *
+ * <p>Story 5.3 — groups a set of fields under a labelled expandable panel on the frontend.
+ */
+public record FormSection(String id, String label, List<FieldDefinition> fields) {
+
+  public FormSection {
+    fields = fields == null ? List.of() : List.copyOf(fields);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
@@ -4,6 +4,7 @@ import com.wkspower.platform.domain.config.model.FieldDefinition;
 import com.wkspower.platform.domain.config.model.FieldOption;
 import com.wkspower.platform.domain.config.model.FieldType;
 import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.FormSection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,25 @@ public final class FormDefinitionMapper {
    */
   public static FormDefinition toDomain(RawFormDefinition raw) {
     List<FieldDefinition> fields = mapFields(raw.fields());
-    return new FormDefinition(raw.id(), raw.topology(), raw.dataModel(), raw.rendering(), fields);
+    List<FormSection> sections = mapSections(raw.sections());
+    return new FormDefinition(
+        raw.id(), raw.topology(), raw.dataModel(), raw.rendering(), fields, sections);
+  }
+
+  /**
+   * Story 5.3 — map raw section entries to domain {@link FormSection} records. Delegates to the
+   * existing {@link #mapFields} helper for each section's field list.
+   */
+  private static List<FormSection> mapSections(List<RawFormSection> rawSections) {
+    if (rawSections == null || rawSections.isEmpty()) return List.of();
+    List<FormSection> out = new ArrayList<>(rawSections.size());
+    for (RawFormSection s : rawSections) {
+      if (s == null || s.id() == null || s.id().isBlank()) continue;
+      String label = s.label() != null ? s.label() : s.id();
+      List<FieldDefinition> sectionFields = mapFields(s.fields());
+      out.add(new FormSection(s.id(), label, sectionFields));
+    }
+    return List.copyOf(out);
   }
 
   // ---- private helpers -----------------------------------------------------------------

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormValidator.java
@@ -123,6 +123,38 @@ public class FormValidator {
                 "Invalid rendering '" + rendering + "' — allowed: " + ALLOWED_RENDERINGS,
                 base + "/rendering"));
       }
+
+      // --- sections (required when dataModel is "sectioned") ---
+      // Story 5.3: validate section structure when dataModel declares sectioned layout.
+      if ("sectioned".equals(dataModel)) {
+        List<RawFormSection> sections = def.sections();
+        if (sections == null || sections.isEmpty()) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_CFG_001.wire(),
+                  "Form with dataModel: sectioned must declare at least one section in 'sections[]'",
+                  base + "/sections"));
+        } else {
+          for (int j = 0; j < sections.size(); j++) {
+            RawFormSection sec = sections.get(j);
+            String secBase = base + "/sections/" + j;
+            if (sec == null || sec.id() == null || sec.id().isBlank()) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_CFG_001.wire(),
+                      "Section entry at index " + j + " is missing required 'id'",
+                      secBase + "/id"));
+            }
+            if (sec != null && (sec.label() == null || sec.label().isBlank())) {
+              errors.add(
+                  ErrorDetail.ofField(
+                      ErrorCode.WKS_CFG_001.wire(),
+                      "Section '" + sec.id() + "' is missing required 'label'",
+                      secBase + "/label"));
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
@@ -26,4 +26,24 @@ public record RawFormDefinition(
     @JsonProperty("topology") String topology,
     @JsonProperty("dataModel") String dataModel,
     @JsonProperty("rendering") String rendering,
-    @JsonProperty("fields") List<Map<String, Object>> fields) {}
+    @JsonProperty("fields") List<Map<String, Object>> fields,
+    /**
+     * Story 5.3 — sections declared for {@code dataModel: sectioned} forms. Absent (null) for
+     * monolithic forms; validated by {@link FormValidator} when {@code dataModel} is {@code
+     * sectioned}.
+     */
+    @JsonProperty("sections") List<RawFormSection> sections) {
+
+  /**
+   * Backward-compat constructor for callers (mostly tests) that pre-date Story 5.3's {@code
+   * sections} slot. Defaults {@code sections} to {@code null} — monolithic forms have no sections.
+   */
+  public RawFormDefinition(
+      String id,
+      String topology,
+      String dataModel,
+      String rendering,
+      List<Map<String, Object>> fields) {
+    this(id, topology, dataModel, rendering, fields, null);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormSection.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormSection.java
@@ -1,0 +1,18 @@
+package com.wkspower.platform.infrastructure.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Transport-shaped record for one section entry in a CaseType YAML {@code forms[].sections[]}
+ * block. Used by {@code dataModel: sectioned} forms.
+ *
+ * <p>Story 5.3 — schema extension; no runtime or persistence concern.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RawFormSection(
+    @JsonProperty("id") String id,
+    @JsonProperty("label") String label,
+    @JsonProperty("fields") List<Map<String, Object>> fields) {}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
@@ -1,0 +1,154 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.FormSection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 5.3 — unit tests for {@link FormDefinitionMapper} section mapping. Verifies that sections
+ * round-trip from raw YAML structures to domain {@link FormSection} records with fields intact.
+ */
+class FormDefinitionMapperTest {
+
+  // ---- monolithic forms (no sections) ----
+
+  @Test
+  void monolithic_noSections_sectionsEmptyList() {
+    var raw =
+        new RawFormDefinition(
+            "intake",
+            "single",
+            "monolithic",
+            "single-page",
+            List.of(
+                Map.of(
+                    "id",
+                    "name",
+                    "displayName",
+                    "Full Name",
+                    "type",
+                    "text",
+                    "required",
+                    true,
+                    "order",
+                    0)),
+            null);
+    FormDefinition result = FormDefinitionMapper.toDomain(raw);
+
+    assertThat(result.sections()).isEmpty();
+    assertThat(result.fields()).hasSize(1);
+    assertThat(result.fields().get(0).id()).isEqualTo("name");
+  }
+
+  // ---- sectioned forms ----
+
+  @Test
+  void sectioned_twoSections_fieldsIntact() {
+    var personalFields =
+        List.of(
+            Map.<String, Object>of(
+                "id",
+                "firstName",
+                "displayName",
+                "First Name",
+                "type",
+                "text",
+                "required",
+                true,
+                "order",
+                1),
+            Map.<String, Object>of(
+                "id",
+                "lastName",
+                "displayName",
+                "Last Name",
+                "type",
+                "text",
+                "required",
+                true,
+                "order",
+                2));
+    var employmentFields =
+        List.of(
+            Map.<String, Object>of(
+                "id",
+                "employer",
+                "displayName",
+                "Employer",
+                "type",
+                "text",
+                "required",
+                false,
+                "order",
+                1));
+
+    var sections =
+        List.of(
+            new RawFormSection("personal", "Personal Information", personalFields),
+            new RawFormSection("employment", "Employment Details", employmentFields));
+
+    var raw =
+        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, sections);
+    FormDefinition result = FormDefinitionMapper.toDomain(raw);
+
+    assertThat(result.sections()).hasSize(2);
+
+    FormSection personal = result.sections().get(0);
+    assertThat(personal.id()).isEqualTo("personal");
+    assertThat(personal.label()).isEqualTo("Personal Information");
+    assertThat(personal.fields()).hasSize(2);
+    assertThat(personal.fields())
+        .extracting(f -> f.id())
+        .containsExactlyInAnyOrder("firstName", "lastName");
+
+    FormSection employment = result.sections().get(1);
+    assertThat(employment.id()).isEqualTo("employment");
+    assertThat(employment.label()).isEqualTo("Employment Details");
+    assertThat(employment.fields()).hasSize(1);
+    assertThat(employment.fields().get(0).id()).isEqualTo("employer");
+  }
+
+  @Test
+  void sectioned_sectionWithoutLabel_defaultsToId() {
+    var section = new RawFormSection("personal", null, List.of());
+    var raw =
+        new RawFormDefinition(
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(section));
+    FormDefinition result = FormDefinitionMapper.toDomain(raw);
+
+    // label defaults to id when absent
+    assertThat(result.sections()).hasSize(1);
+    assertThat(result.sections().get(0).label()).isEqualTo("personal");
+  }
+
+  @Test
+  void sectioned_sectionWithBlankId_skipped() {
+    var blankId = new RawFormSection("", "Section A", List.of());
+    var valid = new RawFormSection("employment", "Employment", List.of());
+    var raw =
+        new RawFormDefinition(
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(blankId, valid));
+    FormDefinition result = FormDefinitionMapper.toDomain(raw);
+
+    // blank-id section is skipped; valid section remains
+    assertThat(result.sections()).hasSize(1);
+    assertThat(result.sections().get(0).id()).isEqualTo("employment");
+  }
+
+  @Test
+  void sectioned_nullSectionEntry_skipped() {
+    var sections = new java.util.ArrayList<RawFormSection>();
+    sections.add(null);
+    sections.add(new RawFormSection("employment", "Employment", List.of()));
+    var raw =
+        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, sections);
+    FormDefinition result = FormDefinitionMapper.toDomain(raw);
+
+    assertThat(result.sections()).hasSize(1);
+    assertThat(result.sections().get(0).id()).isEqualTo("employment");
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormValidatorTest.java
@@ -47,7 +47,11 @@ class FormValidatorTest {
   @Test
   void validTriplet_singleSectionedMultiSection_noErrors() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("onboarding", "single", "sectioned", "multi-section", null);
+    // Story 5.3: sectioned forms require at least one section with id + label
+    var section = new RawFormSection("personal", "Personal Information", List.of());
+    var def =
+        new RawFormDefinition(
+            "onboarding", "single", "sectioned", "multi-section", null, List.of(section));
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
     assertThat(errors).isEmpty();
   }
@@ -194,5 +198,95 @@ class FormValidatorTest {
     // Only the second definition should produce errors
     assertThat(errors).isNotEmpty();
     assertThat(errors).allSatisfy(e -> assertThat(e.field()).contains("/forms/1"));
+  }
+
+  // ---- Story 5.3: section validation for dataModel: sectioned ----
+
+  @Test
+  void sectioned_withoutSections_emitsWksCfg001() {
+    List<ErrorDetail> errors = new ArrayList<>();
+    // No sections provided — should require at least one
+    var def =
+        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, null);
+    validator.validate(RawFormConfig.fromList(List.of(def)), errors);
+
+    assertThat(errors)
+        .anySatisfy(
+            e -> {
+              assertThat(e.code()).isEqualTo("WKS-CFG-001");
+              assertThat(e.field()).contains("/sections");
+              assertThat(e.message()).contains("sectioned");
+            });
+  }
+
+  @Test
+  void sectioned_withEmptySectionsList_emitsWksCfg001() {
+    List<ErrorDetail> errors = new ArrayList<>();
+    var def =
+        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, List.of());
+    validator.validate(RawFormConfig.fromList(List.of(def)), errors);
+
+    assertThat(errors)
+        .anySatisfy(
+            e -> {
+              assertThat(e.code()).isEqualTo("WKS-CFG-001");
+              assertThat(e.field()).contains("/sections");
+            });
+  }
+
+  @Test
+  void sectioned_withValidSections_passes() {
+    List<ErrorDetail> errors = new ArrayList<>();
+    var section = new RawFormSection("personal", "Personal Information", List.of());
+    var def =
+        new RawFormDefinition(
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(section));
+    validator.validate(RawFormConfig.fromList(List.of(def)), errors);
+
+    assertThat(errors).isEmpty();
+  }
+
+  @Test
+  void sectioned_sectionMissingLabel_emitsWksCfg001() {
+    List<ErrorDetail> errors = new ArrayList<>();
+    var section = new RawFormSection("personal", null, List.of());
+    var def =
+        new RawFormDefinition(
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(section));
+    validator.validate(RawFormConfig.fromList(List.of(def)), errors);
+
+    assertThat(errors)
+        .anySatisfy(
+            e -> {
+              assertThat(e.code()).isEqualTo("WKS-CFG-001");
+              assertThat(e.field()).contains("/sections/0/label");
+            });
+  }
+
+  @Test
+  void sectioned_sectionMissingId_emitsWksCfg001() {
+    List<ErrorDetail> errors = new ArrayList<>();
+    var section = new RawFormSection(null, "Personal Information", List.of());
+    var def =
+        new RawFormDefinition(
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(section));
+    validator.validate(RawFormConfig.fromList(List.of(def)), errors);
+
+    assertThat(errors)
+        .anySatisfy(
+            e -> {
+              assertThat(e.code()).isEqualTo("WKS-CFG-001");
+              assertThat(e.field()).contains("/sections/0/id");
+            });
+  }
+
+  @Test
+  void monolithic_withoutSections_noSectionErrors() {
+    List<ErrorDetail> errors = new ArrayList<>();
+    // monolithic forms do not need sections — no section errors expected
+    var def = new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null);
+    validator.validate(RawFormConfig.fromList(List.of(def)), errors);
+
+    assertThat(errors).isEmpty();
   }
 }

--- a/frontend/src/components/forms/MultiSectionFormRenderer.test.tsx
+++ b/frontend/src/components/forms/MultiSectionFormRenderer.test.tsx
@@ -1,0 +1,297 @@
+/**
+ * Story 5.3 — MultiSectionFormRenderer unit tests.
+ *
+ * AC1: sections render as expandable panels with labels and status indicators.
+ * AC2: submit blocked and focuses first error section.
+ * AC4: progress indicator shows "X of Y sections complete".
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+// ResizeObserver stub for Radix UI Select internals
+beforeAll(() => {
+  if (typeof window !== 'undefined' && !window.ResizeObserver) {
+    window.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+import { TooltipProvider } from '@/components/ui/Tooltip';
+import { server } from '@/test/server';
+import type { FormDefinitionView } from '@/types/caseType';
+
+import { MultiSectionFormRenderer } from './MultiSectionFormRenderer';
+
+function wrap(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TooltipProvider delayDuration={0}>{ui}</TooltipProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * Two-section sectioned form for testing.
+ * Section "personal": firstName (text, required), lastName (text, required)
+ * Section "employment": employer (text, not required)
+ */
+function twoSectionForm(): FormDefinitionView {
+  return {
+    id: 'bank-opening-form',
+    topology: 'single',
+    dataModel: 'sectioned',
+    rendering: 'multi-section',
+    fields: [],
+    sections: [
+      {
+        id: 'personal',
+        label: 'Personal Information',
+        fields: [
+          {
+            id: 'firstName',
+            displayName: 'First Name',
+            type: 'text',
+            required: true,
+            requiredOnCreate: true,
+            order: 1,
+            options: [],
+          },
+          {
+            id: 'lastName',
+            displayName: 'Last Name',
+            type: 'text',
+            required: true,
+            requiredOnCreate: true,
+            order: 2,
+            options: [],
+          },
+        ],
+      },
+      {
+        id: 'employment',
+        label: 'Employment Details',
+        fields: [
+          {
+            id: 'employer',
+            displayName: 'Employer',
+            type: 'text',
+            required: false,
+            requiredOnCreate: false,
+            order: 1,
+            options: [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC1 — Sections render as expandable panels
+// ---------------------------------------------------------------------------
+
+describe('MultiSectionFormRenderer — AC1: sections render as expandable panels', () => {
+  it('renders both section headings', () => {
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={twoSectionForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    expect(screen.getByText('Personal Information')).toBeInTheDocument();
+    expect(screen.getByText('Employment Details')).toBeInTheDocument();
+  });
+
+  it('renders all fields inside sections by default (sections start expanded)', () => {
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={twoSectionForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    expect(screen.getByLabelText(/First Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Last Name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Employer/)).toBeInTheDocument();
+  });
+
+  it('collapses a section when the section header is clicked', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={twoSectionForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    // Click the "Personal Information" section header to collapse it
+    await user.click(screen.getByRole('button', { name: /Personal Information/i }));
+    // Fields inside that section should no longer be visible
+    expect(screen.queryByLabelText(/First Name/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Last Name/)).not.toBeInTheDocument();
+    // Employment section remains open
+    expect(screen.getByLabelText(/Employer/)).toBeInTheDocument();
+  });
+
+  it('renders a single submit button', () => {
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={twoSectionForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+
+  it('renders initial progress indicator "0 of 2 sections complete"', () => {
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={twoSectionForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    expect(screen.getByText(/0 of 2 sections complete/i)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2 — Submit blocked on validation errors + error indicator
+// ---------------------------------------------------------------------------
+
+describe('MultiSectionFormRenderer — AC2: submit blocked when required fields empty', () => {
+  it('shows FormErrorsBanner with required field names after submitting empty form', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={twoSectionForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    // Both required fields (firstName, lastName) should appear in the banner
+    const bannerButtons = await screen.findAllByRole('button', { name: /First Name|Last Name/ });
+    expect(bannerButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows error indicator (✗) on section with errors after submit', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={twoSectionForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    // Wait for validation to run
+    await screen.findAllByRole('button', { name: /First Name|Last Name/ });
+    // Error indicator should be present for "personal" section
+    const errorIndicators = screen.getAllByLabelText('error');
+    expect(errorIndicators.length).toBeGreaterThan(0);
+  });
+
+  it('HTTP call is NOT fired when validation fails', async () => {
+    const user = userEvent.setup();
+    let called = false;
+    server.use(
+      http.post('/api/cases/:caseId/forms/:formId/submit', () => {
+        called = true;
+        return HttpResponse.json({ data: {} });
+      }),
+    );
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={twoSectionForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(called).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC4 — Progress indicator updates on successful submit
+// ---------------------------------------------------------------------------
+
+describe('MultiSectionFormRenderer — AC4: progress indicator', () => {
+  it('calls onSuccess after a valid submission and shows confirmed state', async () => {
+    const user = userEvent.setup();
+    let successCalled = false;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    server.use(
+      http.post('/api/cases/:caseId/forms/:formId/submit', () =>
+        HttpResponse.json({
+          data: {
+            id: '00000000-0000-0000-0000-000000000001',
+            caseTypeId: 'test-ct',
+            caseTypeVersion: 1,
+            status: 'open',
+            assignee: null,
+            data: { firstName: 'Alice', lastName: 'Smith' },
+            processInstanceId: null,
+            documentCount: 0,
+            createdAt: new Date().toISOString(),
+            createdBy: '00000000-0000-0000-0000-000000000099',
+            updatedAt: new Date().toISOString(),
+            version: 1,
+            caseType: {
+              id: 'test-ct',
+              displayName: 'Test CT',
+              version: 1,
+              fields: [],
+              statuses: [],
+              listColumns: [],
+              stages: [],
+              forms: [],
+            },
+            currentStageId: null,
+            currentStageOrdinal: null,
+            stages: [],
+            availableStatuses: [],
+          },
+          meta: {},
+        }),
+      ),
+    );
+
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={twoSectionForm()}
+        caseId="00000000-0000-0000-0000-000000000001"
+        onSuccess={() => {
+          successCalled = true;
+        }}
+      />,
+    );
+
+    // Fill required fields
+    await user.type(screen.getByLabelText(/First Name/), 'Alice');
+    await user.type(screen.getByLabelText(/Last Name/), 'Smith');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    // MutationButton transitions to 'confirmed' state
+    await screen.findByRole('button', { name: /confirmed/i });
+
+    // onSuccess is NOT called immediately (CF1 delay)
+    expect(successCalled).toBe(false);
+
+    // Advance timers past 1200ms delay
+    vi.advanceTimersByTime(1300);
+    expect(successCalled).toBe(true);
+
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/components/forms/MultiSectionFormRenderer.tsx
+++ b/frontend/src/components/forms/MultiSectionFormRenderer.tsx
@@ -1,0 +1,480 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ChevronDown } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
+
+import { ApiError } from '@/api/client';
+import { submitForm } from '@/api/forms';
+import { Alert } from '@/components/ui/Alert';
+import { Button } from '@/components/ui/Button';
+import { Checkbox } from '@/components/ui/Checkbox';
+import { FormErrorsBanner, type FormErrorEntry } from '@/components/ui/FormErrorsBanner';
+import { FormField, type FormFieldRenderProps } from '@/components/ui/FormField';
+import { Input } from '@/components/ui/Input';
+import { MutationButton, type MutationButtonState } from '@/components/ui/MutationButton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import { Textarea } from '@/components/ui/Textarea';
+import { t } from '@/i18n';
+import { buildZodFromFieldDefs } from '@/lib/buildZodFromFieldDefs';
+import type { FieldDefinition, FormDefinitionView, FormSectionView } from '@/types/caseType';
+
+export interface MultiSectionFormRendererProps {
+  /** The form definition (must have sections[]). */
+  formDefinition: FormDefinitionView;
+  /** The case to submit the form for. */
+  caseId: string;
+  /**
+   * Existing case data to prefill the form with. When provided, field values from the case are used
+   * as initial values so users see current data when reopening a form.
+   */
+  defaultValues?: Record<string, unknown>;
+  /** Called after a successful submit so the parent can react (e.g. navigate). */
+  onSuccess?: () => void;
+}
+
+type SectionStatus = 'incomplete' | 'complete' | 'error';
+
+interface ServerErrorBanner {
+  title: string;
+  message: string;
+}
+
+/**
+ * Story 5.3 AC1–4 — Renders a multi-section form from a {@link FormDefinitionView} with {@code
+ * dataModel: sectioned}. Each section declared in {@code sections[]} appears as an expandable panel
+ * with a section label heading and a validation indicator.
+ *
+ * AC1 — Sections render as expandable panels with section-level validation indicators.
+ * AC2 — Submit is blocked and focuses the first incomplete section when required fields are empty.
+ * AC3 — Independent section validation: completing one section does not re-validate others.
+ * AC4 — Progress indicator shows "X of Y sections complete".
+ *
+ * One RHF {@code useForm} for ALL fields across sections (flat namespace — field IDs must be unique
+ * across sections). Section panels use React state for expand/collapse, NOT HTML {@code <details>}
+ * (needed for programmatic focus to open the correct section on submit error).
+ */
+export function MultiSectionFormRenderer({
+  formDefinition,
+  caseId,
+  defaultValues: externalDefaultValues,
+  onSuccess,
+}: MultiSectionFormRendererProps) {
+  const sections = useMemo(() => formDefinition.sections ?? [], [formDefinition.sections]);
+  const allFields = useMemo(() => sections.flatMap((s) => s.fields), [sections]);
+
+  const [serverError, setServerError] = useState<ServerErrorBanner | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  // Track which sections are expanded — all open initially (AC1)
+  const [expanded, setExpanded] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(sections.map((s) => [s.id, true])),
+  );
+
+  // AC2 — 'submit' mode: include ALL fields where required === true
+  const schema = useMemo(() => buildZodFromFieldDefs(allFields, 'submit'), [allFields]);
+
+  // Default values keyed by field id; merge externalDefaultValues (case.data) over blank defaults
+  const defaultValues = useMemo<Record<string, unknown>>(() => {
+    const dv: Record<string, unknown> = {};
+    for (const f of allFields) dv[f.id] = f.type === 'checkbox' ? false : '';
+    if (externalDefaultValues) Object.assign(dv, externalDefaultValues);
+    return dv;
+  }, [allFields, externalDefaultValues]);
+
+  const form = useForm<Record<string, unknown>>({
+    resolver: zodResolver(schema),
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+    // shouldFocusError: false — we handle focus manually to open the correct section first (AC2)
+    shouldFocusError: false,
+    defaultValues,
+  });
+
+  const state: MutationButtonState = isPending
+    ? 'confirming'
+    : isSuccess
+      ? 'confirmed'
+      : isError || serverError
+        ? 'failed'
+        : 'idle';
+
+  /**
+   * AC1 / AC3 — Section status derived from RHF errors and values.
+   * - Before any submit attempt: always 'incomplete' (no pre-validation shown).
+   * - After submit: 'error' if any field in section has an error; 'complete' if all required fields
+   *   filled and no errors; 'incomplete' otherwise.
+   * This is computed per section independently (AC3 — section A errors don't affect section B).
+   */
+  function getSectionStatus(section: FormSectionView): SectionStatus {
+    if (!form.formState.isSubmitted) return 'incomplete';
+    const fieldIds = new Set(section.fields.map((f) => f.id));
+    const hasErrors = Object.keys(form.formState.errors).some((k) => fieldIds.has(k));
+    if (hasErrors) return 'error';
+    const allRequiredFilled = section.fields
+      .filter((f) => f.required)
+      .every((f) => {
+        const v = form.getValues(f.id as string);
+        return v !== '' && v !== false && v !== null && v !== undefined;
+      });
+    return allRequiredFilled ? 'complete' : 'incomplete';
+  }
+
+  /** AC4 — count sections where all required fields filled and no errors */
+  const completeCount = sections.filter((s) => getSectionStatus(s) === 'complete').length;
+
+  /** AC2 — on submit failure: open the first section that has errors, scroll and focus */
+  function openFirstErrorSection(): void {
+    for (const section of sections) {
+      const fieldIds = new Set(section.fields.map((f) => f.id));
+      const hasError = Object.keys(form.formState.errors).some((k) => fieldIds.has(k));
+      if (hasError) {
+        setExpanded((prev) => ({ ...prev, [section.id]: true }));
+        document.getElementById(`section-${section.id}`)?.scrollIntoView({ behavior: 'smooth' });
+        const firstErrorField = section.fields.find((f) => form.formState.errors[f.id]);
+        if (firstErrorField) {
+          setTimeout(() => form.setFocus(firstErrorField.id as string), 100);
+        }
+        break;
+      }
+    }
+  }
+
+  async function onSubmit(values: Record<string, unknown>): Promise<void> {
+    setServerError(null);
+    setIsError(false);
+    setIsSuccess(false);
+    setIsPending(true);
+    try {
+      await submitForm(caseId, formDefinition.id, values);
+      setIsSuccess(true);
+      // CF1: delay onSuccess by 1200ms so user sees the MutationButton "confirmed" state
+      if (onSuccess) setTimeout(onSuccess, 1200);
+    } catch (err) {
+      handleSubmitError(err);
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  function handleSubmitError(err: unknown): void {
+    setIsError(true);
+    if (err instanceof ApiError && err.status === 422 && err.envelopeErrors) {
+      const knownIds = new Set(allFields.map((f) => f.id));
+      const unmapped: string[] = [];
+      let firstFieldName: string | null = null;
+      for (const e of err.envelopeErrors) {
+        if (e.field && knownIds.has(e.field)) {
+          form.setError(e.field, { type: 'server', message: e.message });
+          if (firstFieldName === null) firstFieldName = e.field;
+        } else if (e.message) {
+          unmapped.push(e.message);
+        }
+      }
+      if (firstFieldName !== null) {
+        openFirstErrorSection();
+      }
+      if (unmapped.length > 0 || firstFieldName === null) {
+        setServerError({
+          title: t('cases.create.errorBanner.title'),
+          message: unmapped.length > 0 ? unmapped.join(' · ') : t('cases.create.errorBanner.body'),
+        });
+      }
+      return;
+    }
+    if (err instanceof ApiError) {
+      setServerError({
+        title: t('cases.create.errorBanner.title'),
+        message: t('cases.create.errorBanner.body'),
+      });
+    } else {
+      setServerError({
+        title: t('cases.create.errorBanner.title'),
+        message: t('cases.create.errorBanner.networkBody'),
+      });
+    }
+  }
+
+  // Collect all errors across all sections for FormErrorsBanner (AC2)
+  function collectAllErrors(): FormErrorEntry[] {
+    const errs = form.formState.errors;
+    const out: FormErrorEntry[] = [];
+    for (const f of allFields) {
+      if (errs[f.id]) {
+        out.push({ field: f.id, displayName: f.displayName, order: f.order });
+      }
+    }
+    return out;
+  }
+
+  const failedReason = serverError?.message ?? null;
+  const failedLabel = failedReason
+    ? t('common.lifecycle.failed', { reason: failedReason })
+    : t('common.lifecycle.failedNoReason');
+
+  const retryAction = (
+    <Button
+      type="button"
+      variant="ghost"
+      onClick={() => {
+        setServerError(null);
+        setIsError(false);
+        void form.handleSubmit(onSubmit)();
+      }}
+    >
+      {t('common.retry')}
+    </Button>
+  );
+
+  return (
+    <div>
+      <FormProvider {...form}>
+        <form
+          noValidate
+          onSubmit={form.handleSubmit(onSubmit, () => {
+            // RHF calls this on validation failure; open first error section
+            openFirstErrorSection();
+          })}
+          aria-busy={isPending ? true : undefined}
+          className="flex flex-col gap-[var(--form-field-gap,1rem)]"
+        >
+          {/* AC2 — FormErrorsBanner with all field errors (same as SinglePageFormRenderer) */}
+          {form.formState.isSubmitted ? (
+            <FormErrorsBanner
+              errors={collectAllErrors()}
+              onAnchorClick={(field) => {
+                // Find the section containing this field, expand it, then focus
+                const ownerSection = sections.find((s) => s.fields.some((f) => f.id === field));
+                if (ownerSection) {
+                  setExpanded((prev) => ({ ...prev, [ownerSection.id]: true }));
+                  setTimeout(() => form.setFocus(field), 50);
+                } else {
+                  form.setFocus(field);
+                }
+              }}
+            />
+          ) : null}
+
+          {/* AC4 — Progress indicator */}
+          {sections.length > 0 ? (
+            <p className="text-sm text-[var(--muted-foreground)]">
+              {t('form.sections.progress', {
+                complete: String(completeCount),
+                total: String(sections.length),
+              })}
+            </p>
+          ) : null}
+
+          {/* AC1 — Section panels */}
+          {sections.map((section) => {
+            const status = getSectionStatus(section);
+            const isOpen = expanded[section.id] ?? true;
+            const sortedFields = [...section.fields].sort((a, b) => a.order - b.order);
+            return (
+              <div
+                key={section.id}
+                id={`section-${section.id}`}
+                className="rounded-md border border-[var(--border)]"
+              >
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between p-4 font-medium"
+                  aria-expanded={isOpen}
+                  onClick={() =>
+                    setExpanded((prev) => ({ ...prev, [section.id]: !prev[section.id] }))
+                  }
+                >
+                  <span>{section.label}</span>
+                  <span className="flex items-center gap-2">
+                    {statusIcon(status)}
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                    />
+                  </span>
+                </button>
+                {isOpen ? (
+                  <div className="flex flex-col gap-[var(--form-field-gap,1rem)] p-4 pt-0">
+                    {sortedFields.length === 0 ? (
+                      <p className="text-sm text-[var(--muted-foreground)]">
+                        {t('cases.create.noRequired', { caseTypeName: section.id })}
+                      </p>
+                    ) : (
+                      sortedFields.map((f) => renderField(f, isPending, form))
+                    )}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+
+          {serverError ? (
+            <Alert role="alert" variant="destructive" className="py-[var(--space-2)] text-sm">
+              <strong className="block">{serverError.title}</strong>
+              <span>{serverError.message}</span>
+            </Alert>
+          ) : null}
+
+          <div className="flex justify-end">
+            <MutationButton
+              state={state}
+              confirmingLabel={t('common.lifecycle.confirming')}
+              confirmedLabel={t('common.lifecycle.confirmed')}
+              failedLabel={failedLabel}
+              retryAction={retryAction}
+            >
+              {t('form.submit')}
+            </MutationButton>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+}
+
+/** AC1 — Section status icon */
+function statusIcon(status: SectionStatus) {
+  if (status === 'complete')
+    return (
+      <span aria-label="complete" className="text-green-600">
+        {t('form.sections.status.complete')}
+      </span>
+    );
+  if (status === 'error')
+    return (
+      <span aria-label="error" className="text-[var(--destructive)]">
+        {t('form.sections.status.error')}
+      </span>
+    );
+  return (
+    <span aria-label="incomplete" className="text-[var(--muted-foreground)]">
+      {t('form.sections.status.incomplete')}
+    </span>
+  );
+}
+
+function renderField(
+  f: FieldDefinition,
+  disabled: boolean,
+  form: UseFormReturn<Record<string, unknown>>,
+) {
+  if (f.type === 'file') {
+    return (
+      <p key={f.id} className="text-sm text-[var(--muted-foreground)]">
+        {t('cases.create.fileNotYet')}
+      </p>
+    );
+  }
+  return (
+    <FormField
+      key={f.id}
+      name={f.id}
+      label={f.displayName}
+      required={f.required}
+      disabled={disabled}
+    >
+      {(field) => renderInput(f, field, form)}
+    </FormField>
+  );
+}
+
+function renderInput(
+  f: FieldDefinition,
+  field: FormFieldRenderProps<Record<string, unknown>, string>,
+  form: UseFormReturn<Record<string, unknown>>,
+) {
+  switch (f.type) {
+    case 'text':
+      return (
+        <Input
+          type="text"
+          maxLength={f.maxLength ?? undefined}
+          {...field}
+          value={String(field.value ?? '')}
+        />
+      );
+    case 'textarea':
+      return (
+        <Textarea
+          maxLength={f.maxLength ?? undefined}
+          {...field}
+          value={String(field.value ?? '')}
+        />
+      );
+    case 'number':
+      return (
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={f.min ?? undefined}
+          max={f.max ?? undefined}
+          step={f.step ?? 1}
+          {...field}
+          value={field.value === undefined || field.value === null ? '' : String(field.value)}
+        />
+      );
+    case 'date':
+      return (
+        <Input
+          type="date"
+          min={f.dateMin ?? undefined}
+          max={f.dateMax ?? undefined}
+          {...field}
+          value={String(field.value ?? '')}
+        />
+      );
+    case 'select': {
+      const stringValue =
+        typeof field.value === 'string' && field.value !== '' ? field.value : undefined;
+      return (
+        <Select
+          value={stringValue}
+          onValueChange={(v) => {
+            field.onChange(v);
+            void form.trigger(f.id);
+          }}
+          disabled={field.disabled}
+        >
+          <SelectTrigger
+            id={field.id}
+            aria-invalid={field['aria-invalid']}
+            aria-describedby={field['aria-describedby']}
+            ref={field.ref as unknown as React.Ref<HTMLButtonElement>}
+          >
+            <SelectValue placeholder={t('cases.create.selectPlaceholder')} />
+          </SelectTrigger>
+          <SelectContent>
+            {f.options.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }
+    case 'checkbox':
+      return (
+        <Checkbox
+          id={field.id}
+          checked={Boolean(field.value)}
+          onCheckedChange={(v) => {
+            field.onChange(Boolean(v));
+            void form.trigger(f.id);
+          }}
+          disabled={field.disabled}
+          aria-invalid={field['aria-invalid']}
+          aria-describedby={field['aria-describedby']}
+          ref={field.ref as unknown as React.Ref<HTMLButtonElement>}
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/frontend/src/components/forms/SinglePageFormRenderer.test.tsx
+++ b/frontend/src/components/forms/SinglePageFormRenderer.test.tsx
@@ -10,7 +10,7 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 // ResizeObserver is not implemented in jsdom but is referenced by Radix UI's Select + Tooltip
 // internals. Stub it so tests can render components that include Select (e.g. select-typed fields).
@@ -172,13 +172,14 @@ describe('SinglePageFormRenderer — AC2: empty submit shows FormErrorsBanner', 
 });
 
 // ---------------------------------------------------------------------------
-// AC3 — Successful submit calls onSuccess
+// AC3 — Successful submit calls onSuccess (after CF1 delay)
 // ---------------------------------------------------------------------------
 
 describe('SinglePageFormRenderer — AC3: successful submit', () => {
-  it('calls onSuccess after a valid submission', async () => {
+  it('calls onSuccess after a valid submission (after 1200ms CF1 delay)', async () => {
     const user = userEvent.setup();
     let successCalled = false;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
 
     server.use(
       http.post('/api/cases/:caseId/forms/:formId/submit', () =>
@@ -233,6 +234,14 @@ describe('SinglePageFormRenderer — AC3: successful submit', () => {
 
     // MutationButton transitions to 'confirmed' state — check the button role
     await screen.findByRole('button', { name: /confirmed/i });
+
+    // CF1: onSuccess is NOT called immediately — user sees confirmed state first
+    expect(successCalled).toBe(false);
+
+    // Advance fake timers past the 1200ms delay
+    vi.advanceTimersByTime(1300);
     expect(successCalled).toBe(true);
+
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/components/forms/SinglePageFormRenderer.tsx
+++ b/frontend/src/components/forms/SinglePageFormRenderer.tsx
@@ -116,7 +116,8 @@ export function SinglePageFormRenderer({
     try {
       await submitForm(caseId, formDefinition.id, values);
       setIsSuccess(true);
-      onSuccess?.();
+      // CF1 fix — delay onSuccess by 1200ms so user sees the MutationButton "confirmed" state
+      if (onSuccess) setTimeout(onSuccess, 1200);
     } catch (err) {
       handleSubmitError(err);
     } finally {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -202,5 +202,10 @@
   "form.loading": "Loading form…",
   "form.error.caseLoad": "Could not load case.",
   "form.error.notFound": "Form not found on this case type.",
+  "form.error.backToCase": "Back to case",
+  "form.sections.progress": "{complete} of {total} sections complete",
+  "form.sections.status.complete": "✓",
+  "form.sections.status.error": "✗",
+  "form.sections.status.incomplete": "⚠",
   "form.submit": "Submit"
 }

--- a/frontend/src/pages/FormPage.tsx
+++ b/frontend/src/pages/FormPage.tsx
@@ -1,6 +1,8 @@
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { MultiSectionFormRenderer } from '@/components/forms/MultiSectionFormRenderer';
 import { SinglePageFormRenderer } from '@/components/forms/SinglePageFormRenderer';
+import { Button } from '@/components/ui/Button';
 import { useCase } from '@/hooks/useCases';
 import { t } from '@/i18n';
 
@@ -39,23 +41,40 @@ export function FormPage() {
   const caseDto = caseQuery.data;
   const formDef = (caseDto.caseType.forms ?? []).find((f) => f.id === formId);
 
+  // CF2 fix — invalid formId shows an error state with navigation link, not floating text
   if (!formDef) {
     return (
-      <div className="flex items-center justify-center p-8 text-sm text-[var(--destructive)]">
-        {t('form.error.notFound')}
+      <div className="mx-auto max-w-2xl p-6">
+        <p className="mb-4 text-sm text-[var(--destructive)]">{t('form.error.notFound')}</p>
+        <Button variant="ghost" onClick={() => navigate(`/cases/${caseId}`)}>
+          {t('form.error.backToCase')}
+        </Button>
       </div>
     );
   }
 
-  return (
-    <div className="mx-auto max-w-2xl p-6">
-      <h1 className="mb-6 text-xl font-semibold">{formDef.id}</h1>
+  // Renderer dispatch — route to MultiSectionFormRenderer for multi-section rendering
+  const renderer =
+    formDef.rendering === 'multi-section' ? (
+      <MultiSectionFormRenderer
+        formDefinition={formDef}
+        caseId={caseId!}
+        defaultValues={caseDto.data}
+        onSuccess={() => navigate(`/cases/${caseId}`)}
+      />
+    ) : (
       <SinglePageFormRenderer
         formDefinition={formDef}
         caseId={caseId!}
         defaultValues={caseDto.data}
         onSuccess={() => navigate(`/cases/${caseId}`)}
       />
+    );
+
+  return (
+    <div className="mx-auto max-w-2xl p-6">
+      <h1 className="mb-6 text-xl font-semibold">{formDef.id}</h1>
+      {renderer}
     </div>
   );
 }

--- a/frontend/src/types/caseType.ts
+++ b/frontend/src/types/caseType.ts
@@ -75,10 +75,22 @@ export interface StageDefinitionView {
 }
 
 /**
+ * Story 5.3 — one section in a {@code dataModel: sectioned} form definition. Groups a set of
+ * fields under a labelled expandable panel rendered by {@code MultiSectionFormRenderer}.
+ */
+export interface FormSectionView {
+  id: string;
+  label: string;
+  fields: FieldDefinition[];
+}
+
+/**
  * Story 5.2 — wire-shape projection of one form definition from the case-type YAML {@code forms[]}
  * block. Carries the three-axis vocabulary and the form's field list so the frontend renderer has
  * everything it needs from the {@code GET /api/case-types/{id}} response without a second
  * round-trip.
+ *
+ * Story 5.3 — adds {@code sections?} for {@code dataModel: sectioned} forms.
  */
 export interface FormDefinitionView {
   id: string;
@@ -86,6 +98,8 @@ export interface FormDefinitionView {
   dataModel: string;
   rendering: string;
   fields: FieldDefinition[];
+  /** Story 5.3 — sections declared for {@code dataModel: sectioned} forms. */
+  sections?: FormSectionView[];
 }
 
 export interface CaseTypeView {


### PR DESCRIPTION
## Summary
- Adds `sections[]` YAML/domain/DTO support for `dataModel: sectioned` form definitions
- New `MultiSectionFormRenderer` component with expand/collapse sections, per-section error state, and progress indicator
- `FormPage` dispatcher routes `rendering: multi-section` to the new renderer
- Fixes CF1 (SinglePageFormRenderer success timing) and CF2 (FormPage error state on missing formDef)
- No Flyway migration; no new wire codes

## Test plan
- [ ] Backend: `mvn verify -B` green
- [ ] Backend: `mvn verify -P tenant-invariant-lint` green
- [ ] Frontend: lint + format + test + build green
- [ ] Manual: form with `dataModel: sectioned` + `rendering: multi-section` renders with collapsible sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)