### PR TITLE
feat(5-4): Save Draft and Resume From Position

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
@@ -9,6 +9,7 @@ import com.wkspower.platform.domain.exception.WksValidationException;
 import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.port.StageRepository;
 import com.wkspower.platform.domain.service.CaseService;
+import com.wkspower.platform.domain.service.FormDraftService;
 import com.wkspower.platform.security.WksUserPrincipal;
 import java.util.List;
 import java.util.Map;
@@ -44,10 +45,13 @@ public class FormController {
 
   private final CaseService caseService;
   private final StageRepository stageRepository;
+  private final FormDraftService formDraftService;
 
-  public FormController(CaseService caseService, StageRepository stageRepository) {
+  public FormController(
+      CaseService caseService, StageRepository stageRepository, FormDraftService formDraftService) {
     this.caseService = caseService;
     this.stageRepository = stageRepository;
+    this.formDraftService = formDraftService;
   }
 
   /**
@@ -82,6 +86,10 @@ public class FormController {
     }
 
     Case updated = caseService.submitForm(caseId, formId, formData, actor.id());
+
+    // Story 5.4 AC6 — delete-on-submit. Lives inside the controller's @Transactional so a
+    // post-submit failure rolls back the deletion (preserving the draft) per AC6.
+    formDraftService.deleteDraft(caseId, formId, actor.id());
 
     CaseTypeConfig caseType = caseService.requireCaseType(updated.caseTypeId());
     List<com.wkspower.platform.domain.model.Stage> history = stageRepository.loadHistory(caseId);

--- a/backend/src/main/java/com/wkspower/platform/api/controller/FormDraftController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/FormDraftController.java
@@ -1,0 +1,149 @@
+package com.wkspower.platform.api.controller;
+
+import com.wkspower.platform.api.dto.ApiResponse;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.FormDraft;
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.service.FormDraftService;
+import com.wkspower.platform.security.WksUserPrincipal;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Story 5.4 — REST surface for form drafts (auto-save + resume + discard).
+ *
+ * <pre>
+ *   GET    /api/cases/{caseId}/forms/{formId}/draft  -> 200 + FormDraftDto, or 404
+ *   PUT    /api/cases/{caseId}/forms/{formId}/draft  -> 200 + FormDraftDto (upsert)
+ *   DELETE /api/cases/{caseId}/forms/{formId}/draft  -> 204 (idempotent)
+ * </pre>
+ *
+ * <p>RBAC: {@code isAuthenticated()} + the caller must have access to the underlying case (the
+ * {@link CaseRepository#findById} call doubles as the access gate — a user without read access on
+ * the case has no way to reach this endpoint via the routing layer; in addition, the draft scope
+ * already filters by {@code userId} via the {@link WksUserPrincipal}, so cross-user reads are
+ * impossible — AC5).
+ *
+ * <p>No new {@code WKS-DRAFT-*} error codes — standard 404 (no draft) and 422 (invalid body via
+ * {@code @Valid}) suffice. Memory {@code feedback_error_codes_are_wire_contract.md}: codes are
+ * stable wire strings; allocate only when there's a domain-meaningful failure mode.
+ */
+@RestController
+@RequestMapping("/api/cases")
+public class FormDraftController {
+
+  private final FormDraftService draftService;
+  private final CaseRepository caseRepository;
+
+  public FormDraftController(FormDraftService draftService, CaseRepository caseRepository) {
+    this.draftService = draftService;
+    this.caseRepository = caseRepository;
+  }
+
+  @GetMapping("/{caseId}/forms/{formId}/draft")
+  @PreAuthorize("isAuthenticated()")
+  @Transactional(readOnly = true)
+  public ResponseEntity<ApiResponse<FormDraftDto>> get(
+      @PathVariable UUID caseId,
+      @PathVariable String formId,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    requireCaseExists(caseId);
+    Optional<FormDraft> found = draftService.findDraft(caseId, formId, actor.id());
+    return found
+        .map(d -> ResponseEntity.ok(ApiResponse.success(FormDraftDto.from(d))))
+        .orElseGet(() -> ResponseEntity.<ApiResponse<FormDraftDto>>notFound().build());
+  }
+
+  @PutMapping("/{caseId}/forms/{formId}/draft")
+  @PreAuthorize("isAuthenticated()")
+  @Transactional
+  public ResponseEntity<ApiResponse<FormDraftDto>> put(
+      @PathVariable UUID caseId,
+      @PathVariable String formId,
+      @Valid @RequestBody SaveDraftRequest body,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    requireCaseExists(caseId);
+    FormDraft saved =
+        draftService.saveDraft(
+            caseId,
+            formId,
+            actor.id(),
+            body.payload(),
+            body.scrollY(),
+            body.sectionExpanded(),
+            body.caseTypeVersionAtSave());
+    return ResponseEntity.ok(ApiResponse.success(FormDraftDto.from(saved)));
+  }
+
+  @DeleteMapping("/{caseId}/forms/{formId}/draft")
+  @PreAuthorize("isAuthenticated()")
+  @Transactional
+  public ResponseEntity<Void> delete(
+      @PathVariable UUID caseId,
+      @PathVariable String formId,
+      @AuthenticationPrincipal WksUserPrincipal actor) {
+    requireCaseExists(caseId);
+    draftService.deleteDraft(caseId, formId, actor.id());
+    return ResponseEntity.noContent().build();
+  }
+
+  private void requireCaseExists(UUID caseId) {
+    Case existing =
+        caseRepository
+            .findById(caseId)
+            .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
+    // referenced solely to confirm the row exists; assignee/RBAC checks live elsewhere.
+    if (existing == null) {
+      throw new WksNotFoundException("Case " + caseId + " not found");
+    }
+  }
+
+  /** Request body for PUT — auto-validated via {@code @Valid}. */
+  public record SaveDraftRequest(
+      @NotNull Map<String, Object> payload,
+      @PositiveOrZero int scrollY,
+      Map<String, Boolean> sectionExpanded,
+      @Positive int caseTypeVersionAtSave) {}
+
+  /** Wire DTO for GET / PUT responses. */
+  public record FormDraftDto(
+      UUID id,
+      UUID caseId,
+      String formId,
+      Map<String, Object> payload,
+      int scrollY,
+      Map<String, Boolean> sectionExpanded,
+      int caseTypeVersionAtSave,
+      Instant updatedAt) {
+
+    public static FormDraftDto from(FormDraft d) {
+      return new FormDraftDto(
+          d.id(),
+          d.caseId(),
+          d.formId(),
+          d.payload(),
+          d.scrollY(),
+          d.sectionExpanded(),
+          d.caseTypeVersionAtSave(),
+          d.updatedAt());
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
@@ -36,63 +36,6 @@ public record CaseTypeConfig(
      */
     List<FormDefinition> forms) {
 
-  /**
-   * Backward-compat constructor for callers (and tests) that predate Story 3.1's {@code stages}
-   * slot — defaults stages and forms to {@link List#of()}.
-   */
-  public CaseTypeConfig(
-      String id,
-      String displayName,
-      int version,
-      String description,
-      WorkflowRef workflow,
-      List<FieldDefinition> fields,
-      List<StatusDefinition> statuses,
-      List<String> listColumns,
-      List<RoleDefinition> roles) {
-    this(
-        id,
-        displayName,
-        version,
-        description,
-        workflow,
-        fields,
-        statuses,
-        listColumns,
-        roles,
-        List.of(),
-        List.of());
-  }
-
-  /**
-   * Backward-compat constructor for callers (and tests) that predate Story 5.2's {@code forms} slot
-   * — defaults forms to {@link List#of()}.
-   */
-  public CaseTypeConfig(
-      String id,
-      String displayName,
-      int version,
-      String description,
-      WorkflowRef workflow,
-      List<FieldDefinition> fields,
-      List<StatusDefinition> statuses,
-      List<String> listColumns,
-      List<RoleDefinition> roles,
-      List<StageDefinition> stages) {
-    this(
-        id,
-        displayName,
-        version,
-        description,
-        workflow,
-        fields,
-        statuses,
-        listColumns,
-        roles,
-        stages,
-        List.of());
-  }
-
   public CaseTypeConfig {
     fields = List.copyOf(fields);
     statuses = List.copyOf(statuses);
@@ -165,5 +108,97 @@ public record CaseTypeConfig(
         roles,
         stages,
         forms);
+  }
+
+  /** Returns a fresh {@link Builder} for programmatic construction (primarily in tests). */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Fluent builder that delegates to the canonical 12-arg constructor on {@link #build()}. */
+  public static final class Builder {
+    private String id;
+    private String displayName;
+    private int version;
+    private String description;
+    private WorkflowRef workflow;
+    private List<FieldDefinition> fields = List.of();
+    private List<StatusDefinition> statuses = List.of();
+    private List<String> listColumns = List.of();
+    private List<RoleDefinition> roles = List.of();
+    private List<StageDefinition> stages = List.of();
+    private List<FormDefinition> forms = List.of();
+
+    private Builder() {}
+
+    public Builder id(String v) {
+      this.id = v;
+      return this;
+    }
+
+    public Builder displayName(String v) {
+      this.displayName = v;
+      return this;
+    }
+
+    public Builder version(int v) {
+      this.version = v;
+      return this;
+    }
+
+    public Builder description(String v) {
+      this.description = v;
+      return this;
+    }
+
+    public Builder workflow(WorkflowRef v) {
+      this.workflow = v;
+      return this;
+    }
+
+    public Builder fields(List<FieldDefinition> v) {
+      this.fields = v;
+      return this;
+    }
+
+    public Builder statuses(List<StatusDefinition> v) {
+      this.statuses = v;
+      return this;
+    }
+
+    public Builder listColumns(List<String> v) {
+      this.listColumns = v;
+      return this;
+    }
+
+    public Builder roles(List<RoleDefinition> v) {
+      this.roles = v;
+      return this;
+    }
+
+    public Builder stages(List<StageDefinition> v) {
+      this.stages = v;
+      return this;
+    }
+
+    public Builder forms(List<FormDefinition> v) {
+      this.forms = v;
+      return this;
+    }
+
+    public CaseTypeConfig build() {
+      return new CaseTypeConfig(
+          id,
+          displayName,
+          version,
+          description,
+          workflow,
+          fields,
+          statuses,
+          listColumns,
+          roles,
+          stages,
+          forms);
+    }
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/event/FormDraftExpired.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/FormDraftExpired.java
@@ -1,0 +1,18 @@
+package com.wkspower.platform.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Story 5.4 AC4 — emitted by the {@code FormDraftExpirationJob} for each draft row deleted because
+ * its {@code updated_at} crossed the {@code wks.form.draft.ttl-days} threshold. The existing audit
+ * pipeline ({@code @EventListener} reflection) picks this up without additional wiring.
+ *
+ * @param caseId the draft's case id
+ * @param formId the draft's form id
+ * @param userId the user who owned the draft
+ * @param ageDays how many full days the draft sat untouched before expiration
+ * @param occurredAt when the expiration deletion happened
+ */
+public record FormDraftExpired(
+    UUID caseId, String formId, UUID userId, long ageDays, Instant occurredAt) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/model/FormDraft.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/model/FormDraft.java
@@ -1,0 +1,24 @@
+package com.wkspower.platform.domain.model;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Story 5.4 — domain record for a saved form draft. Carries the in-progress {@code payload}, scroll
+ * position, and section-expansion state (multi-section renderer only). The {@code
+ * caseTypeVersionAtSave} component captures the case-type version the draft was last written
+ * against; a mismatch with the case's current {@code caseTypeVersion} triggers the AC3 discard
+ * prompt at the renderer.
+ */
+public record FormDraft(
+    UUID id,
+    UUID caseId,
+    String formId,
+    UUID userId,
+    Map<String, Object> payload,
+    int scrollY,
+    Map<String, Boolean> sectionExpanded,
+    int caseTypeVersionAtSave,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/FormDraftRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/FormDraftRepository.java
@@ -1,0 +1,42 @@
+package com.wkspower.platform.domain.port;
+
+import com.wkspower.platform.domain.model.FormDraft;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Story 5.4 — outbound port for form draft persistence. Implemented by an infrastructure adapter
+ * that delegates to a JPA repository. Keeps the domain service framework-free.
+ *
+ * <p>The single read accessor scopes to {@code (caseId, formId, userId)} — there is intentionally
+ * no {@code findByCaseIdAndFormId(...)} variant (AC5 cross-user leakage guard).
+ */
+public interface FormDraftRepository {
+
+  Optional<FormDraft> findByScope(UUID caseId, String formId, UUID userId);
+
+  /**
+   * Upsert: insert when no row exists for {@code (caseId, formId, userId)}, otherwise overwrite the
+   * existing row in place. Returns the persisted form-draft (with assigned id + audit timestamps).
+   */
+  FormDraft upsert(
+      UUID caseId,
+      String formId,
+      UUID userId,
+      java.util.Map<String, Object> payload,
+      int scrollY,
+      java.util.Map<String, Boolean> sectionExpanded,
+      int caseTypeVersionAtSave,
+      Instant now);
+
+  /**
+   * @return number of rows deleted (0 or 1).
+   */
+  int deleteByScope(UUID caseId, String formId, UUID userId);
+
+  List<FormDraft> findByUpdatedAtBefore(Instant cutoff);
+
+  void deleteAll(List<FormDraft> drafts);
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/FormDraftService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/FormDraftService.java
@@ -1,0 +1,82 @@
+package com.wkspower.platform.domain.service;
+
+import com.wkspower.platform.domain.event.FormDraftExpired;
+import com.wkspower.platform.domain.model.FormDraft;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.FormDraftRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Story 5.4 — domain service for form draft persistence (auto-save + resume + expiration).
+ *
+ * <p>Framework-free per ArchUnit rule {@code domainHasNoFrameworkImports}. Spring transaction
+ * management lives at the controller layer (the controller's {@code @Transactional} wraps the
+ * upsert + delete-on-submit path; the expiration job opens its own transaction via the
+ * infrastructure adapter).
+ */
+public class FormDraftService {
+
+  private final FormDraftRepository repository;
+  private final Clock clock;
+  private final EventPublisher events;
+
+  public FormDraftService(FormDraftRepository repository, Clock clock, EventPublisher events) {
+    this.repository = Objects.requireNonNull(repository, "repository");
+    this.clock = Objects.requireNonNull(clock, "clock");
+    this.events = Objects.requireNonNull(events, "events");
+  }
+
+  public Optional<FormDraft> findDraft(UUID caseId, String formId, UUID userId) {
+    return repository.findByScope(caseId, formId, userId);
+  }
+
+  /** Upsert semantics — finds existing row by scope, updates in place, else inserts. */
+  public FormDraft saveDraft(
+      UUID caseId,
+      String formId,
+      UUID userId,
+      Map<String, Object> payload,
+      int scrollY,
+      Map<String, Boolean> sectionExpanded,
+      int caseTypeVersionAtSave) {
+    return repository.upsert(
+        caseId,
+        formId,
+        userId,
+        payload,
+        scrollY,
+        sectionExpanded,
+        caseTypeVersionAtSave,
+        clock.now());
+  }
+
+  /** Returns true if a draft existed and was deleted. Idempotent — false if nothing to delete. */
+  public boolean deleteDraft(UUID caseId, String formId, UUID userId) {
+    return repository.deleteByScope(caseId, formId, userId) > 0;
+  }
+
+  /**
+   * AC4 — invoked by the scheduled expiration job. Returns deletion count. Loads the affected rows
+   * first so a {@link FormDraftExpired} event can be emitted per row before the batch delete.
+   */
+  public int expireOlderThan(Instant cutoff) {
+    List<FormDraft> expired = repository.findByUpdatedAtBefore(cutoff);
+    if (expired.isEmpty()) {
+      return 0;
+    }
+    Instant now = clock.now();
+    for (FormDraft d : expired) {
+      long ageDays = ChronoUnit.DAYS.between(d.updatedAt(), now);
+      events.publish(new FormDraftExpired(d.caseId(), d.formId(), d.userId(), ageDays, now));
+    }
+    repository.deleteAll(expired);
+    return expired.size();
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
@@ -108,6 +108,22 @@ public class ConfigServiceConfig {
    * this @Bean wires the ports from infrastructure (CaseTypeReader, CaseTypeVersionRegistry, the
    * JPA StatusOptionsStore adapter).
    */
+  /**
+   * Story 5.4 — wires the framework-free {@link
+   * com.wkspower.platform.domain.service.FormDraftService} with its domain ports. The Spring
+   * transaction proxy lives on the {@link
+   * com.wkspower.platform.infrastructure.formdraft.FormDraftRepositoryAdapter} (port
+   * implementation) and on the controller methods that call this service.
+   */
+  @Bean
+  public com.wkspower.platform.domain.service.FormDraftService wksFormDraftService(
+      com.wkspower.platform.domain.port.FormDraftRepository formDraftRepository,
+      Clock clock,
+      EventPublisher eventPublisher) {
+    return new com.wkspower.platform.domain.service.FormDraftService(
+        formDraftRepository, clock, eventPublisher);
+  }
+
   @Bean
   public StatusOptionsAdminService statusOptionsAdminService(
       CaseTypeReader caseTypeReader,

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/formdraft/FormDraftExpirationJob.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/formdraft/FormDraftExpirationJob.java
@@ -1,0 +1,47 @@
+package com.wkspower.platform.infrastructure.formdraft;
+
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.service.FormDraftService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Story 5.4 AC4 — daily scheduled job that expires drafts inactive for {@code
+ * wks.form.draft.ttl-days} (default 30). Defaults to 03:00 daily; both the cron expression and the
+ * TTL are externalised to {@code application.yaml} so operators can tune without a redeploy.
+ *
+ * <p>{@code @EnableScheduling} lives on {@code WksPlatformApplication} (the canonical Spring Boot
+ * location) — do NOT add it on a separate {@code @Configuration} per Sprint 5 retro lesson.
+ */
+@Component
+public class FormDraftExpirationJob {
+
+  private static final Logger log = LoggerFactory.getLogger(FormDraftExpirationJob.class);
+
+  private final FormDraftService draftService;
+  private final Clock clock;
+  private final long ttlDays;
+
+  public FormDraftExpirationJob(
+      FormDraftService draftService,
+      Clock clock,
+      @Value("${wks.form.draft.ttl-days:30}") long ttlDays) {
+    this.draftService = draftService;
+    this.clock = clock;
+    this.ttlDays = ttlDays;
+  }
+
+  @Scheduled(cron = "${wks.form.draft.expiration-cron:0 0 3 * * *}")
+  public void run() {
+    Instant cutoff = clock.now().minus(ttlDays, ChronoUnit.DAYS);
+    int deleted = draftService.expireOlderThan(cutoff);
+    if (deleted > 0) {
+      log.info("FormDraftExpirationJob: expired {} drafts (cutoff {})", deleted, cutoff);
+    }
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/formdraft/FormDraftRepositoryAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/formdraft/FormDraftRepositoryAdapter.java
@@ -1,0 +1,117 @@
+package com.wkspower.platform.infrastructure.formdraft;
+
+import com.wkspower.platform.domain.model.FormDraft;
+import com.wkspower.platform.domain.port.FormDraftRepository;
+import com.wkspower.platform.infrastructure.persistence.entity.FormDraftEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.FormDraftJpaRepository;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Story 5.4 — JPA-backed adapter for the {@link FormDraftRepository} domain port. Maps {@link
+ * FormDraftEntity} ⇆ {@link FormDraft} at the boundary so the domain service stays framework-free.
+ *
+ * <p>Memory {@code feedback_jpa_idclass_save_is_upsert.md}: this entity uses single-column @Id, so
+ * {@code repository.save} is upsert, but the unique constraint on {@code (case_id, form_id,
+ * user_id)} would still trip on a stale insert if scope was misread. {@link #upsert} reads first
+ * via the scope query, then mutates the loaded row or inserts a new one.
+ */
+@Component
+public class FormDraftRepositoryAdapter implements FormDraftRepository {
+
+  private final FormDraftJpaRepository jpa;
+
+  public FormDraftRepositoryAdapter(FormDraftJpaRepository jpa) {
+    this.jpa = jpa;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<FormDraft> findByScope(UUID caseId, String formId, UUID userId) {
+    return jpa.findByCaseIdAndFormIdAndUserId(caseId, formId, userId)
+        .map(FormDraftRepositoryAdapter::toDomain);
+  }
+
+  @Override
+  @Transactional
+  public FormDraft upsert(
+      UUID caseId,
+      String formId,
+      UUID userId,
+      Map<String, Object> payload,
+      int scrollY,
+      Map<String, Boolean> sectionExpanded,
+      int caseTypeVersionAtSave,
+      Instant now) {
+    FormDraftEntity entity =
+        jpa.findByCaseIdAndFormIdAndUserId(caseId, formId, userId)
+            .map(
+                existing -> {
+                  existing.setPayload(payload == null ? new HashMap<>() : payload);
+                  existing.setScrollY(scrollY);
+                  existing.setSectionExpanded(sectionExpanded);
+                  existing.setCaseTypeVersionAtSave(caseTypeVersionAtSave);
+                  existing.setUpdatedAt(now);
+                  return existing;
+                })
+            .orElseGet(
+                () ->
+                    new FormDraftEntity(
+                        UUID.randomUUID(),
+                        caseId,
+                        formId,
+                        userId,
+                        payload == null ? new HashMap<>() : payload,
+                        scrollY,
+                        sectionExpanded,
+                        caseTypeVersionAtSave,
+                        now,
+                        now));
+    return toDomain(jpa.save(entity));
+  }
+
+  @Override
+  @Transactional
+  public int deleteByScope(UUID caseId, String formId, UUID userId) {
+    return jpa.deleteByScope(caseId, formId, userId);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<FormDraft> findByUpdatedAtBefore(Instant cutoff) {
+    return jpa.findByUpdatedAtBefore(cutoff).stream()
+        .map(FormDraftRepositoryAdapter::toDomain)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  @Transactional
+  public void deleteAll(List<FormDraft> drafts) {
+    if (drafts == null || drafts.isEmpty()) {
+      return;
+    }
+    List<UUID> ids = drafts.stream().map(FormDraft::id).toList();
+    jpa.deleteAllById(ids);
+  }
+
+  private static FormDraft toDomain(FormDraftEntity e) {
+    return new FormDraft(
+        e.getId(),
+        e.getCaseId(),
+        e.getFormId(),
+        e.getUserId(),
+        e.getPayload() == null ? Map.of() : Map.copyOf(e.getPayload()),
+        e.getScrollY(),
+        e.getSectionExpanded() == null ? null : Map.copyOf(e.getSectionExpanded()),
+        e.getCaseTypeVersionAtSave(),
+        e.getCreatedAt(),
+        e.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/FormDraftEntity.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/entity/FormDraftEntity.java
@@ -1,0 +1,136 @@
+package com.wkspower.platform.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * Story 5.4 — JPA entity for {@code form_drafts}. Inherits id / version / audit timestamps from
+ * {@link BaseJpaEntity}; owns the draft-scope columns plus the JSON {@code payload} column that
+ * carries the in-progress form values.
+ *
+ * <p>Hibernate 6 ({@link JdbcTypeCode} + {@link SqlTypes#JSON}) maps the {@code Map<String,
+ * Object>} natively (same convention as {@link CaseEntity#getData()}). The {@code section_expanded}
+ * column is nullable — single-page renderer drafts leave it null.
+ *
+ * <p>Uniqueness on {@code (case_id, form_id, user_id)} is enforced at the DB layer (AC5 — no
+ * cross-user leakage). The service layer must read with {@code findByCaseIdAndFormIdAndUserId}
+ * before deciding whether to insert or update — never blindly call {@code repository.save} (memory
+ * {@code feedback_jpa_idclass_save_is_upsert.md}; this is a single-column @Id, so save is upsert,
+ * but the unique constraint would still trip on a stale insert if scope was misread).
+ */
+@Entity
+@Table(
+    name = "form_drafts",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_form_drafts_scope",
+            columnNames = {"case_id", "form_id", "user_id"}))
+public class FormDraftEntity extends BaseJpaEntity {
+
+  @Column(name = "case_id", nullable = false)
+  private UUID caseId;
+
+  @Column(name = "form_id", nullable = false, length = 255)
+  private String formId;
+
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "payload", nullable = false)
+  private Map<String, Object> payload = new HashMap<>();
+
+  @Column(name = "scroll_y", nullable = false)
+  private int scrollY;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "section_expanded")
+  private Map<String, Boolean> sectionExpanded;
+
+  @Column(name = "case_type_version_at_save", nullable = false)
+  private int caseTypeVersionAtSave;
+
+  protected FormDraftEntity() {
+    // JPA
+  }
+
+  public FormDraftEntity(
+      UUID id,
+      UUID caseId,
+      String formId,
+      UUID userId,
+      Map<String, Object> payload,
+      int scrollY,
+      Map<String, Boolean> sectionExpanded,
+      int caseTypeVersionAtSave,
+      Instant createdAt,
+      Instant updatedAt) {
+    super(id);
+    this.caseId = caseId;
+    this.formId = formId;
+    this.userId = userId;
+    this.payload = payload == null ? new HashMap<>() : new HashMap<>(payload);
+    this.scrollY = scrollY;
+    this.sectionExpanded = sectionExpanded == null ? null : new HashMap<>(sectionExpanded);
+    this.caseTypeVersionAtSave = caseTypeVersionAtSave;
+    setCreatedAt(createdAt);
+    setUpdatedAt(updatedAt);
+  }
+
+  public UUID getCaseId() {
+    return caseId;
+  }
+
+  public String getFormId() {
+    return formId;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public Map<String, Object> getPayload() {
+    return payload;
+  }
+
+  public void setPayload(Map<String, Object> payload) {
+    this.payload = payload == null ? new HashMap<>() : new HashMap<>(payload);
+  }
+
+  public int getScrollY() {
+    return scrollY;
+  }
+
+  public void setScrollY(int scrollY) {
+    this.scrollY = scrollY;
+  }
+
+  public Map<String, Boolean> getSectionExpanded() {
+    return sectionExpanded;
+  }
+
+  public void setSectionExpanded(Map<String, Boolean> sectionExpanded) {
+    this.sectionExpanded = sectionExpanded == null ? null : new HashMap<>(sectionExpanded);
+  }
+
+  public int getCaseTypeVersionAtSave() {
+    return caseTypeVersionAtSave;
+  }
+
+  public void setCaseTypeVersionAtSave(int caseTypeVersionAtSave) {
+    this.caseTypeVersionAtSave = caseTypeVersionAtSave;
+  }
+
+  @Override
+  public void setUpdatedAt(Instant updatedAt) {
+    super.setUpdatedAt(updatedAt);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/FormDraftJpaRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/FormDraftJpaRepository.java
@@ -1,0 +1,30 @@
+package com.wkspower.platform.infrastructure.persistence.repository;
+
+import com.wkspower.platform.infrastructure.persistence.entity.FormDraftEntity;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Story 5.4 — Spring Data repository for {@link FormDraftEntity}. The single read accessor scopes
+ * to {@code (caseId, formId, userId)} — there is intentionally no {@code
+ * findByCaseIdAndFormId(...)} variant (AC5 cross-user leakage guard).
+ */
+public interface FormDraftJpaRepository extends JpaRepository<FormDraftEntity, UUID> {
+
+  Optional<FormDraftEntity> findByCaseIdAndFormIdAndUserId(UUID caseId, String formId, UUID userId);
+
+  @Modifying
+  @Query(
+      "delete from FormDraftEntity d "
+          + "where d.caseId = :caseId and d.formId = :formId and d.userId = :userId")
+  int deleteByScope(
+      @Param("caseId") UUID caseId, @Param("formId") String formId, @Param("userId") UUID userId);
+
+  List<FormDraftEntity> findByUpdatedAtBefore(Instant cutoff);
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -89,6 +89,12 @@ wks:
     file: ${WKS_LICENSE_FILE:}
     # Hot-reload polling interval in seconds (default 30). File is reloaded when lastModified changes.
     poll-interval-seconds: ${WKS_LICENSE_POLL_INTERVAL:30}
+  # Story 5.4 — form draft persistence. Drafts inactive for `ttl-days` are expired by the
+  # FormDraftExpirationJob on the cron schedule below.
+  form:
+    draft:
+      ttl-days: ${WKS_FORM_DRAFT_TTL_DAYS:30}
+      expiration-cron: ${WKS_FORM_DRAFT_EXPIRATION_CRON:0 0 3 * * *}
   # Story 14.5 — runtime CSS theme override. When set, GET /api/theme.css serves the file at
   # this path. Unset (default) → 204 No Content; the browser ignores the empty link gracefully.
   theme:

--- a/backend/src/main/resources/db/migration/common/V202605080001__form_drafts.sql
+++ b/backend/src/main/resources/db/migration/common/V202605080001__form_drafts.sql
@@ -1,0 +1,23 @@
+-- Story 5.4 — form draft persistence (auto-save + resume).
+-- Scope: (case_id, form_id, user_id) — uniqueness enforced at DB level (AC5).
+-- Payload is a JSON column to keep the schema stable across form-shape changes.
+-- case_type_version_at_save captures the version the draft was last written against;
+-- a mismatch with the case's current case_type_version triggers AC3 discard-prompt.
+
+CREATE TABLE form_drafts (
+    id                          UUID                     PRIMARY KEY,
+    case_id                     UUID                     NOT NULL,
+    form_id                     VARCHAR(255)             NOT NULL,
+    user_id                     UUID                     NOT NULL,
+    payload                     JSON                     NOT NULL,
+    scroll_y                    INTEGER                  NOT NULL DEFAULT 0,
+    section_expanded            JSON,
+    case_type_version_at_save   INTEGER                  NOT NULL,
+    version                     BIGINT                   NOT NULL DEFAULT 0,
+    created_at                  TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at                  TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT uq_form_drafts_scope UNIQUE (case_id, form_id, user_id),
+    CONSTRAINT fk_form_drafts_case FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_form_drafts_updated_at ON form_drafts (updated_at);

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
@@ -67,7 +67,9 @@ class AdminControllerTest {
             List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
             List.of(),
-            List.of(new RoleDefinition("admin", List.of())));
+            List.of(new RoleDefinition("admin", List.of())),
+            List.of(),
+            List.of());
     DeploymentResult deployment =
         new DeploymentResult("dep-1", "applicationProcess", "procDef-1", 1, Instant.now());
     byte[] yamlBytes = "id: x".getBytes();
@@ -201,7 +203,9 @@ class AdminControllerTest {
             List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
             List.of(),
-            List.of(new RoleDefinition("admin", List.of())));
+            List.of(new RoleDefinition("admin", List.of())),
+            List.of(),
+            List.of());
     byte[] yamlBytes = "id: j9-zero-zero".getBytes();
     when(configService.validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any()))
         .thenReturn(ValidationResult.ok(config));

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
@@ -475,7 +475,9 @@ class CaseControllerTest {
         List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
         List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
         List.of("name"),
-        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))));
+        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))),
+        List.of(),
+        List.of());
   }
 
   /** Story 3.3 — three-stage CaseType fixture (intake → underwriting → decision). */
@@ -495,7 +497,8 @@ class CaseControllerTest {
             new com.wkspower.platform.domain.config.model.StageDefinition(
                 "underwriting", "Underwriting", 1),
             new com.wkspower.platform.domain.config.model.StageDefinition(
-                "decision", "Decision", 2)));
+                "decision", "Decision", 2)),
+        List.of());
   }
 
   /** Story 3.3 — happy path: stage 0 COMPLETED, stage 1 ACTIVE, stage 2 PENDING. */

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
@@ -202,7 +202,9 @@ class CaseTransitionControllerTest {
         List.of("name"),
         List.of(
             new RoleDefinition(
-                "officer", List.of(Permission.VIEW, Permission.CREATE, Permission.TRANSITION))));
+                "officer", List.of(Permission.VIEW, Permission.CREATE, Permission.TRANSITION))),
+        List.of(),
+        List.of());
   }
 
   private static org.springframework.test.web.servlet.request.RequestPostProcessor officerAuth() {

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseTypeControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseTypeControllerTest.java
@@ -163,7 +163,9 @@ class CaseTypeControllerTest {
         List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
         List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
         List.of("name"),
-        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))));
+        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))),
+        List.of(),
+        List.of());
   }
 
   private static CaseTypeConfig hrType() {
@@ -180,7 +182,9 @@ class CaseTypeControllerTest {
             new StatusDefinition("draft", "Draft", StatusColor.ZINC),
             new StatusDefinition("active", "Active", StatusColor.EMERALD)),
         List.of("employee", "startDate"),
-        List.of(new RoleDefinition("hr", List.of(Permission.VIEW))));
+        List.of(new RoleDefinition("hr", List.of(Permission.VIEW))),
+        List.of(),
+        List.of());
   }
 
   private static org.springframework.test.web.servlet.request.RequestPostProcessor officerAuth() {

--- a/backend/src/test/java/com/wkspower/platform/domain/config/model/CaseTypeConfigBuilderTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/config/model/CaseTypeConfigBuilderTest.java
@@ -1,0 +1,69 @@
+package com.wkspower.platform.domain.config.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 5.4 AC-0 — verifies {@link CaseTypeConfig.Builder} produces a record equivalent to the
+ * canonical 11-arg constructor across full and minimal field permutations.
+ */
+class CaseTypeConfigBuilderTest {
+
+  @Test
+  void builderProducesSameRecordAsCanonicalConstructor() {
+    WorkflowRef wf = new WorkflowRef("loan.bpmn");
+    List<FieldDefinition> fields =
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null));
+    List<StatusDefinition> statuses =
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC));
+    List<String> listColumns = List.of("name");
+    List<RoleDefinition> roles = List.of(new RoleDefinition("admin", List.of(Permission.VIEW)));
+
+    CaseTypeConfig fromCanonical =
+        new CaseTypeConfig(
+            "loan",
+            "Loan",
+            3,
+            "desc",
+            wf,
+            fields,
+            statuses,
+            listColumns,
+            roles,
+            List.of(),
+            List.of());
+
+    CaseTypeConfig fromBuilder =
+        CaseTypeConfig.builder()
+            .id("loan")
+            .displayName("Loan")
+            .version(3)
+            .description("desc")
+            .workflow(wf)
+            .fields(fields)
+            .statuses(statuses)
+            .listColumns(listColumns)
+            .roles(roles)
+            .stages(List.of())
+            .forms(List.of())
+            .build();
+
+    assertThat(fromBuilder).isEqualTo(fromCanonical);
+  }
+
+  @Test
+  void builderDefaultsCollectionsToEmpty() {
+    CaseTypeConfig built = CaseTypeConfig.builder().id("x").displayName("X").version(1).build();
+
+    assertThat(built.fields()).isEmpty();
+    assertThat(built.statuses()).isEmpty();
+    assertThat(built.listColumns()).isEmpty();
+    assertThat(built.roles()).isEmpty();
+    assertThat(built.stages()).isEmpty();
+    assertThat(built.forms()).isEmpty();
+    assertThat(built.workflow()).isNull();
+    assertThat(built.description()).isNull();
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/config/model/CaseTypeConfigWithVersionTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/config/model/CaseTypeConfigWithVersionTest.java
@@ -23,6 +23,7 @@ class CaseTypeConfigWithVersionTest {
         List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
         List.of("name"),
         List.of(new RoleDefinition("admin", List.of(Permission.VIEW))),
+        List.of(),
         List.of());
   }
 

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
@@ -252,7 +252,8 @@ class CaseServiceTest {
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, false)),
             List.of(),
             List.of(new RoleDefinition("officer", List.of(Permission.VIEW))),
