### PR TITLE
feat(3-8): Blast-Radius Validator & Mutate-Class Version Bump Enforcement

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
@@ -91,10 +91,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     MDC.put(MDC_KEY, ex.getCode());
     try {
       log.warn("Configuration invalid: {} ({} error(s))", ex.getCode(), ex.getErrors().size());
+      java.util.Map<String, Object> meta =
+          ex.getMeta() != null ? ex.getMeta() : java.util.Map.of();
       return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
           .body(
-              ApiResponse.error(
-                  ErrorPayload.ofAggregate(ex.getCode(), ex.getMessage(), ex.getErrors())));
+              new ApiResponse<>(
+                  null,
+                  ErrorPayload.ofAggregate(ex.getCode(), ex.getMessage(), ex.getErrors()),
+                  meta));
     } finally {
       MDC.remove(MDC_KEY);
     }

--- a/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
@@ -91,8 +91,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     MDC.put(MDC_KEY, ex.getCode());
     try {
       log.warn("Configuration invalid: {} ({} error(s))", ex.getCode(), ex.getErrors().size());
-      java.util.Map<String, Object> meta =
-          ex.getMeta() != null ? ex.getMeta() : java.util.Map.of();
+      java.util.Map<String, Object> meta = ex.getMeta() != null ? ex.getMeta() : java.util.Map.of();
       return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
           .body(
               new ApiResponse<>(

--- a/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
@@ -93,9 +93,9 @@ public class AdminController {
       if (yamlResult.isInvalid()) {
         // Story 3.8 — forward blast-radius meta (if any) into the exception so it surfaces in the
         // ApiResponse.meta field (AC2: meta.blastRadius must be present on WKS-CFG-029 rejections).
-        throw new WksConfigException(yamlResult.errors(), yamlResult.responseMeta().isEmpty()
-            ? null
-            : yamlResult.responseMeta());
+        throw new WksConfigException(
+            yamlResult.errors(),
+            yamlResult.responseMeta().isEmpty() ? null : yamlResult.responseMeta());
       }
       var caseType = yamlResult.config().orElseThrow();
       return ApiResponse.success(
@@ -123,9 +123,8 @@ public class AdminController {
             "BPMN engine deployment failed (WKS-CFG-025) — retry or check engine health");
       }
       // Story 3.8 — forward blast-radius meta (if any)
-      throw new WksConfigException(result.errors(), result.responseMeta().isEmpty()
-          ? null
-          : result.responseMeta());
+      throw new WksConfigException(
+          result.errors(), result.responseMeta().isEmpty() ? null : result.responseMeta());
     }
 
     var caseType = result.caseType().orElseThrow();

--- a/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
@@ -21,6 +21,7 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -67,12 +68,17 @@ public class AdminController {
             content = @Content),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "422",
-            description = "YAML or BPMN validation failed (multi-error envelope)",
+            description =
+                "YAML or BPMN validation failed (multi-error envelope). When the failure code is"
+                    + " WKS-CFG-029 (mutate-class change without bumpVersion), the response"
+                    + " meta.blastRadius field carries the full BlastRadiusReport.",
             content = @Content)
       })
   public ApiResponse<DeployResponseDto> deploy(
       @RequestPart("caseType") MultipartFile caseTypePart,
       @RequestPart(name = "bpmn", required = false) MultipartFile bpmnPart,
+      @RequestParam(name = "bumpVersion", required = false, defaultValue = "false")
+          boolean bumpVersion,
       HttpServletRequest request)
       throws Exception {
     rejectDuplicateParts(request);
@@ -83,9 +89,13 @@ public class AdminController {
     // An attached but empty `bpmn` part is treated the same as absent.
     if (bpmnPart == null || bpmnPart.isEmpty()) {
       ValidationResult yamlResult =
-          configService.validateAndRegister("api-deploy.yaml", yaml, actorEmail);
+          configService.validateAndRegister("api-deploy.yaml", yaml, actorEmail, bumpVersion);
       if (yamlResult.isInvalid()) {
-        throw new WksConfigException(yamlResult.errors());
+        // Story 3.8 — forward blast-radius meta (if any) into the exception so it surfaces in the
+        // ApiResponse.meta field (AC2: meta.blastRadius must be present on WKS-CFG-029 rejections).
+        throw new WksConfigException(yamlResult.errors(), yamlResult.responseMeta().isEmpty()
+            ? null
+            : yamlResult.responseMeta());
       }
       var caseType = yamlResult.config().orElseThrow();
       return ApiResponse.success(
@@ -99,7 +109,7 @@ public class AdminController {
 
     byte[] bpmn = bpmnPart.getBytes();
     String bpmnFilename = bpmnPart.getOriginalFilename();
-    DeployResult result = configService.deploy(yaml, bpmn, bpmnFilename, actorEmail);
+    DeployResult result = configService.deploy(yaml, bpmn, bpmnFilename, actorEmail, bumpVersion);
     if (result.isInvalid()) {
       // P10 — WKS-CFG-025 is an engine-side runtime failure (the input was valid; the engine
       // itself failed), not a client-input quality problem. Map it to HTTP 502 Bad Gateway via
@@ -112,7 +122,10 @@ public class AdminController {
         throw new WksWorkflowEngineException(
             "BPMN engine deployment failed (WKS-CFG-025) — retry or check engine health");
       }
-      throw new WksConfigException(result.errors());
+      // Story 3.8 — forward blast-radius meta (if any)
+      throw new WksConfigException(result.errors(), result.responseMeta().isEmpty()
+          ? null
+          : result.responseMeta());
     }
 
     var caseType = result.caseType().orElseThrow();

--- a/backend/src/main/java/com/wkspower/platform/domain/config/DeployResult.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/DeployResult.java
@@ -55,11 +55,8 @@ public record DeployResult(
     return new DeployResult(errors, Optional.empty(), Optional.empty());
   }
 
-  /**
-   * Story 3.8 — invalid result with response-level metadata (e.g. {@code blastRadius} report).
-   */
-  public static DeployResult invalidWithMeta(
-      List<ErrorDetail> errors, Map<String, Object> meta) {
+  /** Story 3.8 — invalid result with response-level metadata (e.g. {@code blastRadius} report). */
+  public static DeployResult invalidWithMeta(List<ErrorDetail> errors, Map<String, Object> meta) {
     return new DeployResult(errors, Optional.empty(), Optional.empty(), meta);
   }
 

--- a/backend/src/main/java/com/wkspower/platform/domain/config/DeployResult.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/DeployResult.java
@@ -4,20 +4,26 @@ import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.exception.ErrorDetail;
 import com.wkspower.platform.domain.workflow.DeploymentResult;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
  * Outcome of {@code ConfigService.deploy(byte[], byte[])}. Either a non-empty {@code errors}
  * aggregate (YAML, BPMN, or registry/engine failure) OR a successful {@code (caseType, deployment)}
  * pair — never both, never neither.
+ *
+ * <p>Story 3.8 — adds {@link #responseMeta()} to carry blast-radius report metadata on WKS-CFG-029
+ * rejections (AC2: {@code meta.blastRadius} must be present in the error response envelope).
  */
 public record DeployResult(
     List<ErrorDetail> errors,
     Optional<CaseTypeConfig> caseType,
-    Optional<DeploymentResult> deployment) {
+    Optional<DeploymentResult> deployment,
+    Map<String, Object> responseMeta) {
 
   public DeployResult {
     errors = List.copyOf(errors);
+    responseMeta = responseMeta == null ? Map.of() : Map.copyOf(responseMeta);
     boolean ok = caseType.isPresent() && deployment.isPresent();
     boolean failed = !errors.isEmpty();
     if (ok == failed) {
@@ -33,12 +39,28 @@ public record DeployResult(
     }
   }
 
+  /** Backward-compat 3-arg constructor — defaults {@link #responseMeta()} to empty map. */
+  public DeployResult(
+      List<ErrorDetail> errors,
+      Optional<CaseTypeConfig> caseType,
+      Optional<DeploymentResult> deployment) {
+    this(errors, caseType, deployment, null);
+  }
+
   public static DeployResult ok(CaseTypeConfig caseType, DeploymentResult deployment) {
     return new DeployResult(List.of(), Optional.of(caseType), Optional.of(deployment));
   }
 
   public static DeployResult invalid(List<ErrorDetail> errors) {
     return new DeployResult(errors, Optional.empty(), Optional.empty());
+  }
+
+  /**
+   * Story 3.8 — invalid result with response-level metadata (e.g. {@code blastRadius} report).
+   */
+  public static DeployResult invalidWithMeta(
+      List<ErrorDetail> errors, Map<String, Object> meta) {
+    return new DeployResult(errors, Optional.empty(), Optional.empty(), meta);
   }
 
   public boolean isInvalid() {

--- a/backend/src/main/java/com/wkspower/platform/domain/config/ValidationResult.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/ValidationResult.java
@@ -4,6 +4,7 @@ import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.config.model.MappingDefinition;
 import com.wkspower.platform.domain.exception.ErrorDetail;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -22,17 +23,24 @@ import java.util.Optional;
  * value into {@code MappingRegistry} after a successful registry write so the runtime router (Story
  * 4.3) can resolve the active mapping by {@code (caseTypeId, version)}. The slot is optional —
  * older callers and validation-failure paths continue to construct without it.
+ *
+ * <p>Story 3.8 introduces {@link #responseMeta()} — optional metadata to include in the HTTP
+ * response envelope's {@code meta} field. Currently used to carry the {@code blastRadius} report
+ * when the blast-radius gate rejects a mutate-class deploy (AC2). Defaults to {@link Map#of()} for
+ * all callers that don't supply it.
  */
 public record ValidationResult(
     List<ErrorDetail> errors,
     List<ErrorDetail> warnings,
     Optional<CaseTypeConfig> config,
-    Optional<MappingDefinition> mappingDefinition) {
+    Optional<MappingDefinition> mappingDefinition,
+    Map<String, Object> responseMeta) {
 
   public ValidationResult {
     errors = List.copyOf(errors);
     warnings = warnings == null ? List.of() : List.copyOf(warnings);
     mappingDefinition = mappingDefinition == null ? Optional.empty() : mappingDefinition;
+    responseMeta = responseMeta == null ? Map.of() : Map.copyOf(responseMeta);
     if (errors.isEmpty() == config.isEmpty()) {
       throw new IllegalStateException(
           "ValidationResult invariant: exactly one of errors-empty and config-present must hold "
@@ -44,10 +52,19 @@ public record ValidationResult(
     }
   }
 
-  /** Backward-compat 3-arg constructor — defaults {@link #mappingDefinition()} to empty. */
+  /** Backward-compat 4-arg constructor — defaults {@link #responseMeta()} to empty map. */
+  public ValidationResult(
+      List<ErrorDetail> errors,
+      List<ErrorDetail> warnings,
+      Optional<CaseTypeConfig> config,
+      Optional<MappingDefinition> mappingDefinition) {
+    this(errors, warnings, config, mappingDefinition, null);
+  }
+
+  /** Backward-compat 3-arg constructor — defaults {@link #mappingDefinition()} and meta to empty. */
   public ValidationResult(
       List<ErrorDetail> errors, List<ErrorDetail> warnings, Optional<CaseTypeConfig> config) {
-    this(errors, warnings, config, Optional.empty());
+    this(errors, warnings, config, Optional.empty(), null);
   }
 
   public static ValidationResult ok(CaseTypeConfig config) {
@@ -69,6 +86,17 @@ public record ValidationResult(
 
   public static ValidationResult invalid(List<ErrorDetail> errors) {
     return new ValidationResult(errors, List.of(), Optional.empty(), Optional.empty());
+  }
+
+  /**
+   * Story 3.8 — invalid result that also carries response-level metadata (e.g. {@code
+   * blastRadius} report). The metadata is forwarded by the controller to {@link
+   * com.wkspower.platform.domain.exception.WksConfigException#WksConfigException(List, Map)} so
+   * the {@code GlobalExceptionHandler} can include it in {@code ApiResponse.meta}.
+   */
+  public static ValidationResult invalidWithMeta(
+      List<ErrorDetail> errors, Map<String, Object> meta) {
+    return new ValidationResult(errors, List.of(), Optional.empty(), Optional.empty(), meta);
   }
 
   public boolean isInvalid() {

--- a/backend/src/main/java/com/wkspower/platform/domain/config/ValidationResult.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/ValidationResult.java
@@ -61,7 +61,9 @@ public record ValidationResult(
     this(errors, warnings, config, mappingDefinition, null);
   }
 
-  /** Backward-compat 3-arg constructor — defaults {@link #mappingDefinition()} and meta to empty. */
+  /**
+   * Backward-compat 3-arg constructor — defaults {@link #mappingDefinition()} and meta to empty.
+   */
   public ValidationResult(
       List<ErrorDetail> errors, List<ErrorDetail> warnings, Optional<CaseTypeConfig> config) {
     this(errors, warnings, config, Optional.empty(), null);
@@ -89,10 +91,10 @@ public record ValidationResult(
   }
 
   /**
-   * Story 3.8 — invalid result that also carries response-level metadata (e.g. {@code
-   * blastRadius} report). The metadata is forwarded by the controller to {@link
-   * com.wkspower.platform.domain.exception.WksConfigException#WksConfigException(List, Map)} so
-   * the {@code GlobalExceptionHandler} can include it in {@code ApiResponse.meta}.
+   * Story 3.8 — invalid result that also carries response-level metadata (e.g. {@code blastRadius}
+   * report). The metadata is forwarded by the controller to {@link
+   * com.wkspower.platform.domain.exception.WksConfigException#WksConfigException(List, Map)} so the
+   * {@code GlobalExceptionHandler} can include it in {@code ApiResponse.meta}.
    */
   public static ValidationResult invalidWithMeta(
       List<ErrorDetail> errors, Map<String, Object> meta) {

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/BlastRadiusReport.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/BlastRadiusReport.java
@@ -4,9 +4,9 @@ import com.wkspower.platform.domain.config.model.MappingChangeClass;
 import java.util.List;
 
 /**
- * Structured output of {@link CaseTypeDiff#classify}. Contains two segregated lists of change
- * units — append-class deltas (safe, no version bump required) and mutate-class deltas (require
- * {@code bumpVersion=true}).
+ * Structured output of {@link CaseTypeDiff#classify}. Contains two segregated lists of change units
+ * — append-class deltas (safe, no version bump required) and mutate-class deltas (require {@code
+ * bumpVersion=true}).
  *
  * <p><b>Wire shape (stable — Admin UI Story 11.X depends on this):</b>
  *
@@ -19,10 +19,10 @@ import java.util.List;
  * </pre>
  *
  * <p>Jackson's default record serialisation is used — no custom serialiser needed. The {@code
- * changeClass} field is derived from the lists and serialised as a computed getter via the
- * {@link #changeClass()} accessor (Jackson includes it automatically for records when there is a
- * public method with a matching name and no-arg signature, but to be safe it is annotated with
- * {@link com.fasterxml.jackson.annotation.JsonProperty}).
+ * changeClass} field is derived from the lists and serialised as a computed getter via the {@link
+ * #changeClass()} accessor (Jackson includes it automatically for records when there is a public
+ * method with a matching name and no-arg signature, but to be safe it is annotated with {@link
+ * com.fasterxml.jackson.annotation.JsonProperty}).
  */
 public record BlastRadiusReport(List<Delta> appendDeltas, List<Delta> mutateDeltas) {
 
@@ -38,7 +38,9 @@ public record BlastRadiusReport(List<Delta> appendDeltas, List<Delta> mutateDelt
    */
   @com.fasterxml.jackson.annotation.JsonProperty("changeClass")
   public MappingChangeClass changeClass() {
-    return mutateDeltas.isEmpty() ? MappingChangeClass.APPEND_CLASS : MappingChangeClass.MUTATE_CLASS;
+    return mutateDeltas.isEmpty()
+        ? MappingChangeClass.APPEND_CLASS
+        : MappingChangeClass.MUTATE_CLASS;
   }
 
   /** Convenience: {@code true} when at least one mutate-class delta is present. */

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/BlastRadiusReport.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/BlastRadiusReport.java
@@ -1,0 +1,48 @@
+package com.wkspower.platform.domain.config.diff;
+
+import com.wkspower.platform.domain.config.model.MappingChangeClass;
+import java.util.List;
+
+/**
+ * Structured output of {@link CaseTypeDiff#classify}. Contains two segregated lists of change
+ * units — append-class deltas (safe, no version bump required) and mutate-class deltas (require
+ * {@code bumpVersion=true}).
+ *
+ * <p><b>Wire shape (stable — Admin UI Story 11.X depends on this):</b>
+ *
+ * <pre>
+ * {
+ *   "changeClass": "MUTATE_CLASS",
+ *   "appendDeltas": [{"kind":"STATUS_ADDED","path":"/statuses/3/id","description":"..."}],
+ *   "mutateDeltas": [{"kind":"STATUS_REMOVED","path":"/statuses/2/id","description":"status 'rejected' was removed"}]
+ * }
+ * </pre>
+ *
+ * <p>Jackson's default record serialisation is used — no custom serialiser needed. The {@code
+ * changeClass} field is derived from the lists and serialised as a computed getter via the
+ * {@link #changeClass()} accessor (Jackson includes it automatically for records when there is a
+ * public method with a matching name and no-arg signature, but to be safe it is annotated with
+ * {@link com.fasterxml.jackson.annotation.JsonProperty}).
+ */
+public record BlastRadiusReport(List<Delta> appendDeltas, List<Delta> mutateDeltas) {
+
+  public BlastRadiusReport {
+    appendDeltas = List.copyOf(appendDeltas);
+    mutateDeltas = List.copyOf(mutateDeltas);
+  }
+
+  /**
+   * Overall classification: {@link MappingChangeClass#MUTATE_CLASS} when {@code mutateDeltas} is
+   * non-empty, otherwise {@link MappingChangeClass#APPEND_CLASS}. Mirrors {@code
+   * MappingChangeClass} for symmetry with the mapping-layer classifier.
+   */
+  @com.fasterxml.jackson.annotation.JsonProperty("changeClass")
+  public MappingChangeClass changeClass() {
+    return mutateDeltas.isEmpty() ? MappingChangeClass.APPEND_CLASS : MappingChangeClass.MUTATE_CLASS;
+  }
+
+  /** Convenience: {@code true} when at least one mutate-class delta is present. */
+  public boolean isMutateClass() {
+    return !mutateDeltas.isEmpty();
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/CaseTypeDiff.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/CaseTypeDiff.java
@@ -19,7 +19,8 @@ import java.util.Set;
 /**
  * Story 3.8 — pure-function blast-radius classifier for the whole-CaseType diff surface. Given a
  * prior and a candidate {@link CaseTypeConfig}, classifies every detected change as either
- * append-class (safe, no version bump required) or mutate-class (requires {@code bumpVersion=true}).
+ * append-class (safe, no version bump required) or mutate-class (requires {@code
+ * bumpVersion=true}).
  *
  * <p><b>Phase-0 scope (Story 3.8):</b> the following change kinds are intentionally out-of-scope
  * and treated as append-class to avoid false-positive mutate classifications:
@@ -127,16 +128,12 @@ public final class CaseTypeDiff {
         // STATUS_REMOVED
         String path = statusPath(statusId, prevEntry.stageId());
         mutateDeltas.add(
-            new Delta(
-                DeltaKind.STATUS_REMOVED,
-                path,
-                "status '" + statusId + "' was removed"));
+            new Delta(DeltaKind.STATUS_REMOVED, path, "status '" + statusId + "' was removed"));
       } else {
         // Check retarget across stages
         boolean prevScoped = prevEntry.stageId() != null;
         boolean nextScoped = nextEntry.stageId() != null;
-        boolean sameScope =
-            Objects.equals(prevEntry.stageId(), nextEntry.stageId());
+        boolean sameScope = Objects.equals(prevEntry.stageId(), nextEntry.stageId());
 
         if (!sameScope) {
           String fromScope = prevScoped ? "stage '" + prevEntry.stageId() + "'" : "case-type level";
@@ -146,12 +143,7 @@ public final class CaseTypeDiff {
               new Delta(
                   DeltaKind.STATUS_RETARGETED,
                   path,
-                  "status '"
-                      + statusId
-                      + "' was retargeted from "
-                      + fromScope
-                      + " to "
-                      + toScope));
+                  "status '" + statusId + "' was retargeted from " + fromScope + " to " + toScope));
         } else if (prevEntry.terminal() != nextEntry.terminal()) {
           // STATUS_TERMINAL_FLIP (same scope)
           String path = statusPath(statusId, prevEntry.stageId()) + "/terminal";
@@ -305,7 +297,8 @@ public final class CaseTypeDiff {
    * DeltaKind#STAGE_APPENDED} (append). Otherwise, emit mutate-class deltas per detected pattern:
    *
    * <ul>
-   *   <li>New stage whose position shifts an existing stage → {@link DeltaKind#STAGE_INSERTED_MIDDLE}
+   *   <li>New stage whose position shifts an existing stage → {@link
+   *       DeltaKind#STAGE_INSERTED_MIDDLE}
    *   <li>Existing stages reordered or removed → {@link DeltaKind#STAGE_REORDERED}
    * </ul>
    *
@@ -387,10 +380,8 @@ public final class CaseTypeDiff {
     }
 
     // Check if existing stages (present in both) were reordered
-    List<String> commonPrevOrder =
-        prevIds.stream().filter(nextIdSet::contains).toList();
-    List<String> commonNextOrder =
-        nextIds.stream().filter(prevIdSet::contains).toList();
+    List<String> commonPrevOrder = prevIds.stream().filter(nextIdSet::contains).toList();
+    List<String> commonNextOrder = nextIds.stream().filter(prevIdSet::contains).toList();
 
     if (!commonPrevOrder.equals(commonNextOrder)) {
       // The relative order of existing stages changed
@@ -402,12 +393,7 @@ public final class CaseTypeDiff {
               new Delta(
                   DeltaKind.STAGE_REORDERED,
                   "/stages/" + id + "/id",
-                  "stage '"
-                      + id
-                      + "' ordinal changed from "
-                      + prevOrd
-                      + " to "
-                      + nextOrd));
+                  "stage '" + id + "' ordinal changed from " + prevOrd + " to " + nextOrd));
         }
       }
     }
@@ -440,8 +426,8 @@ public final class CaseTypeDiff {
    *   <li>New role → ROLE_ADDED (append)
    * </ul>
    *
-   * <p>Phase-0 scope: existing role permission changes and role removal are not classified as mutate
-   * (tracked for Phase-1).
+   * <p>Phase-0 scope: existing role permission changes and role removal are not classified as
+   * mutate (tracked for Phase-1).
    */
   private static void diffRoles(
       CaseTypeConfig prev,

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/CaseTypeDiff.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/CaseTypeDiff.java
@@ -1,0 +1,562 @@
+package com.wkspower.platform.domain.config.diff;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.MappingChangeClass;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.infrastructure.config.MappingDiff;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Story 3.8 — pure-function blast-radius classifier for the whole-CaseType diff surface. Given a
+ * prior and a candidate {@link CaseTypeConfig}, classifies every detected change as either
+ * append-class (safe, no version bump required) or mutate-class (requires {@code bumpVersion=true}).
+ *
+ * <p><b>Phase-0 scope (Story 3.8):</b> the following change kinds are intentionally out-of-scope
+ * and treated as append-class to avoid false-positive mutate classifications:
+ *
+ * <ul>
+ *   <li>Field option-list edits ({@code options[]} changes on select-type fields)
+ *   <li>Role-permissions edits ({@code permissions[]} changes on existing roles)
+ *   <li>{@code listColumns} reordering
+ *   <li>{@code displayName}-only changes at any level
+ * </ul>
+ *
+ * Phase-1 (Story 3.9+) may tighten any of these. Each omission is documented with a {@code //
+ * Phase-0 scope} comment below.
+ *
+ * <p><b>Stage-list semantics (AC1 boundary):</b>
+ *
+ * <ul>
+ *   <li>If {@code next.stages} strictly extends {@code prev.stages} at the tail — i.e. {@code
+ *       next.size() >= prev.size()} AND {@code next.subList(0, prev.size())} has the same stage ids
+ *       in the same order as {@code prev.stages} — all extra stages emit {@link
+ *       DeltaKind#STAGE_APPENDED} (append-class).
+ *   <li>Otherwise → emit {@link DeltaKind#STAGE_INSERTED_MIDDLE} or {@link
+ *       DeltaKind#STAGE_REORDERED} per detected pattern (mutate-class).
+ * </ul>
+ *
+ * <p><b>Pure static — no Spring beans, no I/O.</b> Mirrors {@link MappingDiff} exactly.
+ */
+public final class CaseTypeDiff {
+
+  private CaseTypeDiff() {}
+
+  /**
+   * Classify every difference between {@code prev} and {@code next} into a {@link
+   * BlastRadiusReport}.
+   *
+   * @param prev the prior validated {@link CaseTypeConfig} (loaded from {@code
+   *     case_type_versions.definition_yaml} via the version registry)
+   * @param next the candidate {@link CaseTypeConfig} being deployed
+   * @param prevMapping the prior {@link MappingDefinition}; use {@link MappingDefinition#empty()}
+   *     when no prior mapping exists
+   * @param nextMapping the candidate {@link MappingDefinition}; use {@link
+   *     MappingDefinition#empty()} for zero-attachment deploys
+   * @return a {@link BlastRadiusReport} containing two lists: {@code appendDeltas} and {@code
+   *     mutateDeltas}
+   */
+  public static BlastRadiusReport classify(
+      CaseTypeConfig prev,
+      CaseTypeConfig next,
+      MappingDefinition prevMapping,
+      MappingDefinition nextMapping) {
+    Objects.requireNonNull(prev, "prev");
+    Objects.requireNonNull(next, "next");
+    Objects.requireNonNull(prevMapping, "prevMapping");
+    Objects.requireNonNull(nextMapping, "nextMapping");
+
+    List<Delta> appendDeltas = new ArrayList<>();
+    List<Delta> mutateDeltas = new ArrayList<>();
+
+    diffStatuses(prev, next, appendDeltas, mutateDeltas);
+    diffFields(prev, next, appendDeltas, mutateDeltas);
+    diffStages(prev, next, appendDeltas, mutateDeltas);
+    diffRoles(prev, next, appendDeltas, mutateDeltas);
+    diffForms(prev, next, appendDeltas, mutateDeltas);
+    diffMapping(prevMapping, nextMapping, appendDeltas, mutateDeltas);
+
+    return new BlastRadiusReport(List.copyOf(appendDeltas), List.copyOf(mutateDeltas));
+  }
+
+  // -------------------------------------------------------------------------
+  // Status diff
+  // -------------------------------------------------------------------------
+
+  /**
+   * Detects status changes across all scopes (case-type-level + every stage-scoped set).
+   *
+   * <p>For each status id seen in prev:
+   *
+   * <ul>
+   *   <li>If absent in next anywhere → STATUS_REMOVED (mutate)
+   *   <li>If present but in a different stage scope → STATUS_RETARGETED (mutate)
+   *   <li>If {@code terminal} flag changed (same scope) → STATUS_TERMINAL_FLIP (mutate)
+   * </ul>
+   *
+   * For each status id seen in next but not in prev → STATUS_ADDED (append).
+   *
+   * <p>Phase-0 scope: {@code displayName} and {@code color} changes are not classified.
+   */
+  private static void diffStatuses(
+      CaseTypeConfig prev,
+      CaseTypeConfig next,
+      List<Delta> appendDeltas,
+      List<Delta> mutateDeltas) {
+
+    // Build flat maps: statusId → (stageId or null for case-type-level, terminal flag)
+    Map<String, StatusEntry> prevStatuses = collectAllStatuses(prev);
+    Map<String, StatusEntry> nextStatuses = collectAllStatuses(next);
+
+    // Check for removals, retargets, and terminal flips
+    for (Map.Entry<String, StatusEntry> e : prevStatuses.entrySet()) {
+      String statusId = e.getKey();
+      StatusEntry prevEntry = e.getValue();
+      StatusEntry nextEntry = nextStatuses.get(statusId);
+
+      if (nextEntry == null) {
+        // STATUS_REMOVED
+        String path = statusPath(statusId, prevEntry.stageId());
+        mutateDeltas.add(
+            new Delta(
+                DeltaKind.STATUS_REMOVED,
+                path,
+                "status '" + statusId + "' was removed"));
+      } else {
+        // Check retarget across stages
+        boolean prevScoped = prevEntry.stageId() != null;
+        boolean nextScoped = nextEntry.stageId() != null;
+        boolean sameScope =
+            Objects.equals(prevEntry.stageId(), nextEntry.stageId());
+
+        if (!sameScope) {
+          String fromScope = prevScoped ? "stage '" + prevEntry.stageId() + "'" : "case-type level";
+          String toScope = nextScoped ? "stage '" + nextEntry.stageId() + "'" : "case-type level";
+          String path = statusPath(statusId, prevEntry.stageId());
+          mutateDeltas.add(
+              new Delta(
+                  DeltaKind.STATUS_RETARGETED,
+                  path,
+                  "status '"
+                      + statusId
+                      + "' was retargeted from "
+                      + fromScope
+                      + " to "
+                      + toScope));
+        } else if (prevEntry.terminal() != nextEntry.terminal()) {
+          // STATUS_TERMINAL_FLIP (same scope)
+          String path = statusPath(statusId, prevEntry.stageId()) + "/terminal";
+          mutateDeltas.add(
+              new Delta(
+                  DeltaKind.STATUS_TERMINAL_FLIP,
+                  path,
+                  "status '"
+                      + statusId
+                      + "' terminal flag changed from "
+                      + prevEntry.terminal()
+                      + " to "
+                      + nextEntry.terminal()));
+        }
+        // Phase-0 scope: displayName + color changes not classified
+      }
+    }
+
+    // Check for new statuses (append)
+    for (Map.Entry<String, StatusEntry> e : nextStatuses.entrySet()) {
+      String statusId = e.getKey();
+      if (!prevStatuses.containsKey(statusId)) {
+        String path = statusPath(statusId, e.getValue().stageId());
+        appendDeltas.add(
+            new Delta(DeltaKind.STATUS_ADDED, path, "status '" + statusId + "' was added"));
+      }
+    }
+  }
+
+  /** Collect all statuses across case-type level and all stage-scoped sets. */
+  private static Map<String, StatusEntry> collectAllStatuses(CaseTypeConfig config) {
+    Map<String, StatusEntry> result = new HashMap<>();
+
+    // Case-type-level statuses (stageId = null)
+    for (StatusDefinition s : config.statuses()) {
+      result.put(s.id(), new StatusEntry(null, s.terminal()));
+    }
+
+    // Stage-scoped statuses
+    for (StageDefinition stage : config.stages()) {
+      if (stage.statuses() != null) {
+        for (StatusDefinition s : stage.statuses()) {
+          // Stage-scoped wins over case-type-level for the same id
+          result.put(s.id(), new StatusEntry(stage.id(), s.terminal()));
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private record StatusEntry(String stageId, boolean terminal) {}
+
+  private static String statusPath(String statusId, String stageId) {
+    if (stageId != null) {
+      return "/stages/" + stageId + "/statuses/" + statusId + "/id";
+    }
+    return "/statuses/" + statusId + "/id";
+  }
+
+  // -------------------------------------------------------------------------
+  // Field diff
+  // -------------------------------------------------------------------------
+
+  /**
+   * Detects field changes.
+   *
+   * <ul>
+   *   <li>Field removed → FIELD_REMOVED (mutate)
+   *   <li>Field type changed → FIELD_RETYPED (mutate)
+   *   <li>Field required-ness changed (same id) → FIELD_REQUIRED_FLIPPED (mutate)
+   *   <li>New field added → FIELD_ADDED (append, regardless of required value)
+   * </ul>
+   *
+   * <p>Phase-0 scope: {@code displayName}, {@code order}, {@code options[]}, and {@code
+   * requiredOnCreate} changes are not classified.
+   */
+  private static void diffFields(
+      CaseTypeConfig prev,
+      CaseTypeConfig next,
+      List<Delta> appendDeltas,
+      List<Delta> mutateDeltas) {
+
+    Map<String, FieldDefinition> prevFields = indexById(prev.fields(), FieldDefinition::id);
+    Map<String, FieldDefinition> nextFields = indexById(next.fields(), FieldDefinition::id);
+
+    for (Map.Entry<String, FieldDefinition> e : prevFields.entrySet()) {
+      String fieldId = e.getKey();
+      FieldDefinition prevField = e.getValue();
+      FieldDefinition nextField = nextFields.get(fieldId);
+
+      if (nextField == null) {
+        // FIELD_REMOVED
+        mutateDeltas.add(
+            new Delta(
+                DeltaKind.FIELD_REMOVED,
+                "/fields/" + fieldId + "/id",
+                "field '" + fieldId + "' was removed"));
+      } else {
+        // FIELD_RETYPED
+        if (prevField.type() != nextField.type()) {
+          mutateDeltas.add(
+              new Delta(
+                  DeltaKind.FIELD_RETYPED,
+                  "/fields/" + fieldId + "/type",
+                  "field '"
+                      + fieldId
+                      + "' type changed from "
+                      + prevField.type()
+                      + " to "
+                      + nextField.type()));
+        }
+        // FIELD_REQUIRED_FLIPPED
+        if (prevField.required() != nextField.required()) {
+          mutateDeltas.add(
+              new Delta(
+                  DeltaKind.FIELD_REQUIRED_FLIPPED,
+                  "/fields/" + fieldId + "/required",
+                  "field '"
+                      + fieldId
+                      + "' required changed from "
+                      + prevField.required()
+                      + " to "
+                      + nextField.required()));
+        }
+        // Phase-0 scope: displayName, order, options[], requiredOnCreate not classified
+      }
+    }
+
+    // New fields
+    for (String fieldId : nextFields.keySet()) {
+      if (!prevFields.containsKey(fieldId)) {
+        appendDeltas.add(
+            new Delta(
+                DeltaKind.FIELD_ADDED,
+                "/fields/" + fieldId + "/id",
+                "field '" + fieldId + "' was added"));
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Stage diff
+  // -------------------------------------------------------------------------
+
+  /**
+   * Detects stage-list changes.
+   *
+   * <p>Rule: if {@code next.stages} strictly extends {@code prev.stages} at the tail (all prev
+   * stage ids appear in the same order at the head of next), all extra stages emit {@link
+   * DeltaKind#STAGE_APPENDED} (append). Otherwise, emit mutate-class deltas per detected pattern:
+   *
+   * <ul>
+   *   <li>New stage whose position shifts an existing stage → {@link DeltaKind#STAGE_INSERTED_MIDDLE}
+   *   <li>Existing stages reordered or removed → {@link DeltaKind#STAGE_REORDERED}
+   * </ul>
+   *
+   * <p>Phase-0 scope: {@code displayName} changes on existing stages are not classified.
+   */
+  private static void diffStages(
+      CaseTypeConfig prev,
+      CaseTypeConfig next,
+      List<Delta> appendDeltas,
+      List<Delta> mutateDeltas) {
+
+    List<StageDefinition> prevStages = prev.stages();
+    List<StageDefinition> nextStages = next.stages();
+
+    if (prevStages.isEmpty() && nextStages.isEmpty()) {
+      return;
+    }
+
+    // Collect ids for comparison
+    List<String> prevIds = prevStages.stream().map(StageDefinition::id).toList();
+    List<String> nextIds = nextStages.stream().map(StageDefinition::id).toList();
+
+    // Strict tail-extension check
+    boolean isTailExtension = isTailExtension(prevIds, nextIds);
+
+    if (isTailExtension) {
+      // All extra stages at the tail are append-class
+      for (int i = prevIds.size(); i < nextIds.size(); i++) {
+        appendDeltas.add(
+            new Delta(
+                DeltaKind.STAGE_APPENDED,
+                "/stages/" + nextIds.get(i) + "/id",
+                "stage '" + nextIds.get(i) + "' was appended at position " + i));
+      }
+      return;
+    }
+
+    // Not a tail extension — classify the non-trivial changes
+    Set<String> prevIdSet = new HashSet<>(prevIds);
+    Set<String> nextIdSet = new HashSet<>(nextIds);
+
+    // Stages removed from prev
+    for (String id : prevIds) {
+      if (!nextIdSet.contains(id)) {
+        mutateDeltas.add(
+            new Delta(
+                DeltaKind.STAGE_REORDERED,
+                "/stages/" + id + "/id",
+                "stage '" + id + "' was removed"));
+      }
+    }
+
+    // New stages inserted (not at tail)
+    for (int i = 0; i < nextIds.size(); i++) {
+      String id = nextIds.get(i);
+      if (!prevIdSet.contains(id)) {
+        // Determine if this is a middle insertion or tail
+        // If i < prevIds.size() it is definitely a middle insertion
+        if (i < prevIds.size()) {
+          mutateDeltas.add(
+              new Delta(
+                  DeltaKind.STAGE_INSERTED_MIDDLE,
+                  "/stages/" + id + "/id",
+                  "stage '"
+                      + id
+                      + "' was inserted at position "
+                      + i
+                      + " (middle insertion shifts existing stage ordinals)"));
+        } else {
+          // Logically at the tail, but we already know it's not a pure tail extension
+          // because the prefix didn't match — still append-class for this particular stage
+          appendDeltas.add(
+              new Delta(
+                  DeltaKind.STAGE_APPENDED,
+                  "/stages/" + id + "/id",
+                  "stage '" + id + "' was appended"));
+        }
+      }
+    }
+
+    // Check if existing stages (present in both) were reordered
+    List<String> commonPrevOrder =
+        prevIds.stream().filter(nextIdSet::contains).toList();
+    List<String> commonNextOrder =
+        nextIds.stream().filter(prevIdSet::contains).toList();
+
+    if (!commonPrevOrder.equals(commonNextOrder)) {
+      // The relative order of existing stages changed
+      for (String id : commonPrevOrder) {
+        int prevOrd = prevIds.indexOf(id);
+        int nextOrd = nextIds.indexOf(id);
+        if (prevOrd != nextOrd) {
+          mutateDeltas.add(
+              new Delta(
+                  DeltaKind.STAGE_REORDERED,
+                  "/stages/" + id + "/id",
+                  "stage '"
+                      + id
+                      + "' ordinal changed from "
+                      + prevOrd
+                      + " to "
+                      + nextOrd));
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns {@code true} iff {@code next} starts with all elements of {@code prev} in the same
+   * order (allowing {@code next} to have additional elements at the tail).
+   */
+  private static boolean isTailExtension(List<String> prev, List<String> next) {
+    if (next.size() < prev.size()) {
+      return false;
+    }
+    for (int i = 0; i < prev.size(); i++) {
+      if (!prev.get(i).equals(next.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // -------------------------------------------------------------------------
+  // Role diff
+  // -------------------------------------------------------------------------
+
+  /**
+   * Detects role additions.
+   *
+   * <ul>
+   *   <li>New role → ROLE_ADDED (append)
+   * </ul>
+   *
+   * <p>Phase-0 scope: existing role permission changes and role removal are not classified as mutate
+   * (tracked for Phase-1).
+   */
+  private static void diffRoles(
+      CaseTypeConfig prev,
+      CaseTypeConfig next,
+      List<Delta> appendDeltas,
+      List<Delta> mutateDeltas) {
+
+    Set<String> prevRoles = new HashSet<>();
+    for (RoleDefinition r : prev.roles()) {
+      prevRoles.add(r.name());
+    }
+
+    for (RoleDefinition r : next.roles()) {
+      if (!prevRoles.contains(r.name())) {
+        appendDeltas.add(
+            new Delta(
+                DeltaKind.ROLE_ADDED,
+                "/roles/" + r.name() + "/name",
+                "role '" + r.name() + "' was added"));
+      }
+    }
+    // Phase-0 scope: role removal and permission changes not classified
+  }
+
+  // -------------------------------------------------------------------------
+  // Form diff
+  // -------------------------------------------------------------------------
+
+  /**
+   * Detects form additions.
+   *
+   * <ul>
+   *   <li>New form → FORM_ADDED (append)
+   * </ul>
+   *
+   * <p>Phase-0 scope: form removal and content changes are not classified as mutate.
+   */
+  private static void diffForms(
+      CaseTypeConfig prev,
+      CaseTypeConfig next,
+      List<Delta> appendDeltas,
+      List<Delta> mutateDeltas) {
+
+    Set<String> prevForms = new HashSet<>();
+    for (FormDefinition f : prev.forms()) {
+      prevForms.add(f.id());
+    }
+
+    for (FormDefinition f : next.forms()) {
+      if (!prevForms.contains(f.id())) {
+        appendDeltas.add(
+            new Delta(
+                DeltaKind.FORM_ADDED,
+                "/forms/" + f.id() + "/id",
+                "form '" + f.id() + "' was added"));
+      }
+    }
+    // Phase-0 scope: form removal and changes not classified
+  }
+
+  // -------------------------------------------------------------------------
+  // Mapping diff (delegate to MappingDiff)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Delegates to {@link MappingDiff#classify} and folds the result into the report.
+   *
+   * <ul>
+   *   <li>{@code MUTATE_CLASS} → adds a single {@link DeltaKind#MAPPING} delta to mutate list
+   *   <li>{@code APPEND_CLASS} with actual change → adds a {@link DeltaKind#MAPPING_APPEND} delta
+   *       to append list
+   *   <li>Empty-to-empty → no delta emitted
+   * </ul>
+   */
+  private static void diffMapping(
+      MappingDefinition prev,
+      MappingDefinition next,
+      List<Delta> appendDeltas,
+      List<Delta> mutateDeltas) {
+
+    MappingChangeClass result = MappingDiff.classify(prev, next);
+
+    if (result == MappingChangeClass.MUTATE_CLASS) {
+      mutateDeltas.add(
+          new Delta(
+              DeltaKind.MAPPING,
+              "/attachments",
+              "BPMN mapping change requires version bump (MappingDiff returned MUTATE_CLASS)"));
+    } else if (result == MappingChangeClass.APPEND_CLASS) {
+      // Only emit a delta if there was an actual change (i.e. next is different from prev)
+      if (!prev.attachments().equals(next.attachments())) {
+        appendDeltas.add(
+            new Delta(
+                DeltaKind.MAPPING_APPEND,
+                "/attachments",
+                "BPMN mapping additive change (MappingDiff returned APPEND_CLASS)"));
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Utilities
+  // -------------------------------------------------------------------------
+
+  @FunctionalInterface
+  private interface IdExtractor<T> {
+    String id(T item);
+  }
+
+  private static <T> Map<String, T> indexById(List<T> items, IdExtractor<T> extractor) {
+    Map<String, T> result = new HashMap<>();
+    for (T item : items) {
+      result.put(extractor.id(item), item);
+    }
+    return result;
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/CaseTypeDiff.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/CaseTypeDiff.java
@@ -8,7 +8,6 @@ import com.wkspower.platform.domain.config.model.MappingDefinition;
 import com.wkspower.platform.domain.config.model.RoleDefinition;
 import com.wkspower.platform.domain.config.model.StageDefinition;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
-import com.wkspower.platform.infrastructure.config.MappingDiff;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/Delta.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/Delta.java
@@ -1,0 +1,16 @@
+package com.wkspower.platform.domain.config.diff;
+
+/**
+ * Single change unit inside a {@link BlastRadiusReport}. Immutable record — Jackson serialises it
+ * by default using record component names.
+ *
+ * <p><b>Wire shape:</b>
+ *
+ * <pre>
+ * { "kind": "STATUS_REMOVED", "path": "/statuses/2/id", "description": "status 'rejected' was removed" }
+ * </pre>
+ *
+ * <p>{@code path} follows JSON-pointer-style notation already used by {@code ConfigValidator} (e.g.
+ * {@code /statuses/2/id}, {@code /fields/4/required}, {@code /stages/1/statuses/0/id}).
+ */
+public record Delta(DeltaKind kind, String path, String description) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/DeltaKind.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/DeltaKind.java
@@ -1,14 +1,14 @@
 package com.wkspower.platform.domain.config.diff;
 
 /**
- * Discriminant for a single change unit inside a {@link BlastRadiusReport}. Mutate-class kinds
- * (the ones that require a CaseType version bump per Decision 20) are grouped first; append-class
- * kinds follow.
+ * Discriminant for a single change unit inside a {@link BlastRadiusReport}. Mutate-class kinds (the
+ * ones that require a CaseType version bump per Decision 20) are grouped first; append-class kinds
+ * follow.
  *
- * <p><b>Phase-0 scope (Story 3.8):</b> field option-list edits, role-permissions edits,
- * listColumns reordering, and displayName-only changes are intentionally NOT represented here.
- * {@link com.wkspower.platform.domain.config.diff.CaseTypeDiff} classifies these as append-class
- * (no false-positive mutate). Phase-1 may add new kinds to tighten any of these.
+ * <p><b>Phase-0 scope (Story 3.8):</b> field option-list edits, role-permissions edits, listColumns
+ * reordering, and displayName-only changes are intentionally NOT represented here. {@link
+ * com.wkspower.platform.domain.config.diff.CaseTypeDiff} classifies these as append-class (no
+ * false-positive mutate). Phase-1 may add new kinds to tighten any of these.
  *
  * <p><b>Wire contract:</b> these enum names are serialised by Jackson as-is into the {@code
  * meta.blastRadius} payload (see {@link BlastRadiusReport} javadoc). Never rename an existing
@@ -73,8 +73,8 @@ public enum DeltaKind {
   FORM_ADDED,
 
   /**
-   * The mapping layer returned {@code APPEND_CLASS}. Folded into {@code appendDeltas}. Only
-   * emitted when the mapping changed at all (empty-to-empty produces no delta).
+   * The mapping layer returned {@code APPEND_CLASS}. Folded into {@code appendDeltas}. Only emitted
+   * when the mapping changed at all (empty-to-empty produces no delta).
    */
   MAPPING_APPEND
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/DeltaKind.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/DeltaKind.java
@@ -50,7 +50,7 @@ public enum DeltaKind {
   STAGE_INSERTED_MIDDLE,
 
   /**
-   * The mapping layer ({@link com.wkspower.platform.infrastructure.config.MappingDiff}) returned
+   * The mapping layer ({@link com.wkspower.platform.domain.config.diff.MappingDiff}) returned
    * {@code MUTATE_CLASS}. Folded into this report's {@code mutateDeltas} list.
    */
   MAPPING,

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/DeltaKind.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/DeltaKind.java
@@ -1,0 +1,80 @@
+package com.wkspower.platform.domain.config.diff;
+
+/**
+ * Discriminant for a single change unit inside a {@link BlastRadiusReport}. Mutate-class kinds
+ * (the ones that require a CaseType version bump per Decision 20) are grouped first; append-class
+ * kinds follow.
+ *
+ * <p><b>Phase-0 scope (Story 3.8):</b> field option-list edits, role-permissions edits,
+ * listColumns reordering, and displayName-only changes are intentionally NOT represented here.
+ * {@link com.wkspower.platform.domain.config.diff.CaseTypeDiff} classifies these as append-class
+ * (no false-positive mutate). Phase-1 may add new kinds to tighten any of these.
+ *
+ * <p><b>Wire contract:</b> these enum names are serialised by Jackson as-is into the {@code
+ * meta.blastRadius} payload (see {@link BlastRadiusReport} javadoc). Never rename an existing
+ * constant — that is a breaking wire change.
+ */
+public enum DeltaKind {
+
+  // ---- mutate-class -------------------------------------------------------
+
+  /** A status present in prev is absent in next (any scope). */
+  STATUS_REMOVED,
+
+  /** A status was moved from one stage's scope to a different stage's scope. */
+  STATUS_RETARGETED,
+
+  /** The {@code terminal} flag on a status (same id, same stage scope) was changed. */
+  STATUS_TERMINAL_FLIP,
+
+  /** A field present in prev is absent in next. */
+  FIELD_REMOVED,
+
+  /** A field's {@code type} changed (e.g. TEXT → NUMBER). */
+  FIELD_RETYPED,
+
+  /** A field's {@code required} flag changed (same id). */
+  FIELD_REQUIRED_FLIPPED,
+
+  /**
+   * A stage was removed, or two or more stages were reordered in a non-tail-append pattern. Covers
+   * both pure removal and reordering that alters ordinal positions of existing stages.
+   */
+  STAGE_REORDERED,
+
+  /**
+   * A new stage was inserted in the middle of the existing stage list (i.e. the new stage does not
+   * appear at the tail). Insertion in the middle shifts ordinals of existing stages which is a
+   * mutate-class change because in-flight cases carry a pinned stage ordinal.
+   */
+  STAGE_INSERTED_MIDDLE,
+
+  /**
+   * The mapping layer ({@link com.wkspower.platform.infrastructure.config.MappingDiff}) returned
+   * {@code MUTATE_CLASS}. Folded into this report's {@code mutateDeltas} list.
+   */
+  MAPPING,
+
+  // ---- append-class -------------------------------------------------------
+
+  /** A new status was added (case-type level or stage-scoped). */
+  STATUS_ADDED,
+
+  /** A new field was added (regardless of {@code required} value). */
+  FIELD_ADDED,
+
+  /** A new stage was appended at the tail of the stage list (safe — no ordinal shift). */
+  STAGE_APPENDED,
+
+  /** A new role was added. */
+  ROLE_ADDED,
+
+  /** A new form was added. */
+  FORM_ADDED,
+
+  /**
+   * The mapping layer returned {@code APPEND_CLASS}. Folded into {@code appendDeltas}. Only
+   * emitted when the mapping changed at all (empty-to-empty produces no delta).
+   */
+  MAPPING_APPEND
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/MappingDiff.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/MappingDiff.java
@@ -1,4 +1,4 @@
-package com.wkspower.platform.infrastructure.config;
+package com.wkspower.platform.domain.config.diff;
 
 import com.wkspower.platform.domain.config.model.AttachmentDefinition;
 import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule;
@@ -18,10 +18,13 @@ import java.util.Set;
  * version bump) or {@link MappingChangeClass#MUTATE_CLASS} (something existing was modified or
  * removed — version bump required per D20).
  *
- * <p><b>NOT WIRED INTO DEPLOY GATING IN THIS STORY.</b> Story 3.8's blast-radius validator imports
- * this helper and emits {@link com.wkspower.platform.domain.exception.ErrorCode#WKS_CFG_029} when
- * {@link #classify} returns {@code MUTATE_CLASS} and the deployer did not supply {@code --bump}.
- * 4.2 ships unit tests only; 3.8 wires the call site.
+ * <p><b>NOT WIRED INTO DEPLOY GATING IN THIS STORY.</b> Story 3.8's blast-radius validator
+ * ({@link CaseTypeDiff}) imports this helper and emits {@link
+ * com.wkspower.platform.domain.exception.ErrorCode#WKS_CFG_029} when {@link #classify} returns
+ * {@code MUTATE_CLASS} and the deployer did not supply {@code --bump}. 4.2 shipped unit tests
+ * only; 3.8 wired the call site. Moved to {@code domain/config/diff/} in Story 3.8 so that
+ * {@link CaseTypeDiff} (a domain class) can import it without violating the hexagonal layering
+ * rule (domain must not depend on infrastructure).
  *
  * <h2>Classification rules</h2>
  *

--- a/backend/src/main/java/com/wkspower/platform/domain/config/diff/MappingDiff.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/diff/MappingDiff.java
@@ -18,13 +18,13 @@ import java.util.Set;
  * version bump) or {@link MappingChangeClass#MUTATE_CLASS} (something existing was modified or
  * removed — version bump required per D20).
  *
- * <p><b>NOT WIRED INTO DEPLOY GATING IN THIS STORY.</b> Story 3.8's blast-radius validator
- * ({@link CaseTypeDiff}) imports this helper and emits {@link
+ * <p><b>NOT WIRED INTO DEPLOY GATING IN THIS STORY.</b> Story 3.8's blast-radius validator ({@link
+ * CaseTypeDiff}) imports this helper and emits {@link
  * com.wkspower.platform.domain.exception.ErrorCode#WKS_CFG_029} when {@link #classify} returns
- * {@code MUTATE_CLASS} and the deployer did not supply {@code --bump}. 4.2 shipped unit tests
- * only; 3.8 wired the call site. Moved to {@code domain/config/diff/} in Story 3.8 so that
- * {@link CaseTypeDiff} (a domain class) can import it without violating the hexagonal layering
- * rule (domain must not depend on infrastructure).
+ * {@code MUTATE_CLASS} and the deployer did not supply {@code --bump}. 4.2 shipped unit tests only;
+ * 3.8 wired the call site. Moved to {@code domain/config/diff/} in Story 3.8 so that {@link
+ * CaseTypeDiff} (a domain class) can import it without violating the hexagonal layering rule
+ * (domain must not depend on infrastructure).
  *
  * <h2>Classification rules</h2>
  *

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -137,12 +137,18 @@ public enum ErrorCode {
    */
   WKS_CFG_028("WKS-CFG-028"),
   /**
-   * Mapping-class change requires a CaseType version bump (Story 4.2 AC2 / architecture §833 / D20
-   * cross-ref). RESERVED in Story 4.2 — emitted by Story 3.8's blast-radius validator when {@link
-   * com.wkspower.platform.infrastructure.config.MappingDiff#classify} returns {@code
-   * MappingChangeClass.MUTATE_CLASS} and the deployer did not supply {@code --bump}. {@code
-   * MappingValidator} does not emit this code; the constant exists here so 3.8 can reference it
-   * without re-allocating.
+   * Mutate-class CaseType change attempted without supplying {@code bumpVersion=true} (Story 3.8).
+   *
+   * <p>Story 3.8 emission site: {@code ConfigService.validateAndRegister} and {@code
+   * ConfigService.deploy} invoke {@link
+   * com.wkspower.platform.domain.config.diff.CaseTypeDiff#classify}; this code is emitted when
+   * {@code mutateDeltas} is non-empty and {@code bumpVersion=true} was not supplied on the deploy
+   * request. The response envelope's {@code meta.blastRadius} field carries the full {@link
+   * com.wkspower.platform.domain.config.diff.BlastRadiusReport} for Admin UI rendering.
+   *
+   * <p>{@code MappingValidator} does not emit this code — the constant was reserved in Story 4.2 as
+   * a cross-reference anchor; Story 3.8 is the first emission site. Wire string is {@code
+   * WKS-CFG-029} — stable contract.
    */
   WKS_CFG_029("WKS-CFG-029"),
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -152,6 +152,20 @@ public enum ErrorCode {
    */
   WKS_CFG_029("WKS-CFG-029"),
   /**
+   * Blast-radius gate could not load or re-parse the prior {@code
+   * case_type_versions.definition_yaml} for a CaseType whose {@code currentVersion()} is present
+   * (Story 3.8 PR #417 follow-up).
+   *
+   * <p>Emitted by {@code ConfigService.runBlastRadiusGate} when the prior YAML row is missing, has
+   * null bytes, or fails to re-parse — any state in which the AC2 invariant ("the gate applies on
+   * every deploy that has a prior version") cannot be honored. The deploy is rejected fail-closed
+   * rather than silently bypassing the classifier.
+   *
+   * <p>Wire string is {@code WKS-CFG-030} — stable contract; do not reuse for another meaning per
+   * the {@code feedback_error_codes_are_wire_contract.md} memory.
+   */
+  WKS_CFG_030("WKS-CFG-030"),
+  /**
    * Duplicate stage id within a case-type YAML (Story 3.1 AC1). Deploy-time validator code;
    * surfaces with a {@code stages[i].id} field path.
    */

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/WksConfigException.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/WksConfigException.java
@@ -16,8 +16,8 @@ import java.util.Objects;
  * Story 2.2 (YAML case-type validation + BPMN deploy).
  *
  * <p>Story 3.8 — adds an optional {@code meta} map that the {@code GlobalExceptionHandler} includes
- * in the {@link com.wkspower.platform.api.dto.ApiResponse#meta()} field. Used to carry the
- * {@code blastRadius} report in blast-radius rejection responses (AC2).
+ * in the {@link com.wkspower.platform.api.dto.ApiResponse#meta()} field. Used to carry the {@code
+ * blastRadius} report in blast-radius rejection responses (AC2).
  */
 public class WksConfigException extends WksException {
 

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/WksConfigException.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/WksConfigException.java
@@ -1,6 +1,7 @@
 package com.wkspower.platform.domain.exception;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -13,12 +14,32 @@ import java.util.Objects;
  *
  * <p>Story 1.4 ships only the plumbing and a test-profile probe; the first real producer lands in
  * Story 2.2 (YAML case-type validation + BPMN deploy).
+ *
+ * <p>Story 3.8 — adds an optional {@code meta} map that the {@code GlobalExceptionHandler} includes
+ * in the {@link com.wkspower.platform.api.dto.ApiResponse#meta()} field. Used to carry the
+ * {@code blastRadius} report in blast-radius rejection responses (AC2).
  */
 public class WksConfigException extends WksException {
 
   private final List<ErrorDetail> errors;
 
+  /**
+   * Optional metadata attached to the error response envelope. Null means "no meta" — {@link
+   * com.wkspower.platform.api.GlobalExceptionHandler} will use {@link Map#of()} as the default.
+   */
+  private final Map<String, Object> meta;
+
   public WksConfigException(List<ErrorDetail> errors) {
+    this(errors, null);
+  }
+
+  /**
+   * Story 3.8 — constructor that carries response-level metadata (e.g. {@code blastRadius} report).
+   *
+   * @param errors non-empty aggregate of error details
+   * @param meta optional metadata to include in {@code ApiResponse.meta}; may be {@code null}
+   */
+  public WksConfigException(List<ErrorDetail> errors, Map<String, Object> meta) {
     super(ErrorCode.WKS_CFG_000, "Configuration invalid");
     Objects.requireNonNull(errors, "errors");
     if (errors.isEmpty()) {
@@ -27,9 +48,18 @@ public class WksConfigException extends WksException {
               + "aggregate path is for multi-error failures, never an empty list.");
     }
     this.errors = List.copyOf(errors);
+    this.meta = (meta == null) ? null : Map.copyOf(meta);
   }
 
   public List<ErrorDetail> getErrors() {
     return errors;
+  }
+
+  /**
+   * Returns the response-level meta map, or {@code null} when none was provided. The exception
+   * handler uses {@link Map#of()} when this returns {@code null}.
+   */
+  public Map<String, Object> getMeta() {
+    return meta;
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/port/ExecutionSignalKind.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/ExecutionSignalKind.java
@@ -21,7 +21,7 @@ package com.wkspower.platform.domain.port;
  *
  * <p>Story 4.3.1 AC10 / Option (a) — the legacy {@code USER_TASK_PROPERTY} value collapsed two
  * author-distinguishable shapes ({@code emits.type: status} vs {@code emits.type: task-complete})
- * onto the same enum constant. {@link com.wkspower.platform.infrastructure.config.MappingDiff}
+ * onto the same enum constant. {@link com.wkspower.platform.domain.config.diff.MappingDiff}
  * silently misclassified mutations as APPEND because {@code .equals()} treated them as identical.
  * The split into {@link #TASK_STATUS_CHANGED} and {@link #TASK_COMPLETED} makes the type system the
  * enforcer — every callsite that branches on the user-task family must opt into a single value,

--- a/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
@@ -271,7 +271,8 @@ public class ConfigService {
 
     MappingDefinition prevMapping =
         mappingRegistry
-            .resolve(new CaseTypeRef(validated.id(), String.valueOf(priorVersionNum)),
+            .resolve(
+                new CaseTypeRef(validated.id(), String.valueOf(priorVersionNum)),
                 String.valueOf(priorVersionNum))
             .orElse(MappingDefinition.empty());
     MappingDefinition nextMapping =
@@ -381,9 +382,7 @@ public class ConfigService {
     return deploy(yamlBytes, bpmnBytes, bpmnFilename, actorEmail, false);
   }
 
-  /**
-   * Story 3.8 — overload that threads {@code bumpRequested} through the blast-radius gate.
-   */
+  /** Story 3.8 — overload that threads {@code bumpRequested} through the blast-radius gate. */
   public DeployResult deploy(
       byte[] yamlBytes,
       byte[] bpmnBytes,
@@ -403,8 +402,8 @@ public class ConfigService {
   }
 
   /**
-   * Story 3.8 — overload that threads {@code bumpRequested} through the blast-radius gate (no
-   * BPMN filename variant — used by startup loader and tests).
+   * Story 3.8 — overload that threads {@code bumpRequested} through the blast-radius gate (no BPMN
+   * filename variant — used by startup loader and tests).
    */
   public DeployResult deploy(
       byte[] yamlBytes, byte[] bpmnBytes, String actorEmail, boolean bumpRequested) {

--- a/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
@@ -260,13 +260,25 @@ public class ConfigService {
       boolean bumpRequested) {
     CaseTypeConfig prev = loadPriorConfig(validated.id(), priorVersionNum);
     if (prev == null) {
-      // Cannot load prior — skip gate (fail-open, don't block deploy)
-      log.warn(
-          "ConfigService: could not load prior config for caseTypeId={} v{} — blast-radius gate"
-              + " skipped",
+      // Story 3.8 PR #417 follow-up — fail CLOSED. AC2 requires the gate to apply on every
+      // deploy with a prior version; if we cannot load or re-parse the prior YAML we cannot
+      // classify the change, and silently bypassing the gate would let mutate-class edits ship
+      // unchecked. Reject with WKS-CFG-030 so the operator can investigate (corrupt row,
+      // missing bytes, schema drift).
+      log.error(
+          "ConfigService.deploy: REJECTED — prior YAML for caseTypeId={} v{} could not be loaded"
+              + " or re-parsed; blast-radius gate cannot apply (fail-closed, WKS-CFG-030)",
           validated.id(),
           priorVersionNum);
-      return null;
+      return ValidationResult.invalid(
+          List.of(
+              ErrorDetail.of(
+                  ErrorCode.WKS_CFG_030.wire(),
+                  "Blast-radius gate could not apply — prior version v"
+                      + priorVersionNum
+                      + " for caseTypeId="
+                      + validated.id()
+                      + " could not be loaded or re-parsed. Deploy rejected fail-closed.")));
     }
 
     MappingDefinition prevMapping =

--- a/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
@@ -5,7 +5,10 @@ import com.wkspower.platform.domain.config.CaseTypeVersionRegistration;
 import com.wkspower.platform.domain.config.DeployResult;
 import com.wkspower.platform.domain.config.RegistrationResult;
 import com.wkspower.platform.domain.config.ValidationResult;
+import com.wkspower.platform.domain.config.diff.BlastRadiusReport;
+import com.wkspower.platform.domain.config.diff.CaseTypeDiff;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.MappingChangeClass;
 import com.wkspower.platform.domain.config.model.MappingDefinition;
 import com.wkspower.platform.domain.event.ConfigDeployed;
 import com.wkspower.platform.domain.exception.ErrorCode;
@@ -31,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,20 +178,52 @@ public class ConfigService {
 
   /** Byte-driven YAML-only variant. Retained for the startup loader's BPMN-missing path. */
   public ValidationResult validateAndRegister(String sourceName, byte[] bytes) {
-    return validateAndRegister(sourceName, bytes, "system:startup");
+    return validateAndRegister(sourceName, bytes, "system:startup", false);
   }
 
   /**
    * Story 3.4 — overload that accepts {@code publishedBy}; threaded from the admin REST surface
    * with the actor email (Spring Security context) and from the startup loader with {@code
-   * "system:startup"}.
+   * "system:startup"}. Defaults {@code bumpRequested=false}.
    */
   public ValidationResult validateAndRegister(String sourceName, byte[] bytes, String publishedBy) {
+    return validateAndRegister(sourceName, bytes, publishedBy, false);
+  }
+
+  /**
+   * Story 3.8 — full overload accepting {@code bumpRequested}. The blast-radius classifier runs
+   * here when a prior version exists; a mutate-class change without {@code bumpRequested=true} is
+   * rejected with {@code WKS-CFG-029}. The existing 2-arg and 3-arg overloads delegate here with
+   * {@code bumpRequested=false}.
+   *
+   * @param bumpRequested {@code true} when the caller explicitly requested a version bump (e.g. via
+   *     {@code ?bumpVersion=true} on the admin deploy endpoint)
+   */
+  public ValidationResult validateAndRegister(
+      String sourceName, byte[] bytes, String publishedBy, boolean bumpRequested) {
     ValidationResult result = this.source.loadBytes(sourceName, bytes);
     if (result.isInvalid() || result.config().isEmpty()) {
       return result;
     }
     CaseTypeConfig validated = result.config().get();
+
+    // Story 3.8 AC2 / AC3 / AC4 — blast-radius gate (runs BEFORE applyVersionRegistry per AC2
+    // ordering invariant: must not touch the engine or any registry before the gate passes).
+    Optional<Integer> priorVersion = versionRegistry.currentVersion(validated.id());
+    if (priorVersion.isPresent()) {
+      ValidationResult gateResult =
+          runBlastRadiusGate(validated, result, priorVersion.get(), bumpRequested);
+      if (gateResult != null) {
+        return gateResult; // Rejected — return the error result
+      }
+    } else if (bumpRequested) {
+      // AC4: first deploy with bumpVersion=true — warn + ignore
+      log.warn(
+          "ConfigService.validateAndRegister: bumpVersion=true ignored for caseTypeId={}"
+              + " — no prior version exists",
+          validated.id());
+    }
+
     CaseTypeConfig versioned = applyVersionRegistry(validated, bytes, publishedBy);
     RegistrationResult reg = registrar.register(versioned);
     if (reg.outcome() == RegistrationResult.Outcome.REJECTED_OLDER_VERSION) {
@@ -207,6 +243,87 @@ public class ConfigService {
             result.mappingDefinition().orElse(MappingDefinition.empty()));
     publishMappingToRegistry(versionedResult);
     return versionedResult;
+  }
+
+  /**
+   * Story 3.8 — run the blast-radius classifier against the prior version. Returns a {@link
+   * ValidationResult#invalid(List) invalid result} when the change is mutate-class and {@code
+   * bumpRequested=false}; returns {@code null} when the gate passes (caller should continue).
+   *
+   * <p>This method does NOT throw — it returns an invalid ValidationResult which the caller must
+   * propagate. This mirrors the existing multi-error pattern in {@code ConfigService}.
+   */
+  private ValidationResult runBlastRadiusGate(
+      CaseTypeConfig validated,
+      ValidationResult yamlResult,
+      int priorVersionNum,
+      boolean bumpRequested) {
+    CaseTypeConfig prev = loadPriorConfig(validated.id(), priorVersionNum);
+    if (prev == null) {
+      // Cannot load prior — skip gate (fail-open, don't block deploy)
+      log.warn(
+          "ConfigService: could not load prior config for caseTypeId={} v{} — blast-radius gate"
+              + " skipped",
+          validated.id(),
+          priorVersionNum);
+      return null;
+    }
+
+    MappingDefinition prevMapping =
+        mappingRegistry
+            .resolve(new CaseTypeRef(validated.id(), String.valueOf(priorVersionNum)),
+                String.valueOf(priorVersionNum))
+            .orElse(MappingDefinition.empty());
+    MappingDefinition nextMapping =
+        yamlResult.mappingDefinition().orElse(MappingDefinition.empty());
+
+    BlastRadiusReport report = CaseTypeDiff.classify(prev, validated, prevMapping, nextMapping);
+
+    if (report.changeClass() == MappingChangeClass.MUTATE_CLASS && !bumpRequested) {
+      String paths =
+          report.mutateDeltas().stream()
+              .map(com.wkspower.platform.domain.config.diff.Delta::path)
+              .limit(5)
+              .collect(Collectors.joining(", "));
+      log.info(
+          "ConfigService.deploy: REJECTED mutate-class without bumpVersion for caseTypeId={}"
+              + " — {} delta(s)",
+          validated.id(),
+          report.mutateDeltas().size());
+      return ValidationResult.invalidWithMeta(
+          List.of(
+              ErrorDetail.of(
+                  ErrorCode.WKS_CFG_029.wire(),
+                  "Mutate-class change requires version bump — "
+                      + report.mutateDeltas().size()
+                      + " delta(s): "
+                      + paths)),
+          Map.of("blastRadius", report));
+    }
+
+    if (bumpRequested) {
+      log.info(
+          "ConfigService.deploy: bumpVersion=true with {} change for caseTypeId={}"
+              + " — version bumped per admin opt-in",
+          report.changeClass(),
+          validated.id());
+    }
+
+    return null; // Gate passed
+  }
+
+  /**
+   * Story 3.8 — load the prior {@link CaseTypeConfig} from the version registry's stored YAML.
+   * Returns {@code null} when the YAML cannot be loaded or re-parsed (fail-open).
+   */
+  private CaseTypeConfig loadPriorConfig(String caseTypeId, int version) {
+    Optional<CaseTypeVersionRecord> record = versionRegistry.findVersion(caseTypeId, version);
+    if (record.isEmpty() || record.get().rawYaml() == null) {
+      return null;
+    }
+    ValidationResult prev =
+        source.loadBytes("prior:" + caseTypeId + ":" + version, record.get().rawYaml());
+    return prev.config().orElse(null);
   }
 
   /**
@@ -261,21 +378,51 @@ public class ConfigService {
    */
   public DeployResult deploy(
       byte[] yamlBytes, byte[] bpmnBytes, String bpmnFilename, String actorEmail) {
+    return deploy(yamlBytes, bpmnBytes, bpmnFilename, actorEmail, false);
+  }
+
+  /**
+   * Story 3.8 — overload that threads {@code bumpRequested} through the blast-radius gate.
+   */
+  public DeployResult deploy(
+      byte[] yamlBytes,
+      byte[] bpmnBytes,
+      String bpmnFilename,
+      String actorEmail,
+      boolean bumpRequested) {
     Map<String, byte[]> bpmnByName =
         (bpmnFilename != null && !bpmnFilename.isBlank() && bpmnBytes != null)
             ? Map.of(bpmnFilename, bpmnBytes)
             : Map.of();
     ValidationResult yamlResult = source.loadBytes("api-deploy.yaml", yamlBytes, bpmnByName);
-    return deployWithYamlResult(yamlResult, yamlBytes, bpmnBytes, actorEmail);
+    return deployWithYamlResult(yamlResult, yamlBytes, bpmnBytes, actorEmail, bumpRequested);
   }
 
   public DeployResult deploy(byte[] yamlBytes, byte[] bpmnBytes, String actorEmail) {
+    return deploy(yamlBytes, bpmnBytes, actorEmail, false);
+  }
+
+  /**
+   * Story 3.8 — overload that threads {@code bumpRequested} through the blast-radius gate (no
+   * BPMN filename variant — used by startup loader and tests).
+   */
+  public DeployResult deploy(
+      byte[] yamlBytes, byte[] bpmnBytes, String actorEmail, boolean bumpRequested) {
     ValidationResult yamlResult = source.loadBytes("api-deploy.yaml", yamlBytes);
-    return deployWithYamlResult(yamlResult, yamlBytes, bpmnBytes, actorEmail);
+    return deployWithYamlResult(yamlResult, yamlBytes, bpmnBytes, actorEmail, bumpRequested);
   }
 
   private DeployResult deployWithYamlResult(
       ValidationResult yamlResult, byte[] yamlBytes, byte[] bpmnBytes, String actorEmail) {
+    return deployWithYamlResult(yamlResult, yamlBytes, bpmnBytes, actorEmail, false);
+  }
+
+  private DeployResult deployWithYamlResult(
+      ValidationResult yamlResult,
+      byte[] yamlBytes,
+      byte[] bpmnBytes,
+      String actorEmail,
+      boolean bumpRequested) {
     CaseTypeConfig caseType = yamlResult.config().orElse(null);
 
     BpmnValidationResult bpmnResult = bpmnValidator.validate(bpmnBytes, caseType);
@@ -290,6 +437,24 @@ public class ConfigService {
         aggregate.add(ErrorDetail.of("WKS-CFG-099", "Case type configuration could not be parsed"));
       }
       return DeployResult.invalid(aggregate);
+    }
+
+    // Story 3.8 AC2 — blast-radius gate. Runs BEFORE fingerprint computation and BEFORE engine
+    // deploy (Story 4.5 AC1 ordering invariant: gate before any side-effect).
+    Optional<Integer> priorVersion = versionRegistry.currentVersion(caseType.id());
+    if (priorVersion.isPresent()) {
+      ValidationResult gateResult =
+          runBlastRadiusGate(caseType, yamlResult, priorVersion.get(), bumpRequested);
+      if (gateResult != null) {
+        // Rejected — propagate meta (blastRadius report) in the DeployResult
+        return DeployResult.invalidWithMeta(gateResult.errors(), gateResult.responseMeta());
+      }
+    } else if (bumpRequested) {
+      // AC4: first deploy with bumpVersion=true — warn + ignore
+      log.warn(
+          "ConfigService.deploy: bumpVersion=true ignored for caseTypeId={} — no prior version"
+              + " exists",
+          caseType.id());
     }
 
     // Story 4.5 AC3 — compute fingerprints BEFORE entering the lock; pure computation, no I/O.

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
@@ -2,6 +2,7 @@ package com.wkspower.platform.api.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -74,7 +75,8 @@ class AdminControllerTest {
     byte[] bpmnBytes = "<x/>".getBytes();
     ArgumentCaptor<byte[]> yamlCap = ArgumentCaptor.forClass(byte[].class);
     ArgumentCaptor<byte[]> bpmnCap = ArgumentCaptor.forClass(byte[].class);
-    when(configService.deploy(yamlCap.capture(), bpmnCap.capture(), any(), eq("admin")))
+    // Story 3.8 — controller now calls the 5-arg deploy overload (adds bumpVersion boolean)
+    when(configService.deploy(yamlCap.capture(), bpmnCap.capture(), any(), eq("admin"), anyBoolean()))
         .thenReturn(DeployResult.ok(config, deployment));
 
     mockMvc
@@ -139,7 +141,7 @@ class AdminControllerTest {
 
   @Test
   void validationFailureReturns422Aggregate() throws Exception {
-    when(configService.deploy(any(), any(), any(), any()))
+    when(configService.deploy(any(), any(), any(), any(), anyBoolean()))
         .thenReturn(
             DeployResult.invalid(
                 List.of(
@@ -167,7 +169,7 @@ class AdminControllerTest {
     // MaxUploadSizeExceededException
     // before reaching the handler chain. We simulate by configuring a tiny part cap via the test
     // and asserting the GlobalExceptionHandler maps the exception to 413 + WKS-API-413.
-    when(configService.deploy(any(), any(), any(), any()))
+    when(configService.deploy(any(), any(), any(), any(), anyBoolean()))
         .thenThrow(new MaxUploadSizeExceededException(1024L));
 
     mockMvc
@@ -181,7 +183,7 @@ class AdminControllerTest {
         .andExpect(status().isPayloadTooLarge())
         .andExpect(jsonPath("$.error.code").value("WKS-API-413"));
 
-    verify(configService).deploy(any(), any(), any(), any());
+    verify(configService).deploy(any(), any(), any(), any(), anyBoolean());
   }
 
   // ---- YAML-only deploy (Story 3.2: zero-process case types) -------------
@@ -203,7 +205,8 @@ class AdminControllerTest {
             List.of(),
             List.of(new RoleDefinition("admin", List.of())));
     byte[] yamlBytes = "id: j9-zero-zero".getBytes();
-    when(configService.validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any()))
+    // Story 3.8 — controller now calls the 4-arg validateAndRegister overload (adds bumpVersion)
+    when(configService.validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean()))
         .thenReturn(ValidationResult.ok(config));
 
     mockMvc
@@ -218,12 +221,12 @@ class AdminControllerTest {
         .andExpect(jsonPath("$.data.processDefinitionId").doesNotExist())
         .andExpect(jsonPath("$.data.schemaUri").value("/api/admin/case-types/j9-zero-zero/schema"));
 
-    verify(configService).validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any());
+    verify(configService).validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean());
   }
 
   @Test
   void missingBpmnPartWithInvalidYamlReturns422() throws Exception {
-    when(configService.validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any()))
+    when(configService.validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean()))
         .thenReturn(
             ValidationResult.invalid(List.of(ErrorDetail.of("WKS-CFG-099", "YAML parse failed"))));
 
@@ -247,5 +250,85 @@ class AdminControllerTest {
                 .file(new MockMultipartFile("bpmn", "p.bpmn", "application/xml", "<x/>".getBytes()))
                 .with(user("admin").roles("ADMIN")))
         .andExpect(status().isBadRequest());
+  }
+
+  // ---- Story 3.8: bumpVersion param threading ----------------------------
+
+  @Test
+  void bumpVersionTrueIsThreadedToDeployService() throws Exception {
+    // Story 3.8 AC3 — ?bumpVersion=true must be forwarded to ConfigService.deploy as bumpRequested=true
+    CaseTypeConfig config =
+        new CaseTypeConfig(
+            "loan-ct", "Loan", 2, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of());
+    DeploymentResult deployment =
+        new DeploymentResult("dep-2", "loanProcess", "procDef-2", 2, Instant.now());
+    byte[] yamlBytes = "id: loan-ct".getBytes();
+    byte[] bpmnBytes = "<bpmn/>".getBytes();
+
+    ArgumentCaptor<Boolean> bumpCap = ArgumentCaptor.forClass(Boolean.class);
+    when(configService.deploy(any(), any(), any(), any(), bumpCap.capture()))
+        .thenReturn(DeployResult.ok(config, deployment));
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(new MockMultipartFile("caseType", "ct.yaml", "text/plain", yamlBytes))
+                .file(new MockMultipartFile("bpmn", "p.bpmn", "application/xml", bpmnBytes))
+                .param("bumpVersion", "true")
+                .with(user("admin").roles("ADMIN")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.caseTypeId").value("loan-ct"));
+
+    assertThat(bumpCap.getValue()).isTrue();
+  }
+
+  @Test
+  void bumpVersionFalseByDefault() throws Exception {
+    // Story 3.8 — bumpVersion defaults to false when not supplied
+    CaseTypeConfig config =
+        new CaseTypeConfig("loan-ct", "Loan", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of());
+    DeploymentResult deployment =
+        new DeploymentResult("dep-1", "loanProcess", "procDef-1", 1, Instant.now());
+
+    ArgumentCaptor<Boolean> bumpCap = ArgumentCaptor.forClass(Boolean.class);
+    when(configService.deploy(any(), any(), any(), any(), bumpCap.capture()))
+        .thenReturn(DeployResult.ok(config, deployment));
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(new MockMultipartFile("caseType", "ct.yaml", "text/plain", "id: loan-ct".getBytes()))
+                .file(new MockMultipartFile("bpmn", "p.bpmn", "application/xml", "<bpmn/>".getBytes()))
+                .with(user("admin").roles("ADMIN")))
+        .andExpect(status().isOk());
+
+    assertThat(bumpCap.getValue()).isFalse();
+  }
+
+  @Test
+  void bumpVersionTrueIsThreadedToValidateAndRegister() throws Exception {
+    // Story 3.8 — ?bumpVersion=true forwarded on YAML-only (no BPMN) path
+    CaseTypeConfig config =
+        new CaseTypeConfig("yaml-only-ct", "YAML Only", 2, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of());
+
+    ArgumentCaptor<Boolean> bumpCap = ArgumentCaptor.forClass(Boolean.class);
+    when(configService.validateAndRegister(any(), any(), any(), bumpCap.capture()))
+        .thenReturn(ValidationResult.ok(config));
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(new MockMultipartFile("caseType", "ct.yaml", "text/plain", "id: yaml-only-ct".getBytes()))
+                .param("bumpVersion", "true")
+                .with(user("admin").roles("ADMIN")))
+        .andExpect(status().isOk());
+
+    assertThat(bumpCap.getValue()).isTrue();
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
@@ -76,7 +76,8 @@ class AdminControllerTest {
     ArgumentCaptor<byte[]> yamlCap = ArgumentCaptor.forClass(byte[].class);
     ArgumentCaptor<byte[]> bpmnCap = ArgumentCaptor.forClass(byte[].class);
     // Story 3.8 — controller now calls the 5-arg deploy overload (adds bumpVersion boolean)
-    when(configService.deploy(yamlCap.capture(), bpmnCap.capture(), any(), eq("admin"), anyBoolean()))
+    when(configService.deploy(
+            yamlCap.capture(), bpmnCap.capture(), any(), eq("admin"), anyBoolean()))
         .thenReturn(DeployResult.ok(config, deployment));
 
     mockMvc
@@ -206,7 +207,8 @@ class AdminControllerTest {
             List.of(new RoleDefinition("admin", List.of())));
     byte[] yamlBytes = "id: j9-zero-zero".getBytes();
     // Story 3.8 — controller now calls the 4-arg validateAndRegister overload (adds bumpVersion)
-    when(configService.validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean()))
+    when(configService.validateAndRegister(
+            eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean()))
         .thenReturn(ValidationResult.ok(config));
 
     mockMvc
@@ -221,12 +223,14 @@ class AdminControllerTest {
         .andExpect(jsonPath("$.data.processDefinitionId").doesNotExist())
         .andExpect(jsonPath("$.data.schemaUri").value("/api/admin/case-types/j9-zero-zero/schema"));
 
-    verify(configService).validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean());
+    verify(configService)
+        .validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean());
   }
 
   @Test
   void missingBpmnPartWithInvalidYamlReturns422() throws Exception {
-    when(configService.validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean()))
+    when(configService.validateAndRegister(
+            eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean()))
         .thenReturn(
             ValidationResult.invalid(List.of(ErrorDetail.of("WKS-CFG-099", "YAML parse failed"))));
 
@@ -256,12 +260,19 @@ class AdminControllerTest {
 
   @Test
   void bumpVersionTrueIsThreadedToDeployService() throws Exception {
-    // Story 3.8 AC3 — ?bumpVersion=true must be forwarded to ConfigService.deploy as bumpRequested=true
+    // Story 3.8 AC3 — ?bumpVersion=true must be forwarded to ConfigService.deploy as
+    // bumpRequested=true
     CaseTypeConfig config =
         new CaseTypeConfig(
-            "loan-ct", "Loan", 2, null, null, List.of(),
+            "loan-ct",
+            "Loan",
+            2,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of());
+            List.of(),
+            List.of());
     DeploymentResult deployment =
         new DeploymentResult("dep-2", "loanProcess", "procDef-2", 2, Instant.now());
     byte[] yamlBytes = "id: loan-ct".getBytes();
@@ -288,9 +299,16 @@ class AdminControllerTest {
   void bumpVersionFalseByDefault() throws Exception {
     // Story 3.8 — bumpVersion defaults to false when not supplied
     CaseTypeConfig config =
-        new CaseTypeConfig("loan-ct", "Loan", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "loan-ct",
+            "Loan",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of());
+            List.of(),
+            List.of());
     DeploymentResult deployment =
         new DeploymentResult("dep-1", "loanProcess", "procDef-1", 1, Instant.now());
 
@@ -301,8 +319,12 @@ class AdminControllerTest {
     mockMvc
         .perform(
             multipart("/api/admin/deploy")
-                .file(new MockMultipartFile("caseType", "ct.yaml", "text/plain", "id: loan-ct".getBytes()))
-                .file(new MockMultipartFile("bpmn", "p.bpmn", "application/xml", "<bpmn/>".getBytes()))
+                .file(
+                    new MockMultipartFile(
+                        "caseType", "ct.yaml", "text/plain", "id: loan-ct".getBytes()))
+                .file(
+                    new MockMultipartFile(
+                        "bpmn", "p.bpmn", "application/xml", "<bpmn/>".getBytes()))
                 .with(user("admin").roles("ADMIN")))
         .andExpect(status().isOk());
 
@@ -313,9 +335,16 @@ class AdminControllerTest {
   void bumpVersionTrueIsThreadedToValidateAndRegister() throws Exception {
     // Story 3.8 — ?bumpVersion=true forwarded on YAML-only (no BPMN) path
     CaseTypeConfig config =
-        new CaseTypeConfig("yaml-only-ct", "YAML Only", 2, null, null, List.of(),
+        new CaseTypeConfig(
+            "yaml-only-ct",
+            "YAML Only",
+            2,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of());
+            List.of(),
+            List.of());
 
     ArgumentCaptor<Boolean> bumpCap = ArgumentCaptor.forClass(Boolean.class);
     when(configService.validateAndRegister(any(), any(), any(), bumpCap.capture()))
@@ -324,7 +353,9 @@ class AdminControllerTest {
     mockMvc
         .perform(
             multipart("/api/admin/deploy")
-                .file(new MockMultipartFile("caseType", "ct.yaml", "text/plain", "id: yaml-only-ct".getBytes()))
+                .file(
+                    new MockMultipartFile(
+                        "caseType", "ct.yaml", "text/plain", "id: yaml-only-ct".getBytes()))
                 .param("bumpVersion", "true")
                 .with(user("admin").roles("ADMIN")))
         .andExpect(status().isOk());

--- a/backend/src/test/java/com/wkspower/platform/domain/config/diff/CaseTypeDiffTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/config/diff/CaseTypeDiffTest.java
@@ -69,11 +69,19 @@ class CaseTypeDiffTest {
     CaseTypeConfig prev = base();
     CaseTypeConfig next =
         new CaseTypeConfig(
-            "test-ct", "Test", 1, null, null, List.of(),
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(
                 new StatusDefinition("open", "Open", StatusColor.BLUE),
                 new StatusDefinition("review", "Review", StatusColor.BLUE)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
@@ -91,23 +99,47 @@ class CaseTypeDiffTest {
   void newStatusAdded_stageScoped_appendClass() {
     StageDefinition stagePrev =
         new StageDefinition(
-            "intake", "Intake", 0,
+            "intake",
+            "Intake",
+            0,
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
             Optional.of("open"));
     StageDefinition stageNext =
         new StageDefinition(
-            "intake", "Intake", 0,
+            "intake",
+            "Intake",
+            0,
             List.of(
                 new StatusDefinition("open", "Open", StatusColor.BLUE),
                 new StatusDefinition("review", "Review", StatusColor.BLUE)),
             Optional.of("open"));
 
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(), List.of(), List.of(),
-            List.of(), List.of(stagePrev), List.of());
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(stagePrev),
+            List.of());
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(), List.of(), List.of(),
-            List.of(), List.of(stageNext), List.of());
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(stageNext),
+            List.of());
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
@@ -123,11 +155,20 @@ class CaseTypeDiffTest {
   @Test
   void statusRemoved_mutateClass() {
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(
                 new StatusDefinition("open", "Open", StatusColor.BLUE),
                 new StatusDefinition("rejected", "Rejected", StatusColor.RED)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
     CaseTypeConfig next = base(); // only 'open'
 
     BlastRadiusReport report =
@@ -144,13 +185,31 @@ class CaseTypeDiffTest {
   @Test
   void statusTerminalFlipped_mutateClass() {
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, false)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, true)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
@@ -166,39 +225,69 @@ class CaseTypeDiffTest {
   @Test
   void statusRetargetedAcrossStages_mutateClass() {
     StageDefinition stageA =
-        new StageDefinition("intake", "Intake", 0,
+        new StageDefinition(
+            "intake",
+            "Intake",
+            0,
             List.of(new StatusDefinition("pending", "Pending", StatusColor.BLUE)),
             Optional.of("pending"));
     StageDefinition stageB =
-        new StageDefinition("review", "Review", 1,
+        new StageDefinition(
+            "review",
+            "Review",
+            1,
             List.of(new StatusDefinition("approved", "Approved", StatusColor.EMERALD)),
             Optional.of("approved"));
 
     // In next, 'pending' moves from intake to review
     StageDefinition stageANext =
-        new StageDefinition("intake", "Intake", 0,
+        new StageDefinition(
+            "intake",
+            "Intake",
+            0,
             List.of(new StatusDefinition("drafted", "Drafted", StatusColor.BLUE)),
             Optional.of("drafted"));
     StageDefinition stageBNext =
-        new StageDefinition("review", "Review", 1,
+        new StageDefinition(
+            "review",
+            "Review",
+            1,
             List.of(
                 new StatusDefinition("approved", "Approved", StatusColor.EMERALD),
                 new StatusDefinition("pending", "Pending", StatusColor.BLUE)),
             Optional.of("approved"));
 
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(), List.of(), List.of(),
-            List.of(), List.of(stageA, stageB), List.of());
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(stageA, stageB),
+            List.of());
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(), List.of(), List.of(),
-            List.of(), List.of(stageANext, stageBNext), List.of());
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(stageANext, stageBNext),
+            List.of());
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
 
-    assertThat(report.mutateDeltas())
-        .extracting(Delta::kind)
-        .contains(DeltaKind.STATUS_RETARGETED);
+    assertThat(report.mutateDeltas()).extracting(Delta::kind).contains(DeltaKind.STATUS_RETARGETED);
   }
 
   // ---- test 7: new field added (required=true) → FIELD_ADDED (append) ---
@@ -207,10 +296,18 @@ class CaseTypeDiffTest {
   void newFieldAdded_requiredTrue_appendClass() {
     CaseTypeConfig prev = base();
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
             List.of(textField("name", true)),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
@@ -226,10 +323,18 @@ class CaseTypeDiffTest {
   @Test
   void fieldRemoved_mutateClass() {
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
             List.of(textField("name", false)),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
     CaseTypeConfig next = base(); // no fields
 
     BlastRadiusReport report =
@@ -246,15 +351,31 @@ class CaseTypeDiffTest {
   @Test
   void fieldTypeChanged_mutateClass() {
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
             List.of(typedField("score", FieldType.TEXT, false)),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
             List.of(typedField("score", FieldType.NUMBER, false)),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
@@ -270,15 +391,31 @@ class CaseTypeDiffTest {
   @Test
   void fieldRequiredFlipped_mutateClass() {
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
             List.of(textField("notes", false)),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
             List.of(textField("notes", true)),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(), List.of(), List.of());
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
@@ -294,15 +431,29 @@ class CaseTypeDiffTest {
   @Test
   void newStageAppendedAtTail_appendClass() {
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(),
+            List.of(),
+            List.of(),
             List.of(new StageDefinition("intake", "Intake", 0)),
             List.of());
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(),
+            List.of(),
+            List.of(),
             List.of(
                 new StageDefinition("intake", "Intake", 0),
                 new StageDefinition("review", "Review", 1)),
@@ -322,18 +473,32 @@ class CaseTypeDiffTest {
   @Test
   void stageInsertedInMiddle_mutateClass() {
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(),
+            List.of(),
+            List.of(),
             List.of(
                 new StageDefinition("intake", "Intake", 0),
                 new StageDefinition("decision", "Decision", 1)),
             List.of());
     // 'review' is inserted between 'intake' and 'decision'
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(),
+            List.of(),
+            List.of(),
             List.of(
                 new StageDefinition("intake", "Intake", 0),
                 new StageDefinition("review", "Review", 1),
@@ -359,18 +524,21 @@ class CaseTypeDiffTest {
     // Simplest way: prev has an attachment, next has none (removal = mutate).
     com.wkspower.platform.domain.config.model.AttachmentDefinition prevAttachment =
         new com.wkspower.platform.domain.config.model.AttachmentDefinition(
-            "bpmn", "loan.bpmn", "case", java.util.Optional.empty(),
-            java.util.Map.of(), java.util.Optional.empty(), java.util.Map.of(), List.of());
+            "bpmn",
+            "loan.bpmn",
+            "case",
+            java.util.Optional.empty(),
+            java.util.Map.of(),
+            java.util.Optional.empty(),
+            java.util.Map.of(),
+            List.of());
     MappingDefinition prevMapping = new MappingDefinition(List.of(prevAttachment));
     MappingDefinition nextMapping = MappingDefinition.empty(); // removed → MUTATE_CLASS
 
     CaseTypeConfig config = base();
-    BlastRadiusReport report =
-        CaseTypeDiff.classify(config, config, prevMapping, nextMapping);
+    BlastRadiusReport report = CaseTypeDiff.classify(config, config, prevMapping, nextMapping);
 
-    assertThat(report.mutateDeltas())
-        .extracting(Delta::kind)
-        .containsExactly(DeltaKind.MAPPING);
+    assertThat(report.mutateDeltas()).extracting(Delta::kind).containsExactly(DeltaKind.MAPPING);
     assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
   }
 
@@ -379,26 +547,37 @@ class CaseTypeDiffTest {
   @Test
   void newRoleAdded_appendClass() {
     CaseTypeConfig prev =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
             List.of(),
             List.of(new RoleDefinition("admin", List.of())),
-            List.of(), List.of());
+            List.of(),
+            List.of());
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
             List.of(),
             List.of(
-                new RoleDefinition("admin", List.of()),
-                new RoleDefinition("reviewer", List.of())),
-            List.of(), List.of());
+                new RoleDefinition("admin", List.of()), new RoleDefinition("reviewer", List.of())),
+            List.of(),
+            List.of());
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
 
-    assertThat(report.appendDeltas())
-        .extracting(Delta::kind)
-        .containsExactly(DeltaKind.ROLE_ADDED);
+    assertThat(report.appendDeltas()).extracting(Delta::kind).containsExactly(DeltaKind.ROLE_ADDED);
     assertThat(report.mutateDeltas()).isEmpty();
   }
 
@@ -408,17 +587,25 @@ class CaseTypeDiffTest {
   void newFormAdded_appendClass() {
     CaseTypeConfig prev = base();
     CaseTypeConfig next =
-        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+        new CaseTypeConfig(
+            "test-ct",
+            "Test",
+            1,
+            null,
+            null,
+            List.of(),
             List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
-            List.of(), List.of(), List.of(),
-            List.of(new FormDefinition("intake-form", "single", "monolithic", "single-page", List.of())));
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(
+                new FormDefinition(
+                    "intake-form", "single", "monolithic", "single-page", List.of())));
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
 
-    assertThat(report.appendDeltas())
-        .extracting(Delta::kind)
-        .containsExactly(DeltaKind.FORM_ADDED);
+    assertThat(report.appendDeltas()).extracting(Delta::kind).containsExactly(DeltaKind.FORM_ADDED);
     assertThat(report.mutateDeltas()).isEmpty();
   }
 
@@ -426,17 +613,17 @@ class CaseTypeDiffTest {
 
   @Test
   void changeClass_appendWhenNoMutateDeltas() {
-    BlastRadiusReport report = new BlastRadiusReport(
-        List.of(new Delta(DeltaKind.STATUS_ADDED, "/statuses/x/id", "added")),
-        List.of());
+    BlastRadiusReport report =
+        new BlastRadiusReport(
+            List.of(new Delta(DeltaKind.STATUS_ADDED, "/statuses/x/id", "added")), List.of());
     assertThat(report.changeClass()).isEqualTo(MappingChangeClass.APPEND_CLASS);
   }
 
   @Test
   void changeClass_mutateWhenMutateDeltasPresent() {
-    BlastRadiusReport report = new BlastRadiusReport(
-        List.of(),
-        List.of(new Delta(DeltaKind.STATUS_REMOVED, "/statuses/x/id", "removed")));
+    BlastRadiusReport report =
+        new BlastRadiusReport(
+            List.of(), List.of(new Delta(DeltaKind.STATUS_REMOVED, "/statuses/x/id", "removed")));
     assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/domain/config/diff/CaseTypeDiffTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/config/diff/CaseTypeDiffTest.java
@@ -1,0 +1,442 @@
+package com.wkspower.platform.domain.config.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldDefinition.TypeSlots;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.MappingChangeClass;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CaseTypeDiff}. Covers all 14 scenarios per Story 3.8 AC1 + AC5 unit
+ * requirement. Pure Java — no Spring context.
+ */
+class CaseTypeDiffTest {
+
+  // ---- helpers -----------------------------------------------------------
+
+  private static CaseTypeConfig base() {
+    return new CaseTypeConfig(
+        "test-ct",
+        "Test",
+        1,
+        null,
+        null,
+        List.of(),
+        List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of());
+  }
+
+  private static FieldDefinition textField(String id, boolean required) {
+    return new FieldDefinition(id, id, FieldType.TEXT, required, 0, List.of(), TypeSlots.empty());
+  }
+
+  private static FieldDefinition typedField(String id, FieldType type, boolean required) {
+    return new FieldDefinition(id, id, type, required, 0, List.of(), TypeSlots.empty());
+  }
+
+  // ---- test 1: identical configs → no deltas ----------------------------
+
+  @Test
+  void identicalConfigs_noDeltas() {
+    CaseTypeConfig prev = base();
+    CaseTypeConfig next = base();
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.appendDeltas()).isEmpty();
+    assertThat(report.mutateDeltas()).isEmpty();
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.APPEND_CLASS);
+  }
+
+  // ---- test 2: new status added (case-type level) → STATUS_ADDED --------
+
+  @Test
+  void newStatusAdded_caseTypeLevel_appendClass() {
+    CaseTypeConfig prev = base();
+    CaseTypeConfig next =
+        new CaseTypeConfig(
+            "test-ct", "Test", 1, null, null, List.of(),
+            List.of(
+                new StatusDefinition("open", "Open", StatusColor.BLUE),
+                new StatusDefinition("review", "Review", StatusColor.BLUE)),
+            List.of(), List.of(), List.of(), List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.appendDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.STATUS_ADDED);
+    assertThat(report.mutateDeltas()).isEmpty();
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.APPEND_CLASS);
+  }
+
+  // ---- test 3: new status added (stage-scoped) → STATUS_ADDED -----------
+
+  @Test
+  void newStatusAdded_stageScoped_appendClass() {
+    StageDefinition stagePrev =
+        new StageDefinition(
+            "intake", "Intake", 0,
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            Optional.of("open"));
+    StageDefinition stageNext =
+        new StageDefinition(
+            "intake", "Intake", 0,
+            List.of(
+                new StatusDefinition("open", "Open", StatusColor.BLUE),
+                new StatusDefinition("review", "Review", StatusColor.BLUE)),
+            Optional.of("open"));
+
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(), List.of(), List.of(),
+            List.of(), List.of(stagePrev), List.of());
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(), List.of(), List.of(),
+            List.of(), List.of(stageNext), List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.appendDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.STATUS_ADDED);
+    assertThat(report.mutateDeltas()).isEmpty();
+  }
+
+  // ---- test 4: status removed → STATUS_REMOVED (mutate) -----------------
+
+  @Test
+  void statusRemoved_mutateClass() {
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(
+                new StatusDefinition("open", "Open", StatusColor.BLUE),
+                new StatusDefinition("rejected", "Rejected", StatusColor.RED)),
+            List.of(), List.of(), List.of(), List.of());
+    CaseTypeConfig next = base(); // only 'open'
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.mutateDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.STATUS_REMOVED);
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  // ---- test 5: status terminal flag flipped → STATUS_TERMINAL_FLIP ------
+
+  @Test
+  void statusTerminalFlipped_mutateClass() {
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, false)),
+            List.of(), List.of(), List.of(), List.of());
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE, true)),
+            List.of(), List.of(), List.of(), List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.mutateDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.STATUS_TERMINAL_FLIP);
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  // ---- test 6: status retargeted across stages → STATUS_RETARGETED ------
+
+  @Test
+  void statusRetargetedAcrossStages_mutateClass() {
+    StageDefinition stageA =
+        new StageDefinition("intake", "Intake", 0,
+            List.of(new StatusDefinition("pending", "Pending", StatusColor.BLUE)),
+            Optional.of("pending"));
+    StageDefinition stageB =
+        new StageDefinition("review", "Review", 1,
+            List.of(new StatusDefinition("approved", "Approved", StatusColor.EMERALD)),
+            Optional.of("approved"));
+
+    // In next, 'pending' moves from intake to review
+    StageDefinition stageANext =
+        new StageDefinition("intake", "Intake", 0,
+            List.of(new StatusDefinition("drafted", "Drafted", StatusColor.BLUE)),
+            Optional.of("drafted"));
+    StageDefinition stageBNext =
+        new StageDefinition("review", "Review", 1,
+            List.of(
+                new StatusDefinition("approved", "Approved", StatusColor.EMERALD),
+                new StatusDefinition("pending", "Pending", StatusColor.BLUE)),
+            Optional.of("approved"));
+
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(), List.of(), List.of(),
+            List.of(), List.of(stageA, stageB), List.of());
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(), List.of(), List.of(),
+            List.of(), List.of(stageANext, stageBNext), List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.mutateDeltas())
+        .extracting(Delta::kind)
+        .contains(DeltaKind.STATUS_RETARGETED);
+  }
+
+  // ---- test 7: new field added (required=true) → FIELD_ADDED (append) ---
+
+  @Test
+  void newFieldAdded_requiredTrue_appendClass() {
+    CaseTypeConfig prev = base();
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+            List.of(textField("name", true)),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(), List.of(), List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.appendDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.FIELD_ADDED);
+    assertThat(report.mutateDeltas()).isEmpty();
+  }
+
+  // ---- test 8: field removed → FIELD_REMOVED (mutate) -------------------
+
+  @Test
+  void fieldRemoved_mutateClass() {
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+            List.of(textField("name", false)),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(), List.of(), List.of());
+    CaseTypeConfig next = base(); // no fields
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.mutateDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.FIELD_REMOVED);
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  // ---- test 9: field type changed → FIELD_RETYPED (mutate) --------------
+
+  @Test
+  void fieldTypeChanged_mutateClass() {
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+            List.of(typedField("score", FieldType.TEXT, false)),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(), List.of(), List.of());
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+            List.of(typedField("score", FieldType.NUMBER, false)),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(), List.of(), List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.mutateDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.FIELD_RETYPED);
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  // ---- test 10: field required-ness flipped → FIELD_REQUIRED_FLIPPED ----
+
+  @Test
+  void fieldRequiredFlipped_mutateClass() {
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+            List.of(textField("notes", false)),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(), List.of(), List.of());
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null,
+            List.of(textField("notes", true)),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(), List.of(), List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.mutateDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.FIELD_REQUIRED_FLIPPED);
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  // ---- test 11: new stage appended at tail → STAGE_APPENDED (append) ----
+
+  @Test
+  void newStageAppendedAtTail_appendClass() {
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(),
+            List.of(new StageDefinition("intake", "Intake", 0)),
+            List.of());
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(),
+            List.of(
+                new StageDefinition("intake", "Intake", 0),
+                new StageDefinition("review", "Review", 1)),
+            List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.appendDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.STAGE_APPENDED);
+    assertThat(report.mutateDeltas()).isEmpty();
+  }
+
+  // ---- test 12: stage inserted in middle → STAGE_INSERTED_MIDDLE (mutate)
+
+  @Test
+  void stageInsertedInMiddle_mutateClass() {
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(),
+            List.of(
+                new StageDefinition("intake", "Intake", 0),
+                new StageDefinition("decision", "Decision", 1)),
+            List.of());
+    // 'review' is inserted between 'intake' and 'decision'
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(),
+            List.of(
+                new StageDefinition("intake", "Intake", 0),
+                new StageDefinition("review", "Review", 1),
+                new StageDefinition("decision", "Decision", 2)),
+            List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    // 'review' inserted in middle → STAGE_INSERTED_MIDDLE
+    // 'decision' ordinal changed → STAGE_REORDERED
+    assertThat(report.mutateDeltas())
+        .extracting(Delta::kind)
+        .contains(DeltaKind.STAGE_INSERTED_MIDDLE);
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  // ---- test 13: mapping mutate-class delegate → MAPPING (mutate) --------
+
+  @Test
+  void mappingMutateClassDelegate_mutateClass() {
+    // Create a prev mapping and a next mapping that MappingDiff would classify as MUTATE_CLASS.
+    // Simplest way: prev has an attachment, next has none (removal = mutate).
+    com.wkspower.platform.domain.config.model.AttachmentDefinition prevAttachment =
+        new com.wkspower.platform.domain.config.model.AttachmentDefinition(
+            "bpmn", "loan.bpmn", "case", java.util.Optional.empty(),
+            java.util.Map.of(), java.util.Optional.empty(), java.util.Map.of(), List.of());
+    MappingDefinition prevMapping = new MappingDefinition(List.of(prevAttachment));
+    MappingDefinition nextMapping = MappingDefinition.empty(); // removed → MUTATE_CLASS
+
+    CaseTypeConfig config = base();
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(config, config, prevMapping, nextMapping);
+
+    assertThat(report.mutateDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.MAPPING);
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+
+  // ---- test 14: new role added → ROLE_ADDED (append) --------------------
+
+  @Test
+  void newRoleAdded_appendClass() {
+    CaseTypeConfig prev =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(),
+            List.of(new RoleDefinition("admin", List.of())),
+            List.of(), List.of());
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(),
+            List.of(
+                new RoleDefinition("admin", List.of()),
+                new RoleDefinition("reviewer", List.of())),
+            List.of(), List.of());
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.appendDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.ROLE_ADDED);
+    assertThat(report.mutateDeltas()).isEmpty();
+  }
+
+  // ---- extra: new form added → FORM_ADDED (append) ----------------------
+
+  @Test
+  void newFormAdded_appendClass() {
+    CaseTypeConfig prev = base();
+    CaseTypeConfig next =
+        new CaseTypeConfig("test-ct", "Test", 1, null, null, List.of(),
+            List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)),
+            List.of(), List.of(), List.of(),
+            List.of(new FormDefinition("intake-form", "single", "monolithic", "single-page", List.of())));
+
+    BlastRadiusReport report =
+        CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());
+
+    assertThat(report.appendDeltas())
+        .extracting(Delta::kind)
+        .containsExactly(DeltaKind.FORM_ADDED);
+    assertThat(report.mutateDeltas()).isEmpty();
+  }
+
+  // ---- BlastRadiusReport.changeClass() ----------------------------------------
+
+  @Test
+  void changeClass_appendWhenNoMutateDeltas() {
+    BlastRadiusReport report = new BlastRadiusReport(
+        List.of(new Delta(DeltaKind.STATUS_ADDED, "/statuses/x/id", "added")),
+        List.of());
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.APPEND_CLASS);
+  }
+
+  @Test
+  void changeClass_mutateWhenMutateDeltasPresent() {
+    BlastRadiusReport report = new BlastRadiusReport(
+        List.of(),
+        List.of(new Delta(DeltaKind.STATUS_REMOVED, "/statuses/x/id", "removed")));
+    assertThat(report.changeClass()).isEqualTo(MappingChangeClass.MUTATE_CLASS);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ConfigServiceDeployTest.java
@@ -349,6 +349,45 @@ class ConfigServiceDeployTest {
     assertThat(deployCount.get()).isEqualTo(2);
   }
 
+  // ---- Story 3.8: blast-radius gate + first-deploy short-circuit ----------
+
+  @Test
+  void firstDeployNoBlastRadiusGate_classifierSkipped() {
+    // Story 3.8 AC4 — first deploy (no prior version) must skip the classifier.
+    // The deploy should succeed regardless of bumpVersion value.
+    CaseTypeConfig config = caseType();
+    StubSource source = new StubSource(ValidationResult.ok(config));
+    StubBpmn bpmn = new StubBpmn(BpmnValidationResult.ok("applicationProcess"));
+    StubRegistrar registrar = new StubRegistrar();
+    StubEngine engine = new StubEngine();
+    RecordingPublisher publisher = new RecordingPublisher();
+    ConfigService svc = newCfg(source, registrar, new StubReader(), bpmn, engine, publisher);
+
+    // First deploy with bumpVersion=false → should succeed (no prior version, gate skipped)
+    DeployResult result = svc.deploy(YAML_BYTES, BPMN_BYTES, null, false);
+    assertThat(result.isInvalid())
+        .as("First deploy (no prior) must succeed even without bumpVersion=true")
+        .isFalse();
+  }
+
+  @Test
+  void firstDeployWithBumpVersionTrue_proceedsWithWarnLog() {
+    // Story 3.8 AC4 — bumpVersion=true on first deploy is a benign no-op (WARN log + proceed).
+    CaseTypeConfig config = caseType();
+    StubSource source = new StubSource(ValidationResult.ok(config));
+    StubBpmn bpmn = new StubBpmn(BpmnValidationResult.ok("applicationProcess"));
+    StubRegistrar registrar = new StubRegistrar();
+    StubEngine engine = new StubEngine();
+    RecordingPublisher publisher = new RecordingPublisher();
+    ConfigService svc = newCfg(source, registrar, new StubReader(), bpmn, engine, publisher);
+
+    // bumpVersion=true with no prior version → WARN log emitted, deploy proceeds normally
+    DeployResult result = svc.deploy(YAML_BYTES, BPMN_BYTES, null, true);
+    assertThat(result.isInvalid())
+        .as("First deploy with bumpVersion=true must succeed (benign no-op)")
+        .isFalse();
+  }
+
   // ---- helpers + stubs ---------------------------------------------------
 
   private static ValidationResult invalidYaml(String code, String msg) {

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/BlastRadiusValidatorPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/BlastRadiusValidatorPostgresIT.java
@@ -36,8 +36,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * validator's WKS-API-055 check does not fire on test-only boot config.
  *
  * <p>Memory {@code project_postgres_it_parity_gap.md}: Postgres-IT is mandatory because
- * version-comparison reads via {@code CaseTypeVersionRegistry.loadByVersion} exercise the
- * {@code case_type_versions} table.
+ * version-comparison reads via {@code CaseTypeVersionRegistry.loadByVersion} exercise the {@code
+ * case_type_versions} table.
  */
 @SpringBootTest(properties = "wks.bootstrap.production-validation.enabled=false")
 @ActiveProfiles("production")
@@ -104,7 +104,9 @@ class BlastRadiusValidatorPostgresIT {
         roles:
           - name: admin
             permissions: [view, create, edit, transition]
-        """.formatted(caseTypeId)).getBytes(StandardCharsets.UTF_8);
+        """
+            .formatted(caseTypeId))
+        .getBytes(StandardCharsets.UTF_8);
   }
 
   @AfterEach
@@ -118,11 +120,13 @@ class BlastRadiusValidatorPostgresIT {
   void statusRemovalWithoutBump_rejected() {
     String id = CT_PREFIX + "s1";
     // v1: deploy first
-    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s1", false);
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s1", false);
     assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
 
     // v2: remove 'pending' status
-    byte[] v2Yaml = ("""
+    byte[] v2Yaml =
+        ("""
         id: %s
         displayName: "Blast Radius Test"
         version: 2
@@ -140,9 +144,12 @@ class BlastRadiusValidatorPostgresIT {
         roles:
           - name: admin
             permissions: [view, create, edit, transition]
-        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+        """
+                .formatted(id))
+            .getBytes(StandardCharsets.UTF_8);
 
-    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s1", false);
+    ValidationResult v2 =
+        configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s1", false);
 
     assertThat(v2.isInvalid())
         .as("Status removal without bumpVersion=true must be rejected")
@@ -161,11 +168,13 @@ class BlastRadiusValidatorPostgresIT {
   @Test
   void statusTerminalFlagChange_withoutBump_rejected() {
     String id = CT_PREFIX + "s2";
-    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s2", false);
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s2", false);
     assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
 
     // v2: flip terminal on 'open'
-    byte[] v2Yaml = ("""
+    byte[] v2Yaml =
+        ("""
         id: %s
         displayName: "Blast Radius Test"
         version: 2
@@ -187,9 +196,12 @@ class BlastRadiusValidatorPostgresIT {
         roles:
           - name: admin
             permissions: [view, create, edit, transition]
-        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+        """
+                .formatted(id))
+            .getBytes(StandardCharsets.UTF_8);
 
-    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s2", false);
+    ValidationResult v2 =
+        configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s2", false);
 
     assertThat(v2.isInvalid()).isTrue();
     assertThat(v2.errors().get(0).code()).isEqualTo(ErrorCode.WKS_CFG_029.wire());
@@ -201,11 +213,13 @@ class BlastRadiusValidatorPostgresIT {
   @Test
   void fieldTypeChange_withoutBump_rejected() {
     String id = CT_PREFIX + "s3";
-    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s3", false);
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s3", false);
     assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
 
     // v2: change 'notes' from text → number
-    byte[] v2Yaml = ("""
+    byte[] v2Yaml =
+        ("""
         id: %s
         displayName: "Blast Radius Test"
         version: 2
@@ -227,9 +241,12 @@ class BlastRadiusValidatorPostgresIT {
         roles:
           - name: admin
             permissions: [view, create, edit, transition]
-        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+        """
+                .formatted(id))
+            .getBytes(StandardCharsets.UTF_8);
 
-    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s3", false);
+    ValidationResult v2 =
+        configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s3", false);
 
     assertThat(v2.isInvalid()).isTrue();
     assertThat(v2.errors().get(0).code()).isEqualTo(ErrorCode.WKS_CFG_029.wire());
@@ -241,11 +258,13 @@ class BlastRadiusValidatorPostgresIT {
   @Test
   void fieldRequiredChange_withoutBump_rejected() {
     String id = CT_PREFIX + "s4";
-    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s4", false);
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s4", false);
     assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
 
     // v2: flip 'notes' required: false → true
-    byte[] v2Yaml = ("""
+    byte[] v2Yaml =
+        ("""
         id: %s
         displayName: "Blast Radius Test"
         version: 2
@@ -267,9 +286,12 @@ class BlastRadiusValidatorPostgresIT {
         roles:
           - name: admin
             permissions: [view, create, edit, transition]
-        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+        """
+                .formatted(id))
+            .getBytes(StandardCharsets.UTF_8);
 
-    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s4", false);
+    ValidationResult v2 =
+        configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s4", false);
 
     assertThat(v2.isInvalid()).isTrue();
     assertThat(v2.errors().get(0).code()).isEqualTo(ErrorCode.WKS_CFG_029.wire());
@@ -288,12 +310,14 @@ class BlastRadiusValidatorPostgresIT {
   @Test
   void statusRemovalWithBump_succeeds_newVersion() {
     String id = CT_PREFIX + "s6";
-    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s6", false);
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s6", false);
     assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
     int v1Version = v1.config().get().version();
 
     // v2: remove 'pending' status WITH bumpVersion=true
-    byte[] v2Yaml = ("""
+    byte[] v2Yaml =
+        ("""
         id: %s
         displayName: "Blast Radius Test"
         version: 2
@@ -311,9 +335,12 @@ class BlastRadiusValidatorPostgresIT {
         roles:
           - name: admin
             permissions: [view, create, edit, transition]
-        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+        """
+                .formatted(id))
+            .getBytes(StandardCharsets.UTF_8);
 
-    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s6", true);
+    ValidationResult v2 =
+        configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s6", true);
 
     assertThat(v2.isInvalid())
         .as("Status removal with bumpVersion=true must succeed; errors=" + v2.errors())
@@ -329,12 +356,14 @@ class BlastRadiusValidatorPostgresIT {
   @Test
   void appendClassStatusAdd_withoutBump_succeeds_sameVersion() {
     String id = CT_PREFIX + "s7";
-    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s7", false);
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s7", false);
     assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
     int v1Version = v1.config().get().version();
 
     // v2: add a new status 'approved' (append-class)
-    byte[] v2Yaml = ("""
+    byte[] v2Yaml =
+        ("""
         id: %s
         displayName: "Blast Radius Test"
         version: 2
@@ -360,9 +389,12 @@ class BlastRadiusValidatorPostgresIT {
         roles:
           - name: admin
             permissions: [view, create, edit, transition]
-        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+        """
+                .formatted(id))
+            .getBytes(StandardCharsets.UTF_8);
 
-    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s7", false);
+    ValidationResult v2 =
+        configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s7", false);
 
     assertThat(v2.isInvalid())
         .as("Append-class status add without bump must succeed; errors=" + v2.errors())
@@ -380,23 +412,22 @@ class BlastRadiusValidatorPostgresIT {
   void firstDeploy_noPriorVersion_succeeds_version1() {
     String id = CT_PREFIX + "s8";
     // No prior version exists. bumpVersion=true should be ignored with WARN log.
-    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s8", true);
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s8", true);
 
     assertThat(v1.isInvalid())
         .as("First deploy with bumpVersion=true must succeed (benign no-op); errors=" + v1.errors())
         .isFalse();
     assertThat(v1.config()).isPresent();
-    assertThat(v1.config().get().version())
-        .as("First deploy must produce version 1")
-        .isEqualTo(1);
+    assertThat(v1.config().get().version()).as("First deploy must produce version 1").isEqualTo(1);
   }
 
   // ---- helper ------------------------------------------------------------
 
   /**
-   * Asserts that {@code result.responseMeta().blastRadius.mutateDeltas[0].kind} matches
-   * {@code expectedKind}. Serialises the {@link BlastRadiusReport} via Jackson to verify the wire
-   * shape that the Admin UI will consume (AC2: meta.blastRadius must be present on WKS-CFG-029
+   * Asserts that {@code result.responseMeta().blastRadius.mutateDeltas[0].kind} matches {@code
+   * expectedKind}. Serialises the {@link BlastRadiusReport} via Jackson to verify the wire shape
+   * that the Admin UI will consume (AC2: meta.blastRadius must be present on WKS-CFG-029
    * rejections).
    */
   private static void assertBlastRadiusInMeta(ValidationResult result, DeltaKind expectedKind) {
@@ -410,9 +441,7 @@ class BlastRadiusValidatorPostgresIT {
         .isInstanceOf(BlastRadiusReport.class);
 
     BlastRadiusReport report = (BlastRadiusReport) raw;
-    assertThat(report.mutateDeltas())
-        .as("mutateDeltas must be non-empty")
-        .isNotEmpty();
+    assertThat(report.mutateDeltas()).as("mutateDeltas must be non-empty").isNotEmpty();
     assertThat(report.mutateDeltas().get(0).kind())
         .as("First mutate delta kind must match expected")
         .isEqualTo(expectedKind);
@@ -422,8 +451,12 @@ class BlastRadiusValidatorPostgresIT {
       String json = MAPPER.writeValueAsString(report);
       JsonNode node = MAPPER.readTree(json);
       assertThat(node.has("changeClass")).as("changeClass field must be present in JSON").isTrue();
-      assertThat(node.has("mutateDeltas")).as("mutateDeltas field must be present in JSON").isTrue();
-      assertThat(node.has("appendDeltas")).as("appendDeltas field must be present in JSON").isTrue();
+      assertThat(node.has("mutateDeltas"))
+          .as("mutateDeltas field must be present in JSON")
+          .isTrue();
+      assertThat(node.has("appendDeltas"))
+          .as("appendDeltas field must be present in JSON")
+          .isTrue();
       assertThat(node.get("changeClass").asText()).isEqualTo("MUTATE_CLASS");
     } catch (Exception e) {
       throw new AssertionError("BlastRadiusReport JSON serialisation failed: " + e.getMessage(), e);

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/BlastRadiusValidatorPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/BlastRadiusValidatorPostgresIT.java
@@ -7,11 +7,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wkspower.platform.domain.config.ValidationResult;
 import com.wkspower.platform.domain.config.diff.BlastRadiusReport;
 import com.wkspower.platform.domain.config.diff.DeltaKind;
+import com.wkspower.platform.domain.config.model.AttachmentDefinition;
+import com.wkspower.platform.domain.config.model.MappingDefinition;
 import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.port.CaseTypeRef;
 import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
 import com.wkspower.platform.domain.service.ConfigService;
+import com.wkspower.platform.domain.service.MappingRegistry;
 import com.wkspower.platform.infrastructure.persistence.repository.CaseTypeVersionJpaRepository;
+import jakarta.persistence.EntityManager;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -69,6 +78,8 @@ class BlastRadiusValidatorPostgresIT {
   @Autowired private ConfigService configService;
   @Autowired private CaseTypeVersionRegistry versionRegistry;
   @Autowired private CaseTypeVersionJpaRepository repo;
+  @Autowired private MappingRegistry mappingRegistry;
+  @Autowired private EntityManager em;
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -298,12 +309,137 @@ class BlastRadiusValidatorPostgresIT {
     assertBlastRadiusInMeta(v2, DeltaKind.FIELD_REQUIRED_FLIPPED);
   }
 
-  // ---- Scenario 5: BPMN mapping mutate-class without bump (IT: no actual BPMN here) ---
-  // Note: the mapping gate exercises MappingDiff via CaseTypeDiff. Since this IT uses
-  // the YAML-only path (no BPMN engine), we test the MAPPING kind indirectly via the unit tests.
-  // The mapping gate is covered by CaseTypeDiffTest.mappingMutateClassDelegate_mutateClass.
-  // For the Postgres IT we skip this scenario and focus on the five schema-change kinds
-  // which are the ones exercised on the DB path.
+  // ---- Scenario 5: BPMN MAPPING mutate-class without bump → 422 + WKS-CFG-029 ----
+
+  /**
+   * Story 3.8 AC5 scenario 5 — BPMN MAPPING mutate-class. Exercises the Spring-wired {@link
+   * MappingRegistry#resolve} path inside {@code ConfigService.runBlastRadiusGate}. The unit suite
+   * covers the pure {@code MappingDiff} delegation; only the IT proves the live registry lookup
+   * returns the prior {@link MappingDefinition} and the classifier folds it into the report under
+   * {@link DeltaKind#MAPPING}.
+   *
+   * <p>Setup: deploy v1 (registry publishes empty mapping under key "1"), then overwrite the
+   * registry with a non-empty {@link MappingDefinition} (one attachment). The v2 deploy carries no
+   * BPMN, so {@code yamlResult.mappingDefinition()} resolves to {@link MappingDefinition#empty()} →
+   * attachment removal → MUTATE_CLASS via {@code MappingDiff}.
+   */
+  @Test
+  void bpmnMappingMutateClass_withoutBump_rejected() {
+    String id = CT_PREFIX + "s5";
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s5", false);
+    assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
+
+    // Seed the prior mapping with one attachment so v2 (empty mapping) becomes a removal →
+    // MappingDiff classifies as MUTATE_CLASS. The runBlastRadiusGate keys lookup off
+    // priorVersionNum=1 (see ConfigService.runBlastRadiusGate), so we register under "1".
+    MappingDefinition priorMapping =
+        new MappingDefinition(
+            List.of(
+                new AttachmentDefinition(
+                    "bpmn",
+                    "deploy.bpmn",
+                    "case",
+                    Optional.empty(),
+                    Map.of(
+                        "Task_Approve",
+                        new AttachmentDefinition.UserTaskMapping("approval", "approval-form")),
+                    Optional.empty(),
+                    Map.of(),
+                    List.of())));
+    mappingRegistry.register(new CaseTypeRef(id, "1"), "1", priorMapping);
+
+    // v2 YAML carries the same shape (no schema deltas) so the only mutate signal is MAPPING.
+    byte[] v2Yaml =
+        ("""
+        id: %s
+        displayName: "Blast Radius Test"
+        version: 2
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: false
+          - id: pending
+            displayName: Pending
+            color: amber
+            terminal: false
+        fields:
+          - id: notes
+            displayName: Notes
+            type: text
+            required: false
+            order: 1
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """
+                .formatted(id))
+            .getBytes(StandardCharsets.UTF_8);
+
+    ValidationResult v2 =
+        configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s5", false);
+
+    assertThat(v2.isInvalid())
+        .as("BPMN MAPPING mutate-class without bumpVersion must be rejected")
+        .isTrue();
+    assertThat(v2.errors())
+        .extracting(com.wkspower.platform.domain.exception.ErrorDetail::code)
+        .containsExactly(ErrorCode.WKS_CFG_029.wire());
+    assertBlastRadiusInMeta(v2, DeltaKind.MAPPING);
+
+    // AC2 invariant — the version registry write was NOT executed on rejection. After v1 the
+    // table holds exactly one row for this caseTypeId; the rejected v2 must not have added a
+    // second row.
+    long versionRows = repo.findAll().stream().filter(e -> id.equals(e.getCaseTypeId())).count();
+    assertThat(versionRows)
+        .as("Rejected mutate-class deploy must not write a v2 row to case_type_versions")
+        .isEqualTo(1L);
+  }
+
+  // ---- Scenario 5b (Should-Fix #1): unparseable prior YAML → 422 + WKS-CFG-030 (fail-closed) ----
+
+  /**
+   * PR #417 review Should-Fix — the blast-radius gate must fail CLOSED when the prior YAML cannot
+   * be re-parsed. AC2 invariant requires the gate to apply on every deploy with a prior version;
+   * silently bypassing would let mutate-class edits ship unchecked.
+   *
+   * <p>Setup: deploy v1, then corrupt the {@code definition_yaml} column on the v1 row via a native
+   * UPDATE (the column is JPA-immutable; native SQL is the only path). The next deploy attempt
+   * should be rejected with {@code WKS-CFG-030}.
+   */
+  @Test
+  @Transactional
+  void unparseablePriorYaml_failsClosed_wksCfg030() {
+    String id = CT_PREFIX + "s5b";
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s5b", false);
+    assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
+
+    // Corrupt the stored prior YAML so re-parse fails inside runBlastRadiusGate.
+    em.createNativeQuery(
+            "UPDATE case_type_versions SET definition_yaml = :corrupt WHERE case_type_id = :id")
+        .setParameter("corrupt", "::: not valid YAML at all :::\n\t- [unbalanced")
+        .setParameter("id", id)
+        .executeUpdate();
+    em.flush();
+    em.clear();
+
+    // Any v2 attempt must now be rejected fail-closed — even a benign no-op edit cannot pass
+    // because the gate cannot classify the change.
+    ValidationResult v2 =
+        configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s5b", false);
+
+    assertThat(v2.isInvalid())
+        .as("Deploy must be rejected fail-closed when prior YAML cannot be re-parsed")
+        .isTrue();
+    assertThat(v2.errors())
+        .extracting(com.wkspower.platform.domain.exception.ErrorDetail::code)
+        .containsExactly(ErrorCode.WKS_CFG_030.wire());
+    assertThat(v2.errors().get(0).message())
+        .as("Error message must reference fail-closed semantics")
+        .contains("fail-closed");
+  }
 
   // ---- Scenario 6: status removal WITH bumpVersion=true → 200 + new version ----
 

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/BlastRadiusValidatorPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/BlastRadiusValidatorPostgresIT.java
@@ -1,0 +1,432 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.domain.config.ValidationResult;
+import com.wkspower.platform.domain.config.diff.BlastRadiusReport;
+import com.wkspower.platform.domain.config.diff.DeltaKind;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
+import com.wkspower.platform.domain.service.ConfigService;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseTypeVersionJpaRepository;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Story 3.8 AC5 — Postgres-backed integration test proving the blast-radius validator gate
+ * end-to-end with all six mutate kinds + bump-honor branches.
+ *
+ * <p>Uses {@code @SpringBootTest} with a real Testcontainers Postgres so that {@code
+ * CaseTypeVersionRegistry.loadByVersion} exercises the {@code case_type_versions} table with
+ * Postgres semantics (H2 cannot reproduce concurrent deploy lock contention equivalent). Field
+ * names are sourced from {@code ConfigValidator.java} lines 112–576.
+ *
+ * <p>Memory {@code feedback_production_validator_opt_out.md}: production-validation disabled so the
+ * validator's WKS-API-055 check does not fire on test-only boot config.
+ *
+ * <p>Memory {@code project_postgres_it_parity_gap.md}: Postgres-IT is mandatory because
+ * version-comparison reads via {@code CaseTypeVersionRegistry.loadByVersion} exercise the
+ * {@code case_type_versions} table.
+ */
+@SpringBootTest(properties = "wks.bootstrap.production-validation.enabled=false")
+@ActiveProfiles("production")
+@Testcontainers(disabledWithoutDocker = true)
+class BlastRadiusValidatorPostgresIT {
+
+  @Container
+  @SuppressWarnings("resource")
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("wks")
+          .withUsername("wks")
+          .withPassword("wks");
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("WKS_DB_URL", POSTGRES::getJdbcUrl);
+    registry.add("WKS_DB_USER", POSTGRES::getUsername);
+    registry.add("WKS_DB_PASSWORD", POSTGRES::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    registry.add("WKS_ADMIN_EMAIL", () -> "admin@wkspower.local");
+    registry.add("WKS_ADMIN_PASSWORD", () -> "admin");
+    registry.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+    registry.add("WKS_CORS_ORIGINS", () -> "http://localhost:5173");
+    registry.add(
+        "camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+  }
+
+  @Autowired private ConfigService configService;
+  @Autowired private CaseTypeVersionRegistry versionRegistry;
+  @Autowired private CaseTypeVersionJpaRepository repo;
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** Case-type ID prefix — each test uses a unique suffix to avoid cross-test pollution. */
+  private static final String CT_PREFIX = "blast-radius-pg-";
+
+  // ---- Field names sourced from ConfigValidator.java lines 112, 113, 388, 576 ----
+  // top-level: id (L112), displayName (L113), version (L114), statuses[], fields[], stages[]
+  // statuses[]: id, displayName, color (wire form is lowercase per StatusColor.wire()), terminal
+  // fields[]: id, displayName, type, required, order
+
+  /** Base v1 YAML: two statuses (open + pending), one field (notes), no stages. */
+  private static byte[] v1Yaml(String caseTypeId) {
+    return ("""
+        id: %s
+        displayName: "Blast Radius Test"
+        version: 1
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: false
+          - id: pending
+            displayName: Pending
+            color: amber
+            terminal: false
+        fields:
+          - id: notes
+            displayName: Notes
+            type: text
+            required: false
+            order: 1
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """.formatted(caseTypeId)).getBytes(StandardCharsets.UTF_8);
+  }
+
+  @AfterEach
+  void wipe() {
+    repo.deleteAll();
+  }
+
+  // ---- Scenario 1: status removal without bump → 422 + WKS-CFG-029 ------
+
+  @Test
+  void statusRemovalWithoutBump_rejected() {
+    String id = CT_PREFIX + "s1";
+    // v1: deploy first
+    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s1", false);
+    assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
+
+    // v2: remove 'pending' status
+    byte[] v2Yaml = ("""
+        id: %s
+        displayName: "Blast Radius Test"
+        version: 2
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: false
+        fields:
+          - id: notes
+            displayName: Notes
+            type: text
+            required: false
+            order: 1
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+
+    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s1", false);
+
+    assertThat(v2.isInvalid())
+        .as("Status removal without bumpVersion=true must be rejected")
+        .isTrue();
+    assertThat(v2.errors())
+        .extracting(com.wkspower.platform.domain.exception.ErrorDetail::code)
+        .containsExactly(ErrorCode.WKS_CFG_029.wire());
+    assertThat(v2.errors().get(0).message()).contains("Mutate-class");
+
+    // meta.blastRadius must be present with STATUS_REMOVED kind
+    assertBlastRadiusInMeta(v2, DeltaKind.STATUS_REMOVED);
+  }
+
+  // ---- Scenario 2: status terminal-flag change without bump → 422 + WKS-CFG-029 ----
+
+  @Test
+  void statusTerminalFlagChange_withoutBump_rejected() {
+    String id = CT_PREFIX + "s2";
+    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s2", false);
+    assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
+
+    // v2: flip terminal on 'open'
+    byte[] v2Yaml = ("""
+        id: %s
+        displayName: "Blast Radius Test"
+        version: 2
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: true
+          - id: pending
+            displayName: Pending
+            color: amber
+            terminal: false
+        fields:
+          - id: notes
+            displayName: Notes
+            type: text
+            required: false
+            order: 1
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+
+    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s2", false);
+
+    assertThat(v2.isInvalid()).isTrue();
+    assertThat(v2.errors().get(0).code()).isEqualTo(ErrorCode.WKS_CFG_029.wire());
+    assertBlastRadiusInMeta(v2, DeltaKind.STATUS_TERMINAL_FLIP);
+  }
+
+  // ---- Scenario 3: field type change without bump → 422 + WKS-CFG-029 ---
+
+  @Test
+  void fieldTypeChange_withoutBump_rejected() {
+    String id = CT_PREFIX + "s3";
+    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s3", false);
+    assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
+
+    // v2: change 'notes' from text → number
+    byte[] v2Yaml = ("""
+        id: %s
+        displayName: "Blast Radius Test"
+        version: 2
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: false
+          - id: pending
+            displayName: Pending
+            color: amber
+            terminal: false
+        fields:
+          - id: notes
+            displayName: Notes
+            type: number
+            required: false
+            order: 1
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+
+    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s3", false);
+
+    assertThat(v2.isInvalid()).isTrue();
+    assertThat(v2.errors().get(0).code()).isEqualTo(ErrorCode.WKS_CFG_029.wire());
+    assertBlastRadiusInMeta(v2, DeltaKind.FIELD_RETYPED);
+  }
+
+  // ---- Scenario 4: field required-ness change without bump → 422 --------
+
+  @Test
+  void fieldRequiredChange_withoutBump_rejected() {
+    String id = CT_PREFIX + "s4";
+    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s4", false);
+    assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
+
+    // v2: flip 'notes' required: false → true
+    byte[] v2Yaml = ("""
+        id: %s
+        displayName: "Blast Radius Test"
+        version: 2
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: false
+          - id: pending
+            displayName: Pending
+            color: amber
+            terminal: false
+        fields:
+          - id: notes
+            displayName: Notes
+            type: text
+            required: true
+            order: 1
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+
+    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s4", false);
+
+    assertThat(v2.isInvalid()).isTrue();
+    assertThat(v2.errors().get(0).code()).isEqualTo(ErrorCode.WKS_CFG_029.wire());
+    assertBlastRadiusInMeta(v2, DeltaKind.FIELD_REQUIRED_FLIPPED);
+  }
+
+  // ---- Scenario 5: BPMN mapping mutate-class without bump (IT: no actual BPMN here) ---
+  // Note: the mapping gate exercises MappingDiff via CaseTypeDiff. Since this IT uses
+  // the YAML-only path (no BPMN engine), we test the MAPPING kind indirectly via the unit tests.
+  // The mapping gate is covered by CaseTypeDiffTest.mappingMutateClassDelegate_mutateClass.
+  // For the Postgres IT we skip this scenario and focus on the five schema-change kinds
+  // which are the ones exercised on the DB path.
+
+  // ---- Scenario 6: status removal WITH bumpVersion=true → 200 + new version ----
+
+  @Test
+  void statusRemovalWithBump_succeeds_newVersion() {
+    String id = CT_PREFIX + "s6";
+    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s6", false);
+    assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
+    int v1Version = v1.config().get().version();
+
+    // v2: remove 'pending' status WITH bumpVersion=true
+    byte[] v2Yaml = ("""
+        id: %s
+        displayName: "Blast Radius Test"
+        version: 2
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: false
+        fields:
+          - id: notes
+            displayName: Notes
+            type: text
+            required: false
+            order: 1
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+
+    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s6", true);
+
+    assertThat(v2.isInvalid())
+        .as("Status removal with bumpVersion=true must succeed; errors=" + v2.errors())
+        .isFalse();
+    int v2Version = v2.config().get().version();
+    assertThat(v2Version)
+        .as("New version must be >= prior + 1")
+        .isGreaterThanOrEqualTo(v1Version + 1);
+  }
+
+  // ---- Scenario 7: append-class status add without bump → 200 + same version ----
+
+  @Test
+  void appendClassStatusAdd_withoutBump_succeeds_sameVersion() {
+    String id = CT_PREFIX + "s7";
+    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s7", false);
+    assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
+    int v1Version = v1.config().get().version();
+
+    // v2: add a new status 'approved' (append-class)
+    byte[] v2Yaml = ("""
+        id: %s
+        displayName: "Blast Radius Test"
+        version: 2
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: false
+          - id: pending
+            displayName: Pending
+            color: amber
+            terminal: false
+          - id: approved
+            displayName: Approved
+            color: emerald
+            terminal: true
+        fields:
+          - id: notes
+            displayName: Notes
+            type: text
+            required: false
+            order: 1
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """.formatted(id)).getBytes(StandardCharsets.UTF_8);
+
+    ValidationResult v2 = configService.validateAndRegister("api-deploy.yaml", v2Yaml, "test:s7", false);
+
+    assertThat(v2.isInvalid())
+        .as("Append-class status add without bump must succeed; errors=" + v2.errors())
+        .isFalse();
+    // The version registry uses content hash for idempotency — new bytes produce a new version
+    // row only on REGISTERED outcome. The important assertion is that no WKS-CFG-029 is raised.
+    // Version may bump due to registry-hash change — that's OK per the append-class semantic.
+    // The key invariant: deploy succeeds.
+    assertThat(v2.config()).isPresent();
+  }
+
+  // ---- Scenario 8: first deploy (no prior version) → 200 + version 1; bumpVersion=true ignored --
+
+  @Test
+  void firstDeploy_noPriorVersion_succeeds_version1() {
+    String id = CT_PREFIX + "s8";
+    // No prior version exists. bumpVersion=true should be ignored with WARN log.
+    ValidationResult v1 = configService.validateAndRegister("api-deploy.yaml", v1Yaml(id), "test:s8", true);
+
+    assertThat(v1.isInvalid())
+        .as("First deploy with bumpVersion=true must succeed (benign no-op); errors=" + v1.errors())
+        .isFalse();
+    assertThat(v1.config()).isPresent();
+    assertThat(v1.config().get().version())
+        .as("First deploy must produce version 1")
+        .isEqualTo(1);
+  }
+
+  // ---- helper ------------------------------------------------------------
+
+  /**
+   * Asserts that {@code result.responseMeta().blastRadius.mutateDeltas[0].kind} matches
+   * {@code expectedKind}. Serialises the {@link BlastRadiusReport} via Jackson to verify the wire
+   * shape that the Admin UI will consume (AC2: meta.blastRadius must be present on WKS-CFG-029
+   * rejections).
+   */
+  private static void assertBlastRadiusInMeta(ValidationResult result, DeltaKind expectedKind) {
+    assertThat(result.responseMeta())
+        .as("responseMeta must not be empty on WKS-CFG-029 rejection")
+        .isNotEmpty();
+    Object raw = result.responseMeta().get("blastRadius");
+    assertThat(raw)
+        .as("meta.blastRadius must be present")
+        .isNotNull()
+        .isInstanceOf(BlastRadiusReport.class);
+
+    BlastRadiusReport report = (BlastRadiusReport) raw;
+    assertThat(report.mutateDeltas())
+        .as("mutateDeltas must be non-empty")
+        .isNotEmpty();
+    assertThat(report.mutateDeltas().get(0).kind())
+        .as("First mutate delta kind must match expected")
+        .isEqualTo(expectedKind);
+
+    // Verify Jackson wire shape is stable (Admin UI contract, AC2)
+    try {
+      String json = MAPPER.writeValueAsString(report);
+      JsonNode node = MAPPER.readTree(json);
+      assertThat(node.has("changeClass")).as("changeClass field must be present in JSON").isTrue();
+      assertThat(node.has("mutateDeltas")).as("mutateDeltas field must be present in JSON").isTrue();
+      assertThat(node.has("appendDeltas")).as("appendDeltas field must be present in JSON").isTrue();
+      assertThat(node.get("changeClass").asText()).isEqualTo("MUTATE_CLASS");
+    } catch (Exception e) {
+      throw new AssertionError("BlastRadiusReport JSON serialisation failed: " + e.getMessage(), e);
+    }
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingDiffTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingDiffTest.java
@@ -7,6 +7,7 @@ import com.wkspower.platform.domain.config.model.AttachmentDefinition.EndEventMa
 import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule;
 import com.wkspower.platform.domain.config.model.AttachmentDefinition.SignalMapping;
 import com.wkspower.platform.domain.config.model.AttachmentDefinition.UserTaskMapping;
+import com.wkspower.platform.domain.config.diff.MappingDiff;
 import com.wkspower.platform.domain.config.model.MappingChangeClass;
 import com.wkspower.platform.domain.config.model.MappingDefinition;
 import com.wkspower.platform.domain.port.ExecutionSignalKind;

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingDiffTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/MappingDiffTest.java
@@ -2,12 +2,12 @@ package com.wkspower.platform.infrastructure.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.wkspower.platform.domain.config.diff.MappingDiff;
 import com.wkspower.platform.domain.config.model.AttachmentDefinition;
 import com.wkspower.platform.domain.config.model.AttachmentDefinition.EndEventMapping;
 import com.wkspower.platform.domain.config.model.AttachmentDefinition.PropertyEmissionRule;
 import com.wkspower.platform.domain.config.model.AttachmentDefinition.SignalMapping;
 import com.wkspower.platform.domain.config.model.AttachmentDefinition.UserTaskMapping;
-import com.wkspower.platform.domain.config.diff.MappingDiff;
 import com.wkspower.platform.domain.config.model.MappingChangeClass;
 import com.wkspower.platform.domain.config.model.MappingDefinition;
 import com.wkspower.platform.domain.port.ExecutionSignalKind;


### PR DESCRIPTION
## Story 3.8 — Blast-Radius Validator & Mutate-Class Version Bump Enforcement

### Summary

- **AC1** — `CaseTypeDiff.classify()` covers all 6 mutate kinds (status removal/retarget/terminal-flip, field removal/retype/required-flip, BPMN mapping delegation via `MappingDiff`) + all append kinds. New package `domain/config/diff/` with `CaseTypeDiff`, `BlastRadiusReport`, `Delta`, `DeltaKind`.
- **AC2** — Mutate-class deploy without `bumpVersion=true` returns HTTP 422 + `WKS-CFG-029` with `meta.blastRadius` carrying the full `BlastRadiusReport`. `ErrorCode.WKS_CFG_029` javadoc updated to remove RESERVED language.
- **AC3** — `bumpVersion=true` honored for mutate-class (new version assigned) and append-class (admin opt-in, INFO log). `AdminController.deploy` accepts `?bumpVersion` query param; threaded to both YAML-only and YAML+BPMN service branches.
- **AC4** — First deploy (no prior version) skips classifier; `bumpVersion=true` on first deploy emits WARN + proceeds.
- **AC5** — `BlastRadiusValidatorPostgresIT` (7 scenarios): status-removal/terminal-flip/field-retype/field-required without bump → 422+WKS-CFG-029; status-removal with bump → 200+new version; append-class add → 200; first deploy → version 1.
- **Architecture** — `MappingDiff` relocated from `infrastructure/config` → `domain/config/diff` to satisfy the ArchUnit hexagonal layering rule (domain must not depend on infrastructure).

### Test coverage

- `CaseTypeDiffTest`: 17 unit cases (≥14 required)
- `BlastRadiusValidatorPostgresIT`: 7 Postgres-backed IT scenarios (scenario 5 BPMN mapping covered by unit suite)
- `AdminControllerTest` + `ConfigServiceDeployTest` extended
- `mvn verify -B`: 502 unit tests passing, 144 IT tests passing (1 skipped — Docker-unavailable guard)

### Commits

- `1892407f0` AC1 — classifier + records + unit tests (17 passing)
- `a50f43a3d` AC2-AC4 — service integration + controller wiring + unit test extensions
- `804e24e6d` AC5 — Postgres-IT + ArchUnit fix (MappingDiff moved to domain)
- `ed12e01f7` Spotless formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)