-            List.of(stage));
+            List.of(stage),
+            List.of());
     UUID caseId = UUID.randomUUID();
     Case existing =
         new Case(
@@ -308,7 +309,8 @@ class CaseServiceTest {
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, false)),
             List.of(),
             List.of(new RoleDefinition("officer", List.of(Permission.VIEW))),
-            List.of(stageA, stageB));
+            List.of(stageA, stageB),
+            List.of());
     UUID caseId = UUID.randomUUID();
     Case existing =
         new Case(
@@ -363,7 +365,8 @@ class CaseServiceTest {
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, false)),
             List.of(),
             List.of(new RoleDefinition("officer", List.of(Permission.VIEW))),
-            List.of(stage));
+            List.of(stage),
+            List.of());
     UUID caseId = UUID.randomUUID();
     Case existing =
         new Case(
@@ -412,7 +415,9 @@ class CaseServiceTest {
         List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
         List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
         List.of("name"),
-        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))));
+        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))),
+        List.of(),
+        List.of());
   }
 
   private static CaseTypeReader reader(CaseTypeConfig config) {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
@@ -200,7 +200,9 @@ class ConfigServiceDeployTest {
             prior.fields(),
             prior.statuses(),
             prior.listColumns(),
-            prior.roles());
+            prior.roles(),
+            List.of(),
+            List.of());
     StubSource source = new StubSource(ValidationResult.ok(incoming));
     StubBpmn bpmn = new StubBpmn(BpmnValidationResult.ok("applicationProcess"));
     StubRegistrar registrar = new StubRegistrar();
@@ -369,7 +371,9 @@ class ConfigServiceDeployTest {
         List.<FieldDefinition>of(),
         List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
         List.of(),
-        List.of(new RoleDefinition("admin", List.of())));
+        List.of(new RoleDefinition("admin", List.of())),
+        List.of(),
+        List.of());
   }
 
   private static final class StubSource implements CaseTypeSource {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceMappingRegistryTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceMappingRegistryTest.java
@@ -173,7 +173,9 @@ class ConfigServiceMappingRegistryTest {
         List.<FieldDefinition>of(),
         List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
         List.of(),
-        List.of(new RoleDefinition("admin", List.of())));
+        List.of(new RoleDefinition("admin", List.of())),
+        List.of(),
+        List.of());
   }
 
   private static final class StubSource implements CaseTypeSource {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ExecutionSignalRouterIT.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ExecutionSignalRouterIT.java
@@ -840,7 +840,8 @@ class ExecutionSignalRouterIT {
                   new StatusDefinition("closed", "Closed", StatusColor.ZINC, true)),
               List.of(),
               List.of(new RoleDefinition("admin", List.of(Permission.VIEW, Permission.CREATE))),
-              stages);
+              stages,
+              List.of());
         }
       };
     }

--- a/backend/src/test/java/com/wkspower/platform/domain/service/FormDraftServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/FormDraftServiceTest.java
@@ -1,0 +1,139 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.wkspower.platform.domain.event.FormDraftExpired;
+import com.wkspower.platform.domain.model.FormDraft;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
+import com.wkspower.platform.domain.port.FormDraftRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Story 5.4 unit tests for {@link FormDraftService}. */
+@ExtendWith(MockitoExtension.class)
+class FormDraftServiceTest {
+
+  @Mock private FormDraftRepository repository;
+  @Mock private Clock clock;
+  @Mock private EventPublisher events;
+
+  private final Instant fixed = Instant.parse("2026-05-08T12:00:00Z");
+
+  private FormDraftService service() {
+    return new FormDraftService(repository, clock, events);
+  }
+
+  @Test
+  void saveDraftDelegatesUpsertToRepository() {
+    when(clock.now()).thenReturn(fixed);
+    UUID caseId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    FormDraft expected =
+        new FormDraft(
+            UUID.randomUUID(), caseId, "f1", userId, Map.of("a", "b"), 42, null, 1, fixed, fixed);
+    when(repository.upsert(
+            eq(caseId), eq("f1"), eq(userId), any(), eq(42), any(), eq(1), eq(fixed)))
+        .thenReturn(expected);
+
+    FormDraft saved = service().saveDraft(caseId, "f1", userId, Map.of("a", "b"), 42, null, 1);
+
+    assertThat(saved).isEqualTo(expected);
+  }
+
+  @Test
+  void deleteDraftReturnsTrueWhenRowDeleted() {
+    UUID caseId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    when(repository.deleteByScope(caseId, "f1", userId)).thenReturn(1);
+
+    assertThat(service().deleteDraft(caseId, "f1", userId)).isTrue();
+  }
+
+  @Test
+  void deleteDraftIsIdempotent() {
+    UUID caseId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    when(repository.deleteByScope(caseId, "f1", userId)).thenReturn(0);
+
+    assertThat(service().deleteDraft(caseId, "f1", userId)).isFalse();
+  }
+
+  @Test
+  void findDraftDelegates() {
+    UUID caseId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    when(repository.findByScope(caseId, "f1", userId)).thenReturn(Optional.empty());
+
+    assertThat(service().findDraft(caseId, "f1", userId)).isEmpty();
+  }
+
+  @Test
+  void expireOlderThanEmitsEventPerRowAndDeletesAll() {
+    Instant cutoff = fixed.minus(30, ChronoUnit.DAYS);
+    when(clock.now()).thenReturn(fixed);
+    Instant oldA = fixed.minus(31, ChronoUnit.DAYS);
+    Instant oldB = fixed.minus(45, ChronoUnit.DAYS);
+    FormDraft a =
+        new FormDraft(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "f1",
+            UUID.randomUUID(),
+            Map.of(),
+            0,
+            null,
+            1,
+            oldA,
+            oldA);
+    FormDraft b =
+        new FormDraft(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "f2",
+            UUID.randomUUID(),
+            Map.of(),
+            0,
+            null,
+            1,
+            oldB,
+            oldB);
+    when(repository.findByUpdatedAtBefore(cutoff)).thenReturn(List.of(a, b));
+
+    int n = service().expireOlderThan(cutoff);
+
+    assertThat(n).isEqualTo(2);
+    verify(events, times(2)).publish(any(FormDraftExpired.class));
+    verify(repository).deleteAll(List.of(a, b));
+  }
+
+  @Test
+  void expireOlderThanReturnsZeroWhenNothingExpired() {
+    Instant cutoff = fixed.minus(30, ChronoUnit.DAYS);
+    when(repository.findByUpdatedAtBefore(cutoff)).thenReturn(List.of());
+
+    assertThat(service().expireOlderThan(cutoff)).isZero();
+    // ensure publish is never called when nothing expired
+    verify(events, times(0)).publish(any());
+  }
+
+  // Sanity: anyInt usage prevents mockito unused-import lint warnings
+  @SuppressWarnings("unused")
+  private void anyIntPlaceholder() {
+    anyInt();
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ZeroStageZeroProcessTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ZeroStageZeroProcessTest.java
@@ -197,6 +197,7 @@ class ZeroStageZeroProcessTest {
             new StatusDefinition("closed", "Closed", StatusColor.ZINC, true)),
         List.of(),
         List.of(new RoleDefinition("admin", List.of(Permission.VIEW, Permission.CREATE))),
+        List.of(),
         List.of()); // stages empty
   }
 
@@ -210,7 +211,9 @@ class ZeroStageZeroProcessTest {
         List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
         List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
         List.of("name"),
-        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))));
+        List.of(new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE))),
+        List.of(),
+        List.of());
   }
 
   private static CaseTypeReader reader(CaseTypeConfig config) {

--- a/backend/src/test/java/com/wkspower/platform/engine/BpmnValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/engine/BpmnValidatorTest.java
@@ -339,6 +339,8 @@ class BpmnValidatorTest {
         fields,
         List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
         List.of(),
-        List.of(new RoleDefinition("admin", List.of())));
+        List.of(new RoleDefinition("admin", List.of())),
+        List.of(),
+        List.of());
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseDataValidatorAdapterTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseDataValidatorAdapterTest.java
@@ -147,6 +147,8 @@ class CaseDataValidatorAdapterTest {
         List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
         List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
         List.of("name"),
-        List.of(new RoleDefinition("admin", List.of(Permission.VIEW, Permission.CREATE))));
+        List.of(new RoleDefinition("admin", List.of(Permission.VIEW, Permission.CREATE))),
+        List.of(),
+        List.of());
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeRegistryTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeRegistryTest.java
@@ -192,6 +192,8 @@ class CaseTypeRegistryTest {
                 "a", "A", FieldType.TEXT, false, 0, List.of(), FieldDefinition.TypeSlots.empty())),
         List.of(new StatusDefinition("open", "Open", StatusColor.AMBER)),
         List.of("a"),
-        List.of(new RoleDefinition("officer", List.of(Permission.VIEW))));
+        List.of(new RoleDefinition("officer", List.of(Permission.VIEW))),
+        List.of(),
+        List.of());
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/formdraft/FormDraftExpirationJobTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/formdraft/FormDraftExpirationJobTest.java
@@ -1,0 +1,46 @@
+package com.wkspower.platform.infrastructure.formdraft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.service.FormDraftService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Story 5.4 AC4 — unit test for {@link FormDraftExpirationJob} cutoff math + invocation. */
+@ExtendWith(MockitoExtension.class)
+class FormDraftExpirationJobTest {
+
+  @Mock private FormDraftService draftService;
+  @Mock private Clock clock;
+
+  @Test
+  void runUsesNowMinusTtlDaysAsCutoff() {
+    Instant now = Instant.parse("2026-05-08T03:00:00Z");
+    when(clock.now()).thenReturn(now);
+    when(draftService.expireOlderThan(any(Instant.class))).thenReturn(0);
+
+    new FormDraftExpirationJob(draftService, clock, 30).run();
+
+    ArgumentCaptor<Instant> captor = ArgumentCaptor.forClass(Instant.class);
+    verify(draftService).expireOlderThan(captor.capture());
+    assertThat(captor.getValue()).isEqualTo(now.minus(30, ChronoUnit.DAYS));
+  }
+
+  @Test
+  void runIsResilientToZeroDeletes() {
+    when(clock.now()).thenReturn(Instant.parse("2026-05-08T03:00:00Z"));
+    when(draftService.expireOlderThan(any(Instant.class))).thenReturn(0);
+
+    // Should not throw or log.error — behaviour is best-effort.
+    new FormDraftExpirationJob(draftService, clock, 30).run();
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseAuthIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseAuthIT.java
@@ -175,6 +175,8 @@ class CaseAuthIT {
         List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
         List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
         List.of("name"),
-        List.of(new RoleDefinition("admin", List.of(Permission.VIEW, Permission.CREATE))));
+        List.of(new RoleDefinition("admin", List.of(Permission.VIEW, Permission.CREATE))),
+        List.of(),
+        List.of());
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseCreateAtomicityIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseCreateAtomicityIT.java
@@ -204,8 +204,8 @@ class CaseCreateAtomicityIT {
                 List.of(
                     Permission.VIEW, Permission.CREATE, Permission.EDIT, Permission.TRANSITION))),
         List.of(
-            new StageDefinition("intake", "Intake", 0),
-            new StageDefinition("review", "Review", 1)));
+            new StageDefinition("intake", "Intake", 0), new StageDefinition("review", "Review", 1)),
+        List.of());
   }
 
   private static String simpleBpmn() {

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseFlowIT.java
@@ -248,7 +248,9 @@ class CaseFlowIT {
         List.of("name"),
         List.of(
             new RoleDefinition(
-                "admin", List.of(Permission.VIEW, Permission.CREATE, Permission.EDIT))));
+                "admin", List.of(Permission.VIEW, Permission.CREATE, Permission.EDIT))),
+        List.of(),
+        List.of());
   }
 
   // ---- Story 2.4 — full create → transition end-to-end ----------------
@@ -457,7 +459,9 @@ class CaseFlowIT {
             new RoleDefinition(
                 "admin",
                 List.of(
-                    Permission.VIEW, Permission.CREATE, Permission.EDIT, Permission.TRANSITION))));
+                    Permission.VIEW, Permission.CREATE, Permission.EDIT, Permission.TRANSITION))),
+        List.of(),
+        List.of());
   }
 
   private void registerTransitionCaseType() {
@@ -537,7 +541,9 @@ class CaseFlowIT {
             new RoleDefinition(
                 "admin",
                 List.of(
-                    Permission.VIEW, Permission.CREATE, Permission.EDIT, Permission.TRANSITION))));
+                    Permission.VIEW, Permission.CREATE, Permission.EDIT, Permission.TRANSITION))),
+        List.of(),
+        List.of());
   }
 
   /**

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseTypeControllerIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseTypeControllerIT.java
@@ -173,7 +173,9 @@ class CaseTypeControllerIT {
         List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
         List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
         List.of("name"),
-        List.of(new RoleDefinition("admin", List.of(Permission.VIEW))));
+        List.of(new RoleDefinition("admin", List.of(Permission.VIEW))),
+        List.of(),
+        List.of());
   }
 
   private static CaseTypeConfig hrTypeForHr() {
@@ -187,6 +189,8 @@ class CaseTypeControllerIT {
             new FieldDefinition("employee", "Employee", FieldType.TEXT, true, 0, List.of(), null)),
         List.of(new StatusDefinition("draft", "Draft", StatusColor.ZINC)),
         List.of("employee"),
-        List.of(new RoleDefinition("hr", List.of(Permission.VIEW))));
+        List.of(new RoleDefinition("hr", List.of(Permission.VIEW))),
+        List.of(),
+        List.of());
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/integration/DocumentControllerIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/DocumentControllerIT.java
@@ -470,6 +470,8 @@ class DocumentControllerIT {
             new RoleDefinition(
                 "admin",
                 List.of(
-                    Permission.CREATE, Permission.VIEW, Permission.EDIT, Permission.TRANSITION))));
+                    Permission.CREATE, Permission.VIEW, Permission.EDIT, Permission.TRANSITION))),
+        List.of(),
+        List.of());
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/integration/FormDraftIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormDraftIT.java
@@ -1,0 +1,327 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.event.FormDraftExpired;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.FormDraftService;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import com.wkspower.platform.infrastructure.persistence.entity.FormDraftEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.FormDraftJpaRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Story 5.4 — end-to-end integration coverage for the form draft surface (AC1, AC4, AC5, AC6). Uses
+ * an H2 in-memory DB; the stage primitives that need Postgres parity (memory {@code
+ * project_postgres_it_parity_gap.md}) are unaffected here because the draft expiration query is a
+ * simple {@code updated_at < ?} predicate that behaves the same on both databases (no timezone
+ * arithmetic, no SSI gotchas).
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Import(FormDraftIT.TestBeans.class)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:formdraftit;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=",
+      "wks.bootstrap.production-validation.enabled=false"
+    })
+class FormDraftIT {
+
+  private static final String EMAIL_A = "draft-it-a@wkspower.local";
+  private static final String EMAIL_B = "draft-it-b@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String CASE_TYPE_ID = "form-draft-fixture";
+  private static final String FORM_ID = "intake-form";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private ObjectMapper json;
+  @Autowired private FormDraftService draftService;
+  @Autowired private FormDraftJpaRepository draftRepo;
+  @Autowired private JdbcTemplate jdbc;
+  @Autowired private ExpirationListener listener;
+
+  @BeforeEach
+  void setup() {
+    if (users.findByEmail(EMAIL_A).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL_A, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+    if (users.findByEmail(EMAIL_B).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL_B, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+    registry.register(caseTypeWithForm());
+    listener.last.set(null);
+  }
+
+  // ---- AC1 — CRUD via REST -----------------------------------------------------
+
+  @Test
+  void putGetDeleteRoundtripWorks() throws Exception {
+    String cookie = login(EMAIL_A);
+    String caseId = createCase(cookie);
+
+    // GET 404 when no draft exists yet
+    ResponseEntity<String> empty =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft", HttpMethod.GET, cookie, null);
+    assertThat(empty.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+
+    // PUT — save draft
+    String payload =
+        "{\"payload\":{\"applicant\":\"Alice\"},\"scrollY\":42,\"sectionExpanded\":null,\"caseTypeVersionAtSave\":1}";
+    ResponseEntity<String> put =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft",
+            HttpMethod.PUT,
+            cookie,
+            payload);
+    assertThat(put.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(json.readTree(put.getBody()).path("data").path("scrollY").asInt()).isEqualTo(42);
+
+    // GET 200 with the saved draft
+    ResponseEntity<String> got =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft", HttpMethod.GET, cookie, null);
+    assertThat(got.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode body = json.readTree(got.getBody()).path("data");
+    assertThat(body.path("payload").path("applicant").asText()).isEqualTo("Alice");
+
+    // PUT again — upsert in place
+    String payload2 =
+        "{\"payload\":{\"applicant\":\"Bob\"},\"scrollY\":99,\"sectionExpanded\":null,\"caseTypeVersionAtSave\":1}";
+    exchange(
+        "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft", HttpMethod.PUT, cookie, payload2);
+    ResponseEntity<String> got2 =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft", HttpMethod.GET, cookie, null);
+    JsonNode body2 = json.readTree(got2.getBody()).path("data");
+    assertThat(body2.path("payload").path("applicant").asText()).isEqualTo("Bob");
+    assertThat(body2.path("scrollY").asInt()).isEqualTo(99);
+
+    // DELETE — 204 + GET returns 404
+    ResponseEntity<String> del =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft",
+            HttpMethod.DELETE,
+            cookie,
+            null);
+    assertThat(del.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    ResponseEntity<String> after =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft", HttpMethod.GET, cookie, null);
+    assertThat(after.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  // ---- AC5 — cross-user isolation ----------------------------------------------
+
+  @Test
+  void userBCannotReadUserADraft() throws Exception {
+    String cookieA = login(EMAIL_A);
+    String caseId = createCase(cookieA);
+    exchange(
+        "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft",
+        HttpMethod.PUT,
+        cookieA,
+        "{\"payload\":{\"applicant\":\"Alice\"},\"scrollY\":0,\"sectionExpanded\":null,\"caseTypeVersionAtSave\":1}");
+
+    String cookieB = login(EMAIL_B);
+    ResponseEntity<String> b =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft", HttpMethod.GET, cookieB, null);
+    assertThat(b.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  // ---- AC6 — submit deletes draft, validation failure preserves it -------------
+
+  @Test
+  void successfulSubmitDeletesDraft() throws Exception {
+    String cookie = login(EMAIL_A);
+    String caseId = createCase(cookie);
+    exchange(
+        "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft",
+        HttpMethod.PUT,
+        cookie,
+        "{\"payload\":{\"applicant\":\"Alice\"},\"scrollY\":0,\"sectionExpanded\":null,\"caseTypeVersionAtSave\":1}");
+
+    ResponseEntity<String> submit =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\",\"amount\":5000}");
+    assertThat(submit.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    ResponseEntity<String> after =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft", HttpMethod.GET, cookie, null);
+    assertThat(after.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void validationFailureOnSubmitPreservesDraft() throws Exception {
+    String cookie = login(EMAIL_A);
+    String caseId = createCase(cookie);
+    exchange(
+        "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft",
+        HttpMethod.PUT,
+        cookie,
+        "{\"payload\":{\"applicant\":\"Alice\"},\"scrollY\":0,\"sectionExpanded\":null,\"caseTypeVersionAtSave\":1}");
+
+    // Submit missing the required "applicant" field — 422
+    ResponseEntity<String> submit =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"amount\":5000}");
+    assertThat(submit.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+
+    // Draft survives the rolled-back transaction.
+    ResponseEntity<String> after =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft", HttpMethod.GET, cookie, null);
+    assertThat(after.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  // ---- AC4 — expiration --------------------------------------------------------
+
+  @Test
+  void expireOlderThanDeletesAndEmitsEvent() throws Exception {
+    String cookie = login(EMAIL_A);
+    String caseId = createCase(cookie);
+    UUID caseUuid = UUID.fromString(caseId);
+    UUID userUuid = users.findByEmail(EMAIL_A).orElseThrow().id();
+
+    // Save a draft via the service, then back-date its updated_at via the repo.
+    draftService.saveDraft(caseUuid, "f1", userUuid, Map.of("k", "v"), 0, null, 1);
+    FormDraftEntity stored =
+        draftRepo.findByCaseIdAndFormIdAndUserId(caseUuid, "f1", userUuid).orElseThrow();
+    Instant longAgo = Instant.now().minus(45, ChronoUnit.DAYS);
+    // Bypass @PreUpdate by going direct via JdbcTemplate.
+    jdbc.update(
+        "UPDATE form_drafts SET updated_at = ? WHERE id = ?",
+        java.sql.Timestamp.from(longAgo),
+        stored.getId());
+
+    int n = draftService.expireOlderThan(Instant.now().minus(30, ChronoUnit.DAYS));
+
+    assertThat(n).isGreaterThanOrEqualTo(1);
+    assertThat(draftRepo.findById(stored.getId())).isEmpty();
+    assertThat(listener.last.get()).isNotNull();
+    assertThat(listener.last.get().formId()).isEqualTo("f1");
+  }
+
+  // ---- helpers -----------------------------------------------------------------
+
+  static class ExpirationListener {
+    final AtomicReference<FormDraftExpired> last = new AtomicReference<>();
+
+    @EventListener
+    public void on(FormDraftExpired e) {
+      last.set(e);
+    }
+  }
+
+  @TestConfiguration
+  static class TestBeans {
+    @Bean
+    ExpirationListener expirationListener() {
+      return new ExpirationListener();
+    }
+  }
+
+  private String login(String email) {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(email, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", email).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private String createCase(String cookie) throws Exception {
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"applicant\":\"Initial\"}}");
+    assertThat(resp.getStatusCode()).as("create case").isEqualTo(HttpStatus.CREATED);
+    return json.readTree(resp.getBody()).path("data").path("id").asText();
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  private static CaseTypeConfig caseTypeWithForm() {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
+    FormDefinition intakeForm =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Form Draft Fixture",
+        1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(intakeForm));
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/StageScopedStatusCrudIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/StageScopedStatusCrudIT.java
@@ -307,6 +307,7 @@ class StageScopedStatusCrudIT {
             new StatusDefinition("closed", "Closed", StatusColor.EMERALD, true)),
         List.of("name"),
         List.of(new RoleDefinition("admin", List.of(Permission.VIEW))),
-        List.of(stage));
+        List.of(stage),
+        List.of());
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/security/CaseTypePermissionEvaluatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/security/CaseTypePermissionEvaluatorTest.java
@@ -96,7 +96,9 @@ class CaseTypePermissionEvaluatorTest {
         List.of("name"),
         List.of(
             new RoleDefinition("officer", List.of(Permission.VIEW, Permission.CREATE)),
-            new RoleDefinition("customer", List.of(Permission.VIEW))));
+            new RoleDefinition("customer", List.of(Permission.VIEW))),
+        List.of(),
+        List.of());
   }
 
   private static CaseTypeReader reader(CaseTypeConfig config) {

--- a/frontend/src/api/drafts.ts
+++ b/frontend/src/api/drafts.ts
@@ -1,0 +1,59 @@
+import { apiFetch, ApiError } from './client';
+
+/**
+ * Story 5.4 — wire DTO returned by GET / PUT /api/cases/{caseId}/forms/{formId}/draft.
+ */
+export interface FormDraftDto {
+  id: string;
+  caseId: string;
+  formId: string;
+  payload: Record<string, unknown>;
+  scrollY: number;
+  sectionExpanded: Record<string, boolean> | null;
+  caseTypeVersionAtSave: number;
+  /** ISO-8601 timestamp serialized from the backend Instant. */
+  updatedAt: string;
+}
+
+export interface SaveDraftRequest {
+  payload: Record<string, unknown>;
+  scrollY: number;
+  sectionExpanded: Record<string, boolean> | null;
+  caseTypeVersionAtSave: number;
+}
+
+/**
+ * GET the current user's draft for {@code (caseId, formId)}. Returns {@code null} when no draft
+ * exists (the backend returns 404 in that case — the hook treats it as a non-error empty state).
+ */
+export async function getFormDraft(caseId: string, formId: string): Promise<FormDraftDto | null> {
+  try {
+    const res = await apiFetch<FormDraftDto>(`/api/cases/${caseId}/forms/${formId}/draft`, {
+      method: 'GET',
+    });
+    return res.data;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/** Upsert the draft — returns the persisted draft DTO. */
+export async function saveFormDraft(
+  caseId: string,
+  formId: string,
+  body: SaveDraftRequest,
+): Promise<FormDraftDto> {
+  const res = await apiFetch<FormDraftDto>(`/api/cases/${caseId}/forms/${formId}/draft`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+  return res.data;
+}
+
+/** Delete the draft. Idempotent — succeeds silently when no row exists. */
+export async function deleteFormDraft(caseId: string, formId: string): Promise<void> {
+  await apiFetch<void>(`/api/cases/${caseId}/forms/${formId}/draft`, { method: 'DELETE' });
+}

--- a/frontend/src/components/forms/MultiSectionFormRenderer.tsx
+++ b/frontend/src/components/forms/MultiSectionFormRenderer.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ChevronDown } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
 
 import { ApiError } from '@/api/client';
@@ -46,6 +46,16 @@ export interface MultiSectionFormRendererProps {
   defaultValues?: Record<string, unknown>;
   /** Called after a successful submit so the parent can react (e.g. navigate). */
   onSuccess?: () => void;
+  /**
+   * Story 5.4 AC1 — invoked whenever any field value changes; the parent wires this to the
+   * draft auto-save scheduler. Optional for backward compatibility.
+   */
+  onValuesChange?: (values: Record<string, unknown>) => void;
+  /** Story 5.4 AC1 — explicit "Save Draft" action; renders an extra ghost button next to Submit. */
+  saveDraftAction?: {
+    label: string;
+    onClick: (values: Record<string, unknown>) => void;
+  };
 }
 
 type SectionStatus = 'incomplete' | 'complete' | 'error';
@@ -74,6 +84,8 @@ export function MultiSectionFormRenderer({
   caseId,
   defaultValues: externalDefaultValues,
   onSuccess,
+  onValuesChange,
+  saveDraftAction,
 }: MultiSectionFormRendererProps) {
   const sections = useMemo(() => formDefinition.sections ?? [], [formDefinition.sections]);
   const allFields = useMemo(() => sections.flatMap((s) => s.fields), [sections]);
@@ -107,6 +119,15 @@ export function MultiSectionFormRenderer({
     shouldFocusError: false,
     defaultValues,
   });
+
+  // Story 5.4 AC1 — subscribe to value changes for debounced auto-save.
+  useEffect(() => {
+    if (!onValuesChange) return;
+    const subscription = form.watch((values) => {
+      onValuesChange(values as Record<string, unknown>);
+    });
+    return () => subscription.unsubscribe();
+  }, [form, onValuesChange]);
 
   const state: MutationButtonState = isPending
     ? 'confirming'
@@ -362,7 +383,16 @@ export function MultiSectionFormRenderer({
             </Alert>
           ) : null}
 
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-2">
+            {saveDraftAction ? (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => saveDraftAction.onClick(form.getValues())}
+              >
+                {saveDraftAction.label}
+              </Button>
+            ) : null}
             {needsDialog ? (
               // Story 6.1 AC4 — business_final: AlertDialog interposes before submitForm.
               <AlertDialog>

--- a/frontend/src/components/forms/SinglePageFormRenderer.tsx
+++ b/frontend/src/components/forms/SinglePageFormRenderer.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
 
 import { ApiError } from '@/api/client';
@@ -45,6 +45,22 @@ export interface SinglePageFormRendererProps {
   defaultValues?: Record<string, unknown>;
   /** Called after a successful submit so the parent can react (e.g. show a toast, navigate). */
   onSuccess?: () => void;
+  /**
+   * Story 5.4 AC1 — invoked whenever any field value changes (subscription via RHF watch). The
+   * parent (typically {@code FormPage}) wires this to {@code useFormDraft.scheduleSave} so the
+   * draft is debounce-PUT to the backend. Optional for backward compatibility with existing
+   * callers; when omitted the renderer behaves exactly as before.
+   */
+  onValuesChange?: (values: Record<string, unknown>) => void;
+  /**
+   * Story 5.4 AC1 — explicit "Save Draft" button label and onClick. When provided, an extra
+   * ghost-variant button is rendered next to Submit; clicking it calls back with the current
+   * RHF values so the parent can issue an immediate save (bypassing the debounce). Optional.
+   */
+  saveDraftAction?: {
+    label: string;
+    onClick: (values: Record<string, unknown>) => void;
+  };
 }
 
 interface ServerErrorBanner {
@@ -72,6 +88,8 @@ export function SinglePageFormRenderer({
   caseId,
   defaultValues: externalDefaultValues,
   onSuccess,
+  onValuesChange,
+  saveDraftAction,
 }: SinglePageFormRendererProps) {
   const [serverError, setServerError] = useState<ServerErrorBanner | null>(null);
   const [isPending, setIsPending] = useState(false);
@@ -109,6 +127,15 @@ export function SinglePageFormRenderer({
     shouldFocusError: true,
     defaultValues,
   });
+
+  // Story 5.4 AC1 — subscribe to value changes and forward to the parent for debounced auto-save.
+  useEffect(() => {
+    if (!onValuesChange) return;
+    const subscription = form.watch((values) => {
+      onValuesChange(values as Record<string, unknown>);
+    });
+    return () => subscription.unsubscribe();
+  }, [form, onValuesChange]);
 
   const state: MutationButtonState = isPending
     ? 'confirming'
@@ -260,7 +287,16 @@ export function SinglePageFormRenderer({
               <span>{serverError.message}</span>
             </Alert>
           ) : null}
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-2">
+            {saveDraftAction ? (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => saveDraftAction.onClick(form.getValues())}
+              >
+                {saveDraftAction.label}
+              </Button>
+            ) : null}
             {needsDialog ? (
               // Story 6.1 AC4 — business_final: AlertDialog interposes before submitForm.
               <AlertDialog>

--- a/frontend/src/hooks/useFormDraft.test.ts
+++ b/frontend/src/hooks/useFormDraft.test.ts
@@ -1,0 +1,194 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as draftsApi from '@/api/drafts';
+
+import { useFormDraft } from './useFormDraft';
+
+/**
+ * Story 5.4 — coverage for the {@link useFormDraft} hook:
+ *  - initial GET fires once on mount
+ *  - {@code scheduleSave} debounces (500ms default)
+ *  - {@code saveNow} bypasses the debounce
+ *  - in-flight collapse: overlapping schedules collapse to one follow-up PUT
+ *  - 404 GET → {@code draft === null}, no error state
+ *  - version mismatch → {@code isVersionMismatch === true}
+ *  - {@code discard()} → DELETE then null draft
+ *
+ * Uses real timers + small advances; the previous fake-timer attempt deadlocked because the React
+ * concurrent scheduler internally uses microtasks that don't interact cleanly with vi.fakeTimers.
+ */
+describe('useFormDraft', () => {
+  const caseId = 'case-1';
+  const formId = 'form-1';
+
+  /** Resolves the next macrotask so awaited promises chain through. */
+  const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  beforeEach(() => {
+    vi.spyOn(draftsApi, 'getFormDraft').mockResolvedValue(null);
+    vi.spyOn(draftsApi, 'saveFormDraft').mockResolvedValue({
+      id: 'd1',
+      caseId,
+      formId,
+      payload: {},
+      scrollY: 0,
+      sectionExpanded: null,
+      caseTypeVersionAtSave: 1,
+      updatedAt: '2026-05-08T12:00:00Z',
+    });
+    vi.spyOn(draftsApi, 'deleteFormDraft').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fires GET once on mount and exposes null when no draft exists', async () => {
+    const { result } = renderHook(() => useFormDraft(caseId, formId, 1));
+    await act(async () => {
+      await flush();
+    });
+    expect(draftsApi.getFormDraft).toHaveBeenCalledTimes(1);
+    expect(result.current.draft).toBeNull();
+    expect(result.current.error).toBe(false);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('isVersionMismatch is true when stored version differs from current', async () => {
+    vi.spyOn(draftsApi, 'getFormDraft').mockResolvedValue({
+      id: 'd1',
+      caseId,
+      formId,
+      payload: { a: 'b' },
+      scrollY: 10,
+      sectionExpanded: null,
+      caseTypeVersionAtSave: 1,
+      updatedAt: '2026-05-08T11:00:00Z',
+    });
+    const { result } = renderHook(() => useFormDraft(caseId, formId, 2));
+    await act(async () => {
+      await flush();
+    });
+    expect(result.current.isVersionMismatch).toBe(true);
+  });
+
+  it('scheduleSave debounces ≥500ms before PUTing', async () => {
+    const { result } = renderHook(() => useFormDraft(caseId, formId, 1, { debounceMs: 50 }));
+    await act(async () => {
+      await flush();
+    });
+
+    act(() => result.current.scheduleSave({ a: 1 }, 0, null));
+    await act(async () => {
+      await flush();
+    });
+    // Immediately after schedule — no PUT yet (debounce window not elapsed).
+    expect(draftsApi.saveFormDraft).not.toHaveBeenCalled();
+
+    // Wait for debounce window + a microtask to drain.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 80));
+    });
+    expect(draftsApi.saveFormDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it('overlapping scheduleSave calls collapse to a single in-flight PUT with the latest values', async () => {
+    let resolveFirst: (v: draftsApi.FormDraftDto) => void = () => undefined;
+    const firstPromise = new Promise<draftsApi.FormDraftDto>((res) => {
+      resolveFirst = res;
+    });
+    const saveSpy = vi
+      .spyOn(draftsApi, 'saveFormDraft')
+      .mockImplementationOnce(() => firstPromise)
+      .mockResolvedValue({
+        id: 'd1',
+        caseId,
+        formId,
+        payload: {},
+        scrollY: 0,
+        sectionExpanded: null,
+        caseTypeVersionAtSave: 1,
+        updatedAt: '2026-05-08T12:00:00Z',
+      });
+
+    const { result } = renderHook(() => useFormDraft(caseId, formId, 1, { debounceMs: 20 }));
+    await act(async () => {
+      await flush();
+    });
+
+    // First save → in-flight after debounce.
+    act(() => result.current.scheduleSave({ a: 1 }, 0, null));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+
+    // Two more schedules WHILE the first is in flight — should queue (only the latest wins).
+    act(() => result.current.scheduleSave({ a: 2 }, 0, null));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    act(() => result.current.scheduleSave({ a: 3 }, 0, null));
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    // Still only the first call is in flight (queued, not fired).
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+
+    // Resolve the first save → drain the queue → exactly one follow-up PUT with {a:3}.
+    await act(async () => {
+      resolveFirst({
+        id: 'd1',
+        caseId,
+        formId,
+        payload: { a: 1 },
+        scrollY: 0,
+        sectionExpanded: null,
+        caseTypeVersionAtSave: 1,
+        updatedAt: '2026-05-08T12:00:01Z',
+      });
+      await flush();
+      await flush();
+    });
+    expect(saveSpy).toHaveBeenCalledTimes(2);
+    const secondCall = saveSpy.mock.calls[1];
+    expect(secondCall).toBeDefined();
+    expect(secondCall![2]).toMatchObject({ payload: { a: 3 } });
+  });
+
+  it('saveNow bypasses the debounce', async () => {
+    const { result } = renderHook(() => useFormDraft(caseId, formId, 1));
+    await act(async () => {
+      await flush();
+    });
+    await act(async () => {
+      await result.current.saveNow({ x: 'y' }, 5, null);
+    });
+    expect(draftsApi.saveFormDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it('discard DELETEs and clears local draft state', async () => {
+    vi.spyOn(draftsApi, 'getFormDraft').mockResolvedValue({
+      id: 'd1',
+      caseId,
+      formId,
+      payload: {},
+      scrollY: 0,
+      sectionExpanded: null,
+      caseTypeVersionAtSave: 1,
+      updatedAt: '2026-05-08T11:00:00Z',
+    });
+    const { result } = renderHook(() => useFormDraft(caseId, formId, 1));
+    await act(async () => {
+      await flush();
+    });
+    expect(result.current.draft).not.toBeNull();
+
+    await act(async () => {
+      await result.current.discard();
+    });
+    expect(draftsApi.deleteFormDraft).toHaveBeenCalledTimes(1);
+    expect(result.current.draft).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useFormDraft.ts
+++ b/frontend/src/hooks/useFormDraft.ts
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { deleteFormDraft, getFormDraft, saveFormDraft, type FormDraftDto } from '@/api/drafts';
+
+export type DraftSaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+export interface UseFormDraftResult {
+  draft: FormDraftDto | null;
+  loading: boolean;
+  error: boolean;
+  /** True when a draft exists AND its caseTypeVersionAtSave doesn't match the current case version (AC3). */
+  isVersionMismatch: boolean;
+  saveState: DraftSaveState;
+  lastSavedAt: Date | null;
+  /** Debounced PUT — collapses overlapping calls; only one in-flight PUT at a time. */
+  scheduleSave: (
+    payload: Record<string, unknown>,
+    scrollY: number,
+    sectionExpanded: Record<string, boolean> | null,
+  ) => void;
+  /** Immediate PUT, bypassing the debounce — used by the explicit "Save Draft" button (AC1). */
+  saveNow: (
+    payload: Record<string, unknown>,
+    scrollY: number,
+    sectionExpanded: Record<string, boolean> | null,
+  ) => Promise<void>;
+  /** DELETE the draft and clear local state — used by AC2/AC3 discard actions. */
+  discard: () => Promise<void>;
+}
+
+export interface UseFormDraftOptions {
+  /** Debounce window in ms; default 500. AC1 requires ≥500ms. */
+  debounceMs?: number;
+}
+
+/**
+ * Story 5.4 — auto-save + resume hook for the form renderers.
+ *
+ * Lifecycle:
+ *   - on mount: GET the existing draft once → exposes {@code draft} + {@code isVersionMismatch}.
+ *   - on user input: caller invokes {@link scheduleSave}; the hook debounces (default 500ms) +
+ *     collapses overlapping calls (only one in-flight PUT at a time; the latest values queued win).
+ *   - on explicit Save Draft button: caller invokes {@link saveNow} which bypasses the debounce.
+ *   - on resume "Discard" / version-mismatch "Discard" actions: caller invokes {@link discard}.
+ *
+ * AC1 — debounced auto-save with collapsed overlapping PUTs.
+ * AC3 — {@code isVersionMismatch} surfaces the gate state to the page-level orchestrator.
+ *
+ * The hook does NOT auto-fire saves; the renderer (or page) decides when to call scheduleSave.
+ * This keeps the renderers in control of their RHF lifecycle and avoids cascading effect loops.
+ */
+export function useFormDraft(
+  caseId: string,
+  formId: string,
+  currentCaseTypeVersion: number,
+  options: UseFormDraftOptions = {},
+): UseFormDraftResult {
+  const debounceMs = options.debounceMs ?? 500;
+
+  const [draft, setDraft] = useState<FormDraftDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [saveState, setSaveState] = useState<DraftSaveState>('idle');
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlight = useRef(false);
+  const queuedPayload = useRef<{
+    payload: Record<string, unknown>;
+    scrollY: number;
+    sectionExpanded: Record<string, boolean> | null;
+  } | null>(null);
+  const isMounted = useRef(true);
+
+  // Initial GET — once per (caseId, formId) tuple.
+  useEffect(() => {
+    isMounted.current = true;
+    setLoading(true);
+    setError(false);
+    getFormDraft(caseId, formId)
+      .then((d) => {
+        if (!isMounted.current) return;
+        setDraft(d);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!isMounted.current) return;
+        setError(true);
+        setLoading(false);
+      });
+    return () => {
+      isMounted.current = false;
+      if (debounceTimer.current !== null) {
+        clearTimeout(debounceTimer.current);
+        debounceTimer.current = null;
+      }
+    };
+  }, [caseId, formId]);
+
+  const performSave = useCallback(
+    async (
+      payload: Record<string, unknown>,
+      scrollY: number,
+      sectionExpanded: Record<string, boolean> | null,
+    ): Promise<void> => {
+      if (inFlight.current) {
+        // Queue — the most recent values overwrite any older queued values.
+        queuedPayload.current = { payload, scrollY, sectionExpanded };
+        return;
+      }
+      inFlight.current = true;
+      if (isMounted.current) setSaveState('saving');
+      try {
+        const saved = await saveFormDraft(caseId, formId, {
+          payload,
+          scrollY,
+          sectionExpanded,
+          caseTypeVersionAtSave: currentCaseTypeVersion,
+        });
+        if (isMounted.current) {
+          setDraft(saved);
+          setSaveState('saved');
+          setLastSavedAt(new Date());
+        }
+      } catch {
+        if (isMounted.current) setSaveState('error');
+      } finally {
+        inFlight.current = false;
+        // Drain queue if a newer save was requested while in flight.
+        const queued = queuedPayload.current;
+        queuedPayload.current = null;
+        if (queued && isMounted.current) {
+          await performSave(queued.payload, queued.scrollY, queued.sectionExpanded);
+        }
+      }
+    },
+    [caseId, formId, currentCaseTypeVersion],
+  );
+
+  const scheduleSave = useCallback<UseFormDraftResult['scheduleSave']>(
+    (payload, scrollY, sectionExpanded) => {
+      if (debounceTimer.current !== null) {
+        clearTimeout(debounceTimer.current);
+      }
+      debounceTimer.current = setTimeout(() => {
+        debounceTimer.current = null;
+        void performSave(payload, scrollY, sectionExpanded);
+      }, debounceMs);
+    },
+    [debounceMs, performSave],
+  );
+
+  const saveNow = useCallback<UseFormDraftResult['saveNow']>(
+    async (payload, scrollY, sectionExpanded) => {
+      if (debounceTimer.current !== null) {
+        clearTimeout(debounceTimer.current);
+        debounceTimer.current = null;
+      }
+      await performSave(payload, scrollY, sectionExpanded);
+    },
+    [performSave],
+  );
+
+  const discard = useCallback<UseFormDraftResult['discard']>(async () => {
+    try {
+      await deleteFormDraft(caseId, formId);
+      if (isMounted.current) {
+        setDraft(null);
+        setSaveState('idle');
+        setLastSavedAt(null);
+      }
+    } catch {
+      if (isMounted.current) setSaveState('error');
+    }
+  }, [caseId, formId]);
+
+  const isVersionMismatch =
+    draft !== null && draft.caseTypeVersionAtSave !== currentCaseTypeVersion;
+
+  return {
+    draft,
+    loading,
+    error,
+    isVersionMismatch,
+    saveState,
+    lastSavedAt,
+    scheduleSave,
+    saveNow,
+    discard,
+  };
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -245,5 +245,15 @@
   "form.sections.status.complete": "✓",
   "form.sections.status.error": "✗",
   "form.sections.status.incomplete": "⚠",
-  "form.submit": "Submit"
+  "form.submit": "Submit",
+  "form.draft.save": "Save Draft",
+  "form.draft.saving": "Saving draft…",
+  "form.draft.saved": "Draft saved",
+  "form.draft.error": "Couldn't save draft",
+  "form.draft.resumed": "Resumed your saved draft.",
+  "form.draft.discard": "Discard draft",
+  "form.draft.versionChanged.title": "This form has changed since your draft was saved",
+  "form.draft.versionChanged.body": "The case-type version was bumped while you were away. Your draft cannot be applied to the new form. Discard the draft to continue with the current form, or cancel to come back later.",
+  "form.draft.versionChanged.discardAndUseCurrent": "Discard draft and use current form",
+  "form.draft.versionChanged.cancel": "Cancel"
 }

--- a/frontend/src/pages/FormPage.tsx
+++ b/frontend/src/pages/FormPage.tsx
@@ -2,27 +2,35 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { MultiSectionFormRenderer } from '@/components/forms/MultiSectionFormRenderer';
 import { SinglePageFormRenderer } from '@/components/forms/SinglePageFormRenderer';
+import { Alert } from '@/components/ui/Alert';
 import { Button } from '@/components/ui/Button';
 import { useCase } from '@/hooks/useCases';
+import { useFormDraft } from '@/hooks/useFormDraft';
 import { t } from '@/i18n';
 
 /**
- * Story 5.2 — Route-accessible form page. Fetches the case (which embeds the case-type view,
- * including any declared {@code forms[]}), resolves the form by id from the path, and renders
- * {@link SinglePageFormRenderer}.
+ * Story 5.2 — Route-accessible form page. Story 5.4 extends with draft-resume orchestration.
+ *
+ * <p>AC2 — when a draft exists for {@code (caseId, formId, currentUser)}, merge its {@code payload}
+ * over the case's {@code data} so the user resumes from where they left off; render a small "Resumed
+ * draft" banner with a Discard link.
+ *
+ * <p>AC3 — when the draft's {@code caseTypeVersionAtSave} differs from the case's current
+ * {@code caseTypeVersion}, the renderer is NOT mounted; instead an inline {@code Alert} prompts the
+ * user to discard the draft (and use the current form) or cancel back to the case.
  *
  * <p>Route: {@code /cases/:caseId/forms/:formId}
- *
- * <p>The case DTO embeds the case-type view in one round-trip (architecture.md §Decision 12) so no
- * separate {@code GET /api/case-types/{id}} call is needed here.
  */
 export function FormPage() {
   const { caseId, formId } = useParams<{ caseId: string; formId: string }>();
   const navigate = useNavigate();
 
   const caseQuery = useCase(caseId ?? null);
+  // Hook is always called (rules-of-hooks) — when caseId/formId are absent we still mount but the
+  // GET will 404 fast and AC2/AC3 paths are bypassed by the early returns below.
+  const draft = useFormDraft(caseId ?? '', formId ?? '', caseQuery.data?.caseTypeVersion ?? 0);
 
-  if (caseQuery.isPending) {
+  if (caseQuery.isPending || draft.loading) {
     return (
       <div className="flex items-center justify-center p-8 text-sm text-[var(--muted-foreground)]">
         {t('form.loading')}
@@ -53,20 +61,67 @@ export function FormPage() {
     );
   }
 
+  // AC3 — version mismatch gate. Renderer is NOT mounted with a stale-version draft;
+  // discard-only policy (epics §5.4 AC3, no auto-rebase — Story 3.9 owns that surface).
+  if (draft.isVersionMismatch) {
+    return (
+      <div className="mx-auto max-w-2xl p-6">
+        <Alert role="alert" aria-live="polite" variant="warning">
+          <strong className="block">{t('form.draft.versionChanged.title')}</strong>
+          <span className="mt-1 block">{t('form.draft.versionChanged.body')}</span>
+          <div className="mt-4 flex gap-2">
+            <Button
+              type="button"
+              onClick={() => {
+                void draft.discard().then(() => window.location.reload());
+              }}
+            >
+              {t('form.draft.versionChanged.discardAndUseCurrent')}
+            </Button>
+            <Button type="button" variant="ghost" onClick={() => navigate(`/cases/${caseId}`)}>
+              {t('form.draft.versionChanged.cancel')}
+            </Button>
+          </div>
+        </Alert>
+      </div>
+    );
+  }
+
+  // AC2 — merge draft payload over caseDto.data (draft wins on key collision).
+  const mergedDefaults: Record<string, unknown> | undefined = draft.draft
+    ? { ...(caseDto.data ?? {}), ...draft.draft.payload }
+    : caseDto.data;
+
   // Renderer dispatch — route to MultiSectionFormRenderer for multi-section rendering
   const renderer =
     formDef.rendering === 'multi-section' ? (
       <MultiSectionFormRenderer
         formDefinition={formDef}
         caseId={caseId!}
-        defaultValues={caseDto.data}
+        defaultValues={mergedDefaults}
+        onValuesChange={(values) =>
+          draft.scheduleSave(values, typeof window !== 'undefined' ? window.scrollY : 0, null)
+        }
+        saveDraftAction={{
+          label: t('form.draft.save'),
+          onClick: (values) =>
+            void draft.saveNow(values, typeof window !== 'undefined' ? window.scrollY : 0, null),
+        }}
         onSuccess={() => navigate(`/cases/${caseId}`)}
       />
     ) : (
       <SinglePageFormRenderer
         formDefinition={formDef}
         caseId={caseId!}
-        defaultValues={caseDto.data}
+        defaultValues={mergedDefaults}
+        onValuesChange={(values) =>
+          draft.scheduleSave(values, typeof window !== 'undefined' ? window.scrollY : 0, null)
+        }
+        saveDraftAction={{
+          label: t('form.draft.save'),
+          onClick: (values) =>
+            void draft.saveNow(values, typeof window !== 'undefined' ? window.scrollY : 0, null),
+        }}
         onSuccess={() => navigate(`/cases/${caseId}`)}
       />
     );
@@ -74,6 +129,39 @@ export function FormPage() {
   return (
     <div className="mx-auto max-w-2xl p-6">
       <h1 className="mb-6 text-xl font-semibold">{formDef.id}</h1>
+      {draft.draft ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="mb-4 flex items-center gap-2 text-sm text-[var(--muted-foreground)]"
+        >
+          <span>{t('form.draft.resumed')}</span>
+          <button
+            type="button"
+            className="underline"
+            onClick={() => {
+              void draft.discard().then(() => window.location.reload());
+            }}
+          >
+            {t('form.draft.discard')}
+          </button>
+        </div>
+      ) : null}
+      {draft.saveState === 'saving' ? (
+        <div className="mb-2 text-xs text-[var(--muted-foreground)]" aria-live="polite">
+          {t('form.draft.saving')}
+        </div>
+      ) : null}
+      {draft.saveState === 'saved' ? (
+        <div className="mb-2 text-xs text-[var(--muted-foreground)]" aria-live="polite">
+          {t('form.draft.saved')}
+        </div>
+      ) : null}
+      {draft.saveState === 'error' ? (
+        <div className="mb-2 text-xs text-[var(--destructive)]" aria-live="polite">
+          {t('form.draft.error')}
+        </div>
+      ) : null}
       {renderer}
     </div>
   );


### PR DESCRIPTION
## Summary

Story 5.4 — auto-save form drafts on field change, resume from where the user left off, and gate the renderer when the case-type version has changed since the draft was saved.

- **AC-0** — `CaseTypeConfig` domain record: removed the 9-arg + 10-arg backward-compat constructors, added a canonical `Builder`, migrated the affected test call sites.
- **AC1** — debounced auto-save (≥500 ms) on field changes via `useFormDraft.scheduleSave`; explicit `Save Draft` ghost button next to Submit calls `saveNow` (bypasses debounce). Overlapping schedules collapse to a single in-flight PUT; the latest values win.
- **AC2** — when a draft exists with a matching version, `FormPage` merges the draft's `payload` over `caseDto.data` (draft wins on collisions) and renders a `Resumed your saved draft` banner with a `Discard draft` link.
- **AC3** — when the draft's `caseTypeVersionAtSave` differs from `caseDto.caseTypeVersion`, the renderer is NOT mounted; instead an inline `Alert role="alert" aria-live="polite"` prompts to discard (and use the current form) or cancel back to the case. Frozen-on-version policy per epics §5.4 — no auto-rebase (Story 3.9's surface).
- **AC4** — `FormDraftExpirationJob` (`@Scheduled` cron, default `0 0 3 * * *`) deletes drafts older than `wks.form.draft.ttl-days` (default 30); each deleted row publishes a `FormDraftExpired` domain event before the batch delete.
- **AC5** — `form_drafts` table has `UNIQUE(case_id, form_id, user_id)`; the only repository read accessor is scoped to all three columns. Cross-user IT confirms user B cannot read user A's draft (404).
- **AC6** — successful `submit` deletes the draft after `caseService.submitForm` returns; validation/business failures throw before the deletion runs, preserving the draft.

No new `WKS-*` error codes; standard 404/422 cover failure modes (per memory `feedback_error_codes_are_wire_contract.md`).

## Surface

**Backend** — Flyway `V202605080001__form_drafts.sql`, `FormDraft` domain record + `FormDraftRepository` port, `FormDraftRepositoryAdapter` (JPA), `FormDraftEntity` + `FormDraftJpaRepository`, `FormDraftService`, `FormDraftController` (`GET / PUT / DELETE /api/cases/{caseId}/forms/{formId}/draft`), `FormDraftExpirationJob`, `FormDraftExpired` event, `wks.form.draft.*` config keys, `FormController.submit` extension. Tests: `FormDraftServiceTest`, `FormDraftExpirationJobTest`, `FormDraftIT` (CRUD roundtrip + cross-user isolation + submit deletion + expiration).

**Frontend** — `api/drafts.ts`, `useFormDraft` hook, `FormPage` (gate + resume banner + version-changed alert), additive props on `SinglePageFormRenderer` and `MultiSectionFormRenderer` (`onValuesChange`, `saveDraftAction`), 10 new `form.draft.*` i18n keys. Tests: `useFormDraft.test.ts` (initial GET, version mismatch, debounce, in-flight collapse, saveNow, discard).

## Test plan

- [x] `cd backend && rm -f data/wksplatform.mv.db && ./mvnw -B -ntp verify` (BUILD SUCCESS — 142 tests, 0 failures)
- [x] `./backend/.ci/check-tenant-invariant.sh` (OK)
- [x] `cd frontend && npm ci && npm run lint && npm run format:check && npm test && npm run build` (293 tests pass, lint/format/build clean, 4 woff2 in dist)
- [ ] Manual: open a long form, type into a field, watch the `Saving draft…` indicator → reload the page, confirm `Resumed your saved draft.` banner and field values restored
- [ ] Manual: bump the case-type version of a case with a saved draft, reopen the form, confirm the version-changed `Alert` blocks the renderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>