### PR TITLE
feat(6-1): Archetype UI Specialization — closed catalog, affordance registry, AlertDialog, terminal-accent

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
@@ -61,8 +61,19 @@ public record CaseTypeViewDto(
    * Wire-shape projection of {@code StageDefinition} for the case-type detail endpoint and the
    * embedded {@link CaseDto#caseType()} sub-object. Mirrors the YAML grammar 1:1 so the timeline
    * has the declared display name + ordinal without a second round-trip. Story 3.3.
+   *
+   * <p>Story 6.1 — adds {@code archetype} for UI specialization (nullable; omitted means default
+   * affordance).
    */
-  public record StageDefinitionView(String id, String displayName, int ordinal) {}
+  public record StageDefinitionView(String id, String displayName, int ordinal,
+      @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+      String archetype) {
+
+    /** Backward-compat constructor for callers that pre-date Story 6.1's archetype slot. */
+    public StageDefinitionView(String id, String displayName, int ordinal) {
+      this(id, displayName, ordinal, null);
+    }
+  }
 
   /**
    * Wire-shape projection of {@code FieldDefinition} for the case-type detail endpoint. Every
@@ -105,11 +116,28 @@ public record CaseTypeViewDto(
       String dataModel,
       String rendering,
       List<FieldView> fields,
-      List<FormSectionView> sections) {
+      List<FormSectionView> sections,
+      /**
+       * Story 6.1 — optional archetype from the closed catalog. {@code null} means omitted;
+       * the frontend falls back to the default affordance. Excluded from JSON when null to avoid
+       * surfacing implementation details to unaware clients.
+       */
+      @JsonInclude(JsonInclude.Include.NON_NULL) String archetype) {
 
     public FormDefinitionView {
       fields = fields == null ? List.of() : List.copyOf(fields);
       sections = sections == null ? List.of() : List.copyOf(sections);
+    }
+
+    /** Backward-compat constructor for callers that pre-date Story 6.1's archetype slot. */
+    public FormDefinitionView(
+        String id,
+        String topology,
+        String dataModel,
+        String rendering,
+        List<FieldView> fields,
+        List<FormSectionView> sections) {
+      this(id, topology, dataModel, rendering, fields, sections, null);
     }
   }
 

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
@@ -65,9 +65,13 @@ public record CaseTypeViewDto(
    * <p>Story 6.1 — adds {@code archetype} for UI specialization (nullable; omitted means default
    * affordance).
    */
-  public record StageDefinitionView(String id, String displayName, int ordinal,
-      @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-      String archetype) {
+  public record StageDefinitionView(
+      String id,
+      String displayName,
+      int ordinal,
+      @com.fasterxml.jackson.annotation.JsonInclude(
+              com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+          String archetype) {
 
     /** Backward-compat constructor for callers that pre-date Story 6.1's archetype slot. */
     public StageDefinitionView(String id, String displayName, int ordinal) {
@@ -118,8 +122,8 @@ public record CaseTypeViewDto(
       List<FieldView> fields,
       List<FormSectionView> sections,
       /**
-       * Story 6.1 — optional archetype from the closed catalog. {@code null} means omitted;
-       * the frontend falls back to the default affordance. Excluded from JSON when null to avoid
+       * Story 6.1 — optional archetype from the closed catalog. {@code null} means omitted; the
+       * frontend falls back to the default affordance. Excluded from JSON when null to avoid
        * surfacing implementation details to unaware clients.
        */
       @JsonInclude(JsonInclude.Include.NON_NULL) String archetype) {

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -191,7 +191,12 @@ public final class CaseDtoMapper {
         form.sections().stream().map(CaseDtoMapper::toFormSectionView).toList();
     // Story 6.1 — thread archetype through; null means omitted (default affordance on frontend).
     return new FormDefinitionView(
-        form.id(), form.topology(), form.dataModel(), form.rendering(), fieldViews, sectionViews,
+        form.id(),
+        form.topology(),
+        form.dataModel(),
+        form.rendering(),
+        fieldViews,
+        sectionViews,
         form.archetype());
   }
 

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -162,7 +162,8 @@ public final class CaseDtoMapper {
   public static CaseTypeViewDto toCaseTypeView(CaseTypeConfig caseType) {
     List<StageDefinitionView> stages =
         caseType.stages().stream()
-            .map(s -> new StageDefinitionView(s.id(), s.displayName(), s.ordinal()))
+            // Story 6.1 — thread archetype through to the wire DTO.
+            .map(s -> new StageDefinitionView(s.id(), s.displayName(), s.ordinal(), s.archetype()))
             .toList();
     // Story 5.2 — map form definitions to wire DTOs.
     List<FormDefinitionView> forms =
@@ -188,8 +189,10 @@ public final class CaseDtoMapper {
     List<FieldView> fieldViews = form.fields().stream().map(CaseDtoMapper::toFieldView).toList();
     List<FormSectionView> sectionViews =
         form.sections().stream().map(CaseDtoMapper::toFormSectionView).toList();
+    // Story 6.1 — thread archetype through; null means omitted (default affordance on frontend).
     return new FormDefinitionView(
-        form.id(), form.topology(), form.dataModel(), form.rendering(), fieldViews, sectionViews);
+        form.id(), form.topology(), form.dataModel(), form.rendering(), fieldViews, sectionViews,
+        form.archetype());
   }
 
   /** Story 5.3 — map one {@link FormSection} to its wire DTO. */

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
@@ -36,7 +36,13 @@ public record FormDefinition(
      * Story 5.3 — sections declared for {@code dataModel: sectioned} forms. Empty for monolithic
      * forms.
      */
-    List<FormSection> sections) {
+    List<FormSection> sections,
+    /**
+     * Story 6.1 — optional archetype from the closed catalog ({@code draft_section},
+     * {@code submit_for_processing}, {@code business_final}). {@code null} means omitted — the
+     * frontend falls back to default affordance behavior.
+     */
+    String archetype) {
 
   public FormDefinition {
     fields = fields == null ? List.of() : List.copyOf(fields);
@@ -45,8 +51,7 @@ public record FormDefinition(
 
   /**
    * Backward-compat constructor for callers that pre-date Story 5.3's {@code sections} slot.
-   * Defaults {@code sections} to {@link List#of()}, preserving the contract that monolithic forms
-   * never have sections.
+   * Defaults {@code sections} and {@code archetype} to their null/empty defaults.
    */
   public FormDefinition(
       String id,
@@ -54,6 +59,20 @@ public record FormDefinition(
       String dataModel,
       String rendering,
       List<FieldDefinition> fields) {
-    this(id, topology, dataModel, rendering, fields, List.of());
+    this(id, topology, dataModel, rendering, fields, List.of(), null);
+  }
+
+  /**
+   * Backward-compat constructor for callers that pre-date Story 6.1's {@code archetype} slot.
+   * Defaults {@code archetype} to {@code null}.
+   */
+  public FormDefinition(
+      String id,
+      String topology,
+      String dataModel,
+      String rendering,
+      List<FieldDefinition> fields,
+      List<FormSection> sections) {
+    this(id, topology, dataModel, rendering, fields, sections, null);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
@@ -38,9 +38,9 @@ public record FormDefinition(
      */
     List<FormSection> sections,
     /**
-     * Story 6.1 — optional archetype from the closed catalog ({@code draft_section},
-     * {@code submit_for_processing}, {@code business_final}). {@code null} means omitted — the
-     * frontend falls back to default affordance behavior.
+     * Story 6.1 — optional archetype from the closed catalog ({@code draft_section}, {@code
+     * submit_for_processing}, {@code business_final}). {@code null} means omitted — the frontend
+     * falls back to default affordance behavior.
      */
     String archetype) {
 

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/StageDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/StageDefinition.java
@@ -48,7 +48,9 @@ public record StageDefinition(
     String displayName,
     int ordinal,
     List<StatusDefinition> statuses,
-    Optional<String> initialStatus) {
+    Optional<String> initialStatus,
+    /** Story 6.1 — optional archetype from the closed catalog. {@code null} means omitted. */
+    String archetype) {
 
   public StageDefinition {
     Objects.requireNonNull(id, "id");
@@ -68,7 +70,20 @@ public record StageDefinition(
    * stage with no {@code statuses:} or {@code initialStatus:} keys.
    */
   public StageDefinition(String id, String displayName, int ordinal) {
-    this(id, displayName, ordinal, null, Optional.empty());
+    this(id, displayName, ordinal, null, Optional.empty(), null);
+  }
+
+  /**
+   * Backward-compat constructor for Story 3.6 callers that pre-date Story 6.1's {@code archetype}
+   * slot. Defaults {@code archetype} to {@code null}.
+   */
+  public StageDefinition(
+      String id,
+      String displayName,
+      int ordinal,
+      List<StatusDefinition> statuses,
+      Optional<String> initialStatus) {
+    this(id, displayName, ordinal, statuses, initialStatus, null);
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -439,9 +439,9 @@ public enum ErrorCode {
   // ---------------------------------------------------------------------------
   /**
    * Story 6.1 — YAML-declared archetype on a task / form / stage references a value outside the
-   * closed Phase-0 catalog ({@code draft_section}, {@code submit_for_processing},
-   * {@code business_final}). Distinct from BPMN-side {@link #WKS_CFG_020} (missing) and
-   * {@link #WKS_CFG_021} (contradiction); this code is the YAML-surface unknown-value violation.
+   * closed Phase-0 catalog ({@code draft_section}, {@code submit_for_processing}, {@code
+   * business_final}). Distinct from BPMN-side {@link #WKS_CFG_020} (missing) and {@link
+   * #WKS_CFG_021} (contradiction); this code is the YAML-surface unknown-value violation.
    */
   WKS_ARCH_001("WKS-ARCH-001");
 

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -428,7 +428,22 @@ public enum ErrorCode {
    * claims are absent. Platform boots in degraded state (WARN-level; not an exception to callers).
    * Story 7.1 AC3.
    */
-  WKS_LIC_002("WKS-LIC-002");
+  WKS_LIC_002("WKS-LIC-002"),
+
+  // ---------------------------------------------------------------------------
+  // Archetype validation band (Story 6.1) — YAML-surface archetype violations.
+  // Distinct from BPMN-side WKS-CFG-020 (missing) and WKS-CFG-021 (contradiction);
+  // this code is the YAML-surface unknown-value violation.
+  // Per feedback_error_codes_are_wire_contract.md: the wire string is stable and must
+  // never be reused for a different meaning.
+  // ---------------------------------------------------------------------------
+  /**
+   * Story 6.1 — YAML-declared archetype on a task / form / stage references a value outside the
+   * closed Phase-0 catalog ({@code draft_section}, {@code submit_for_processing},
+   * {@code business_final}). Distinct from BPMN-side {@link #WKS_CFG_020} (missing) and
+   * {@link #WKS_CFG_021} (contradiction); this code is the YAML-surface unknown-value violation.
+   */
+  WKS_ARCH_001("WKS-ARCH-001");
 
   private final String wire;
 

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -72,6 +72,17 @@ public class ConfigValidator {
   }
 
   /**
+   * Story 6.1 AC1 — Closed archetype catalog for YAML-declared tasks / forms / stages.
+   *
+   * <p>Per architecture rules: deliberately duplicated from {@code BpmnValidator.VALID_ARCHETYPES}
+   * (the BPMN surface); the two surfaces have distinct error codes ({@code WKS-CFG-020/021} vs
+   * {@code WKS-ARCH-001}) and extracting a shared constant would couple the engine module to the
+   * config module unnecessarily. When Phase-1 adds a fourth archetype, BOTH sites must be updated.
+   */
+  private static final Set<String> VALID_ARCHETYPES =
+      Set.of("draft_section", "submit_for_processing", "business_final");
+
+  /**
    * Reserved stage ids — Story 3.1 AC1 (Sprint-1 triage Q4: initial set, extend on first conflict).
    * Lives here as a private constant so the validator owns the rule; if a future story needs to
    * extend, the touch-point is one place.
@@ -157,6 +168,24 @@ public class ConfigValidator {
     // its findings into the same error list. FormValidator is collect-all and never short-circuits.
     if (formValidator != null && raw.forms() != null && !raw.forms().definitions().isEmpty()) {
       formValidator.validate(raw.forms(), errors);
+    }
+
+    // Story 6.1 AC1 — Validate form archetypes against the closed catalog.
+    // Runs unconditionally (after FormValidator) so archetype violations are always surfaced.
+    if (raw.forms() != null) {
+      List<RawFormDefinition> formDefs = raw.forms().definitions();
+      for (int fi = 0; fi < formDefs.size(); fi++) {
+        RawFormDefinition form = formDefs.get(fi);
+        if (form != null && form.archetype() != null && !VALID_ARCHETYPES.contains(form.archetype())) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_ARCH_001.wire(),
+                  "Unknown archetype '"
+                      + form.archetype()
+                      + "' — must be one of: draft_section, submit_for_processing, business_final",
+                  "/forms/" + fi + "/archetype"));
+        }
+      }
     }
 
     if (!errors.isEmpty()) {
@@ -248,7 +277,18 @@ public class ConfigValidator {
         List<StatusDefinition> stageStatuses = checkStageStatuses(s.statuses(), base, eb, errors);
         Optional<String> initialStatus =
             resolveStageInitialStatus(s.initialStatus(), stageStatuses, base, eb, errors);
-        out.add(new StageDefinition(id, displayName, i, stageStatuses, initialStatus));
+        // Story 6.1 — validate and thread archetype through.
+        if (s.archetype() != null && !VALID_ARCHETYPES.contains(s.archetype())) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_ARCH_001.wire(),
+                  "Unknown archetype '"
+                      + s.archetype()
+                      + "' — must be one of: draft_section, submit_for_processing, business_final",
+                  "/stages/" + i + "/archetype"));
+        }
+        out.add(new StageDefinition(id, displayName, i, stageStatuses, initialStatus,
+            s.archetype()));
       }
     }
     return out;

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -176,7 +176,9 @@ public class ConfigValidator {
       List<RawFormDefinition> formDefs = raw.forms().definitions();
       for (int fi = 0; fi < formDefs.size(); fi++) {
         RawFormDefinition form = formDefs.get(fi);
-        if (form != null && form.archetype() != null && !VALID_ARCHETYPES.contains(form.archetype())) {
+        if (form != null
+            && form.archetype() != null
+            && !VALID_ARCHETYPES.contains(form.archetype())) {
           errors.add(
               ErrorDetail.ofField(
                   ErrorCode.WKS_ARCH_001.wire(),
@@ -287,8 +289,8 @@ public class ConfigValidator {
                       + "' — must be one of: draft_section, submit_for_processing, business_final",
                   "/stages/" + i + "/archetype"));
         }
-        out.add(new StageDefinition(id, displayName, i, stageStatuses, initialStatus,
-            s.archetype()));
+        out.add(
+            new StageDefinition(id, displayName, i, stageStatuses, initialStatus, s.archetype()));
       }
     }
     return out;

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
@@ -37,8 +37,10 @@ public final class FormDefinitionMapper {
   public static FormDefinition toDomain(RawFormDefinition raw) {
     List<FieldDefinition> fields = mapFields(raw.fields());
     List<FormSection> sections = mapSections(raw.sections());
+    // Story 6.1 — thread archetype through; null means omitted (default affordance on frontend).
     return new FormDefinition(
-        raw.id(), raw.topology(), raw.dataModel(), raw.rendering(), fields, sections);
+        raw.id(), raw.topology(), raw.dataModel(), raw.rendering(), fields, sections,
+        raw.archetype());
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
@@ -39,7 +39,12 @@ public final class FormDefinitionMapper {
     List<FormSection> sections = mapSections(raw.sections());
     // Story 6.1 — thread archetype through; null means omitted (default affordance on frontend).
     return new FormDefinition(
-        raw.id(), raw.topology(), raw.dataModel(), raw.rendering(), fields, sections,
+        raw.id(),
+        raw.topology(),
+        raw.dataModel(),
+        raw.rendering(),
+        fields,
+        sections,
         raw.archetype());
   }
 

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -92,7 +92,9 @@ public record RawCaseTypeConfig(
    * the validator can iterate uniformly.
    */
   public record RawStage(
-      String id, String displayName, List<RawStatus> statuses, String initialStatus) {
+      String id, String displayName, List<RawStatus> statuses, String initialStatus,
+      /** Story 6.1 — optional archetype from the closed catalog. */
+      String archetype) {
 
     /**
      * Backward-compat constructor — pre-Story 3.6 callers that didn't know about stage-scoped
@@ -100,12 +102,12 @@ public record RawCaseTypeConfig(
      * back to the flat case-type-level status set per Story 3.6 AC2).
      */
     public RawStage(String id, String displayName) {
-      this(id, displayName, null, null);
+      this(id, displayName, null, null, null);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static RawStage fromString(String id) {
-      return new RawStage(id, null, null, null);
+      return new RawStage(id, null, null, null, null);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -113,8 +115,9 @@ public record RawCaseTypeConfig(
         @JsonProperty("id") String id,
         @JsonProperty("displayName") String displayName,
         @JsonProperty("statuses") List<RawStatus> statuses,
-        @JsonProperty("initialStatus") String initialStatus) {
-      return new RawStage(id, displayName, statuses, initialStatus);
+        @JsonProperty("initialStatus") String initialStatus,
+        @JsonProperty("archetype") String archetype) {
+      return new RawStage(id, displayName, statuses, initialStatus, archetype);
     }
   }
 

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -92,7 +92,10 @@ public record RawCaseTypeConfig(
    * the validator can iterate uniformly.
    */
   public record RawStage(
-      String id, String displayName, List<RawStatus> statuses, String initialStatus,
+      String id,
+      String displayName,
+      List<RawStatus> statuses,
+      String initialStatus,
       /** Story 6.1 — optional archetype from the closed catalog. */
       String archetype) {
 

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
@@ -34,9 +34,9 @@ public record RawFormDefinition(
      */
     @JsonProperty("sections") List<RawFormSection> sections,
     /**
-     * Story 6.1 — optional archetype from the closed catalog ({@code draft_section},
-     * {@code submit_for_processing}, {@code business_final}). Validated by {@link ConfigValidator}
-     * which emits {@code WKS-ARCH-001} for unknown values.
+     * Story 6.1 — optional archetype from the closed catalog ({@code draft_section}, {@code
+     * submit_for_processing}, {@code business_final}). Validated by {@link ConfigValidator} which
+     * emits {@code WKS-ARCH-001} for unknown values.
      */
     @JsonProperty("archetype") String archetype) {
 

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
@@ -32,11 +32,17 @@ public record RawFormDefinition(
      * monolithic forms; validated by {@link FormValidator} when {@code dataModel} is {@code
      * sectioned}.
      */
-    @JsonProperty("sections") List<RawFormSection> sections) {
+    @JsonProperty("sections") List<RawFormSection> sections,
+    /**
+     * Story 6.1 — optional archetype from the closed catalog ({@code draft_section},
+     * {@code submit_for_processing}, {@code business_final}). Validated by {@link ConfigValidator}
+     * which emits {@code WKS-ARCH-001} for unknown values.
+     */
+    @JsonProperty("archetype") String archetype) {
 
   /**
    * Backward-compat constructor for callers (mostly tests) that pre-date Story 5.3's {@code
-   * sections} slot. Defaults {@code sections} to {@code null} — monolithic forms have no sections.
+   * sections} slot. Defaults {@code sections} and {@code archetype} to {@code null}.
    */
   public RawFormDefinition(
       String id,
@@ -44,6 +50,20 @@ public record RawFormDefinition(
       String dataModel,
       String rendering,
       List<Map<String, Object>> fields) {
-    this(id, topology, dataModel, rendering, fields, null);
+    this(id, topology, dataModel, rendering, fields, null, null);
+  }
+
+  /**
+   * Backward-compat constructor for callers that pre-date Story 6.1's {@code archetype} slot.
+   * Defaults {@code archetype} to {@code null}.
+   */
+  public RawFormDefinition(
+      String id,
+      String topology,
+      String dataModel,
+      String rendering,
+      List<Map<String, Object>> fields,
+      List<RawFormSection> sections) {
+    this(id, topology, dataModel, rendering, fields, sections, null);
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
@@ -1054,7 +1054,9 @@ class ConfigValidatorTest {
             displayName: Final
         """;
     var result = validate(yaml);
-    assertThat(result.isInvalid()).as("omitted stage archetype should not produce errors").isFalse();
+    assertThat(result.isInvalid())
+        .as("omitted stage archetype should not produce errors")
+        .isFalse();
   }
 
   private static final String GREEN_YAML =

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorTest.java
@@ -870,6 +870,193 @@ class ConfigValidatorTest {
     return match.get();
   }
 
+  // ---- Story 6.1 — YAML archetype validation (AC1) ----
+
+  @Test
+  void story61_formArchetypeUnknown_emitsWksArch001() {
+    String yaml =
+        """
+        id: ct-arch
+        displayName: Arch Test
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        forms:
+          definitions:
+            - id: intake-form
+              topology: single
+              dataModel: monolithic
+              rendering: single-page
+              archetype: unknown_archetype
+              fields: []
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).isTrue();
+    var e = assertErrorOn(result.errors(), "WKS-ARCH-001", "/forms/0/archetype");
+    assertThat(e.message()).contains("unknown_archetype");
+    assertThat(e.message()).contains("draft_section");
+  }
+
+  @Test
+  void story61_formArchetypeDraftSection_passes() {
+    String yaml =
+        """
+        id: ct-arch
+        displayName: Arch Test
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        forms:
+          definitions:
+            - id: intake-form
+              topology: single
+              dataModel: monolithic
+              rendering: single-page
+              archetype: draft_section
+              fields: []
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).as("draft_section is a valid archetype").isFalse();
+  }
+
+  @Test
+  void story61_formArchetypeSubmitForProcessing_passes() {
+    String yaml =
+        """
+        id: ct-arch
+        displayName: Arch Test
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        forms:
+          definitions:
+            - id: intake-form
+              topology: single
+              dataModel: monolithic
+              rendering: single-page
+              archetype: submit_for_processing
+              fields: []
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).as("submit_for_processing is a valid archetype").isFalse();
+  }
+
+  @Test
+  void story61_formArchetypeBusinessFinal_passes() {
+    String yaml =
+        """
+        id: ct-arch
+        displayName: Arch Test
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        forms:
+          definitions:
+            - id: intake-form
+              topology: single
+              dataModel: monolithic
+              rendering: single-page
+              archetype: business_final
+              fields: []
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).as("business_final is a valid archetype").isFalse();
+  }
+
+  @Test
+  void story61_formArchetypeOmitted_passes() {
+    String yaml =
+        """
+        id: ct-arch
+        displayName: Arch Test
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        forms:
+          definitions:
+            - id: intake-form
+              topology: single
+              dataModel: monolithic
+              rendering: single-page
+              fields: []
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).as("omitted archetype should not produce errors").isFalse();
+  }
+
+  @Test
+  void story61_stageArchetypeUnknown_emitsWksArch001() {
+    String yaml =
+        """
+        id: ct-stage-arch
+        displayName: Stage Arch Test
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+          - { id: closed, displayName: Closed, color: zinc }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        stages:
+          - id: intake
+            displayName: Intake
+          - id: review
+            displayName: Review
+          - id: final
+            displayName: Final
+            archetype: not_a_real_archetype
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).isTrue();
+    var e = assertErrorOn(result.errors(), "WKS-ARCH-001", "/stages/2/archetype");
+    assertThat(e.message()).contains("not_a_real_archetype");
+  }
+
+  @Test
+  void story61_stageArchetypeOmitted_passes() {
+    String yaml =
+        """
+        id: ct-stage-arch
+        displayName: Stage Arch Test
+        version: 1
+        statuses:
+          - { id: open, displayName: Open, color: blue }
+          - { id: closed, displayName: Closed, color: zinc }
+        listColumns: []
+        roles:
+          - name: officer
+            permissions: [view]
+        stages:
+          - id: intake
+            displayName: Intake
+          - id: final
+            displayName: Final
+        """;
+    var result = validate(yaml);
+    assertThat(result.isInvalid()).as("omitted stage archetype should not produce errors").isFalse();
+  }
+
   private static final String GREEN_YAML =
       """
       id: loan-application

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
@@ -151,4 +151,29 @@ class FormDefinitionMapperTest {
     assertThat(result.sections()).hasSize(1);
     assertThat(result.sections().get(0).id()).isEqualTo("employment");
   }
+
+  // ---- Story 6.1 — archetype round-trip ----
+
+  @Test
+  void archetype_presentInRaw_roundTripsToDomainsRecord() {
+    var raw =
+        new RawFormDefinition(
+            "final-form", "single", "monolithic", "single-page",
+            List.of(Map.of("id", "note", "displayName", "Note", "type", "text",
+                "required", false, "order", 0)),
+            null, "business_final");
+    FormDefinition result = FormDefinitionMapper.toDomain(raw);
+    assertThat(result.archetype()).isEqualTo("business_final");
+  }
+
+  @Test
+  void archetype_null_nullInDomainRecord() {
+    var raw =
+        new RawFormDefinition(
+            "draft-form", "single", "monolithic", "single-page",
+            List.of(Map.of("id", "note", "displayName", "Note", "type", "text",
+                "required", false, "order", 0)));
+    FormDefinition result = FormDefinitionMapper.toDomain(raw);
+    assertThat(result.archetype()).isNull();
+  }
 }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
@@ -158,10 +158,24 @@ class FormDefinitionMapperTest {
   void archetype_presentInRaw_roundTripsToDomainsRecord() {
     var raw =
         new RawFormDefinition(
-            "final-form", "single", "monolithic", "single-page",
-            List.of(Map.of("id", "note", "displayName", "Note", "type", "text",
-                "required", false, "order", 0)),
-            null, "business_final");
+            "final-form",
+            "single",
+            "monolithic",
+            "single-page",
+            List.of(
+                Map.of(
+                    "id",
+                    "note",
+                    "displayName",
+                    "Note",
+                    "type",
+                    "text",
+                    "required",
+                    false,
+                    "order",
+                    0)),
+            null,
+            "business_final");
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
     assertThat(result.archetype()).isEqualTo("business_final");
   }
@@ -170,9 +184,22 @@ class FormDefinitionMapperTest {
   void archetype_null_nullInDomainRecord() {
     var raw =
         new RawFormDefinition(
-            "draft-form", "single", "monolithic", "single-page",
-            List.of(Map.of("id", "note", "displayName", "Note", "type", "text",
-                "required", false, "order", 0)));
+            "draft-form",
+            "single",
+            "monolithic",
+            "single-page",
+            List.of(
+                Map.of(
+                    "id",
+                    "note",
+                    "displayName",
+                    "Note",
+                    "type",
+                    "text",
+                    "required",
+                    false,
+                    "order",
+                    0)));
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
     assertThat(result.archetype()).isNull();
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -1514,6 +1515,52 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/src/components/forms/MultiSectionFormRenderer.test.tsx
+++ b/frontend/src/components/forms/MultiSectionFormRenderer.test.tsx
@@ -6,7 +6,7 @@
  * AC4: progress indicator shows "X of Y sections complete".
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import type { ReactElement } from 'react';
@@ -216,6 +216,100 @@ describe('MultiSectionFormRenderer — AC2: submit blocked when required fields 
       />,
     );
     await user.click(screen.getByRole('button', { name: /submit/i }));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(called).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 6.1 AC4 — archetype-driven CTA and confirmation dialog
+// ---------------------------------------------------------------------------
+
+describe('MultiSectionFormRenderer — Story 6.1 AC4: archetype affordances', () => {
+  it('renders "Submit for final approval" button for business_final archetype', () => {
+    const form: FormDefinitionView = {
+      ...twoSectionForm(),
+      archetype: 'business_final',
+    };
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Submit for final approval' })).toBeInTheDocument();
+  });
+
+  it('renders "Save section" (ghost) button for draft_section archetype', () => {
+    const form: FormDefinitionView = {
+      ...twoSectionForm(),
+      archetype: 'draft_section',
+    };
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Save section' });
+    expect(btn).toBeInTheDocument();
+    expect(btn.className).toMatch(/hover:bg-\[var\(--muted\)\]/);
+  });
+
+  it('renders "Submit" button when archetype is null (backward-compat)', () => {
+    const form: FormDefinitionView = {
+      ...twoSectionForm(),
+      archetype: null,
+    };
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+
+  it('business_final: clicking submit opens AlertDialog', async () => {
+    const user = userEvent.setup();
+    const form: FormDefinitionView = {
+      ...twoSectionForm(),
+      archetype: 'business_final',
+    };
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Submit for final approval' }));
+    await screen.findByText('Confirm submission');
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('business_final: cancel dialog does NOT fire POST', async () => {
+    const user = userEvent.setup();
+    let called = false;
+    server.use(
+      http.post('/api/cases/:caseId/forms/:formId/submit', () => {
+        called = true;
+        return HttpResponse.json({ data: {} });
+      }),
+    );
+    const form: FormDefinitionView = {
+      ...twoSectionForm(),
+      archetype: 'business_final',
+    };
+    wrap(
+      <MultiSectionFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Submit for final approval' }));
+    await screen.findByText('Confirm submission');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(screen.queryByText('Confirm submission')).not.toBeInTheDocument());
     await new Promise((r) => setTimeout(r, 50));
     expect(called).toBe(false);
   });

--- a/frontend/src/components/forms/MultiSectionFormRenderer.tsx
+++ b/frontend/src/components/forms/MultiSectionFormRenderer.tsx
@@ -6,6 +6,15 @@ import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
 import { ApiError } from '@/api/client';
 import { submitForm } from '@/api/forms';
 import { Alert } from '@/components/ui/Alert';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/AlertDialog';
 import { Button } from '@/components/ui/Button';
 import { Checkbox } from '@/components/ui/Checkbox';
 import { FormErrorsBanner, type FormErrorEntry } from '@/components/ui/FormErrorsBanner';
@@ -21,6 +30,7 @@ import {
 } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
 import { t } from '@/i18n';
+import { getArchetypeAffordance } from '@/lib/archetypes';
 import { buildZodFromFieldDefs } from '@/lib/buildZodFromFieldDefs';
 import type { FieldDefinition, FormDefinitionView, FormSectionView } from '@/types/caseType';
 
@@ -233,8 +243,39 @@ export function MultiSectionFormRenderer({
     </Button>
   );
 
+  // Story 6.1 AC4 — archetype-driven submit CTA affordance.
+  // When archetype is absent, falls back to the pre-6.1 'form.submit' label and default variant,
+  // preserving existing behavior exactly (AC4: "for archetype = null, existing behavior preserved").
+  const affordance = getArchetypeAffordance(formDefinition.archetype);
+  const submitLabel = formDefinition.archetype ? t(affordance.ctaLabelKey) : t('form.submit');
+  const submitVariant = formDefinition.archetype
+    ? affordance.ctaTone === 'secondary'
+      ? 'ghost'
+      : 'default'
+    : 'default';
+  const needsDialog = affordance.confirmationFlow === 'confirmation-dialog';
+  const isTerminal =
+    affordance.postActionState === 'locked' || affordance.postActionState === 'terminal-accent';
+
+  const submitButton = (
+    <MutationButton
+      state={state}
+      variant={submitVariant}
+      confirmingLabel={t('common.lifecycle.confirming')}
+      confirmedLabel={t('common.lifecycle.confirmed')}
+      failedLabel={failedLabel}
+      retryAction={retryAction}
+      // Story 6.1 AC4 — when an AlertDialog interposes, the button must NOT be type="submit"
+      // so clicking the trigger opens the dialog rather than running HTML5 form validation.
+      // The dialog's AlertDialogAction fires form.handleSubmit(onSubmit) explicitly.
+      type={needsDialog ? 'button' : 'submit'}
+    >
+      {submitLabel}
+    </MutationButton>
+  );
+
   return (
-    <div>
+    <div data-archetype-terminal={isTerminal && isSuccess ? 'true' : undefined}>
       <FormProvider {...form}>
         <form
           noValidate
@@ -322,15 +363,28 @@ export function MultiSectionFormRenderer({
           ) : null}
 
           <div className="flex justify-end">
-            <MutationButton
-              state={state}
-              confirmingLabel={t('common.lifecycle.confirming')}
-              confirmedLabel={t('common.lifecycle.confirmed')}
-              failedLabel={failedLabel}
-              retryAction={retryAction}
-            >
-              {t('form.submit')}
-            </MutationButton>
+            {needsDialog ? (
+              // Story 6.1 AC4 — business_final: AlertDialog interposes before submitForm.
+              <AlertDialog>
+                <AlertDialogTrigger asChild>{submitButton}</AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogTitle>{t('task.confirm.title')}</AlertDialogTitle>
+                  <AlertDialogDescription>{t('task.confirm.description')}</AlertDialogDescription>
+                  <div className="flex justify-end gap-2 pt-2">
+                    <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => {
+                        void form.handleSubmit(onSubmit)();
+                      }}
+                    >
+                      {submitLabel}
+                    </AlertDialogAction>
+                  </div>
+                </AlertDialogContent>
+              </AlertDialog>
+            ) : (
+              submitButton
+            )}
           </div>
         </form>
       </FormProvider>

--- a/frontend/src/components/forms/SinglePageFormRenderer.test.tsx
+++ b/frontend/src/components/forms/SinglePageFormRenderer.test.tsx
@@ -5,7 +5,7 @@
  * AC2: empty submit shows FormErrorsBanner with field names.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import type { ReactElement } from 'react';
@@ -166,6 +166,102 @@ describe('SinglePageFormRenderer — AC2: empty submit shows FormErrorsBanner', 
     );
     await user.click(screen.getByRole('button', { name: /submit/i }));
     // Give any async effects time to flush.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(called).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 6.1 AC4 — archetype-driven CTA and confirmation dialog
+// ---------------------------------------------------------------------------
+
+describe('SinglePageFormRenderer — Story 6.1 AC4: archetype affordances', () => {
+  it('renders "Submit for final approval" button for business_final archetype', () => {
+    const form: FormDefinitionView = {
+      ...threeFieldForm(),
+      archetype: 'business_final',
+    };
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Submit for final approval' })).toBeInTheDocument();
+  });
+
+  it('renders "Save section" (ghost) button for draft_section archetype', () => {
+    const form: FormDefinitionView = {
+      ...threeFieldForm(),
+      archetype: 'draft_section',
+    };
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Save section' });
+    expect(btn).toBeInTheDocument();
+    expect(btn.className).toMatch(/hover:bg-\[var\(--muted\)\]/);
+  });
+
+  it('renders "Submit" button when archetype is null (backward-compat)', () => {
+    const form: FormDefinitionView = {
+      ...threeFieldForm(),
+      archetype: null,
+    };
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+
+  it('business_final: clicking submit opens AlertDialog', async () => {
+    const user = userEvent.setup();
+    const form: FormDefinitionView = {
+      ...threeFieldForm(),
+      archetype: 'business_final',
+    };
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Submit for final approval' }));
+    // AlertDialog should open showing confirmation title
+    await screen.findByText('Confirm submission');
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('business_final: cancel dialog does NOT fire PUT', async () => {
+    const user = userEvent.setup();
+    let called = false;
+    server.use(
+      http.post('/api/cases/:caseId/forms/:formId/submit', () => {
+        called = true;
+        return HttpResponse.json({ data: {} });
+      }),
+    );
+    const form: FormDefinitionView = {
+      ...threeFieldForm(),
+      archetype: 'business_final',
+    };
+    wrap(
+      <SinglePageFormRenderer
+        formDefinition={form}
+        caseId="00000000-0000-0000-0000-000000000001"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Submit for final approval' }));
+    await screen.findByText('Confirm submission');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    // Dialog closes
+    await waitFor(() => expect(screen.queryByText('Confirm submission')).not.toBeInTheDocument());
     await new Promise((r) => setTimeout(r, 50));
     expect(called).toBe(false);
   });

--- a/frontend/src/components/forms/SinglePageFormRenderer.tsx
+++ b/frontend/src/components/forms/SinglePageFormRenderer.tsx
@@ -5,6 +5,15 @@ import { FormProvider, useForm, type UseFormReturn } from 'react-hook-form';
 import { ApiError } from '@/api/client';
 import { submitForm } from '@/api/forms';
 import { Alert } from '@/components/ui/Alert';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/AlertDialog';
 import { Button } from '@/components/ui/Button';
 import { Checkbox } from '@/components/ui/Checkbox';
 import { FormErrorsBanner, type FormErrorEntry } from '@/components/ui/FormErrorsBanner';
@@ -20,6 +29,7 @@ import {
 } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
 import { t } from '@/i18n';
+import { getArchetypeAffordance } from '@/lib/archetypes';
 import { buildZodFromFieldDefs } from '@/lib/buildZodFromFieldDefs';
 import type { FieldDefinition, FormDefinitionView } from '@/types/caseType';
 
@@ -185,8 +195,39 @@ export function SinglePageFormRenderer({
     </Button>
   );
 
+  // Story 6.1 AC4 — archetype-driven submit CTA affordance.
+  // When archetype is absent, falls back to the pre-6.1 'form.submit' label and default variant,
+  // preserving existing behavior exactly (AC4: "for archetype = null, existing behavior preserved").
+  const affordance = getArchetypeAffordance(formDefinition.archetype);
+  const submitLabel = formDefinition.archetype ? t(affordance.ctaLabelKey) : t('form.submit');
+  const submitVariant = formDefinition.archetype
+    ? affordance.ctaTone === 'secondary'
+      ? 'ghost'
+      : 'default'
+    : 'default';
+  const needsDialog = affordance.confirmationFlow === 'confirmation-dialog';
+  const isTerminal =
+    affordance.postActionState === 'locked' || affordance.postActionState === 'terminal-accent';
+
+  const submitButton = (
+    <MutationButton
+      state={state}
+      variant={submitVariant}
+      confirmingLabel={t('common.lifecycle.confirming')}
+      confirmedLabel={t('common.lifecycle.confirmed')}
+      failedLabel={failedLabel}
+      retryAction={retryAction}
+      // Story 6.1 AC4 — when an AlertDialog interposes, the button must NOT be type="submit"
+      // so clicking the trigger opens the dialog rather than running HTML5 form validation.
+      // The dialog's AlertDialogAction fires form.handleSubmit(onSubmit) explicitly.
+      type={needsDialog ? 'button' : 'submit'}
+    >
+      {submitLabel}
+    </MutationButton>
+  );
+
   return (
-    <div>
+    <div data-archetype-terminal={isTerminal && isSuccess ? 'true' : undefined}>
       <FormProvider {...form}>
         <form
           noValidate
@@ -220,15 +261,28 @@ export function SinglePageFormRenderer({
             </Alert>
           ) : null}
           <div className="flex justify-end">
-            <MutationButton
-              state={state}
-              confirmingLabel={t('common.lifecycle.confirming')}
-              confirmedLabel={t('common.lifecycle.confirmed')}
-              failedLabel={failedLabel}
-              retryAction={retryAction}
-            >
-              {t('form.submit')}
-            </MutationButton>
+            {needsDialog ? (
+              // Story 6.1 AC4 — business_final: AlertDialog interposes before submitForm.
+              <AlertDialog>
+                <AlertDialogTrigger asChild>{submitButton}</AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogTitle>{t('task.confirm.title')}</AlertDialogTitle>
+                  <AlertDialogDescription>{t('task.confirm.description')}</AlertDialogDescription>
+                  <div className="flex justify-end gap-2 pt-2">
+                    <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => {
+                        void form.handleSubmit(onSubmit)();
+                      }}
+                    >
+                      {submitLabel}
+                    </AlertDialogAction>
+                  </div>
+                </AlertDialogContent>
+              </AlertDialog>
+            ) : (
+              submitButton
+            )}
           </div>
         </form>
       </FormProvider>

--- a/frontend/src/components/ui/AlertDialog.tsx
+++ b/frontend/src/components/ui/AlertDialog.tsx
@@ -1,0 +1,139 @@
+/**
+ * Story 6.1 — AlertDialog primitive built on @radix-ui/react-alert-dialog.
+ *
+ * Follows the same shadcn-ui-style wrapping pattern as Dialog.tsx. AlertDialog differs from Dialog
+ * in that it is designed for destructive / confirmation actions — it traps focus more aggressively
+ * and does not allow dismissal by clicking the overlay (Radix default behavior).
+ *
+ * Usage:
+ * ```tsx
+ * <AlertDialog>
+ *   <AlertDialogTrigger asChild>
+ *     <Button>Delete</Button>
+ *   </AlertDialogTrigger>
+ *   <AlertDialogContent>
+ *     <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+ *     <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+ *     <AlertDialogCancel>Cancel</AlertDialogCancel>
+ *     <AlertDialogAction onClick={handleConfirm}>Continue</AlertDialogAction>
+ *   </AlertDialogContent>
+ * </AlertDialog>
+ * ```
+ */
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+
+import { cn } from '@/lib/cn';
+
+export const AlertDialog = AlertDialogPrimitive.Root;
+export const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+export const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+export const AlertDialogOverlay = forwardRef<
+  ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(function AlertDialogOverlay({ className, ...props }, ref) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      ref={ref}
+      className={cn(
+        'fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+export const AlertDialogContent = forwardRef<
+  ElementRef<typeof AlertDialogPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(function AlertDialogContent({ className, children, ...props }, ref) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-[var(--border)] bg-[var(--card)] p-6 shadow-lg rounded-[var(--radius-lg)] focus:outline-none',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </AlertDialogPrimitive.Content>
+    </AlertDialogPortal>
+  );
+});
+
+export const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col gap-1.5 text-left', className)} {...props} />
+);
+
+export const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-row justify-end gap-2', className)} {...props} />
+);
+
+export const AlertDialogTitle = forwardRef<
+  ElementRef<typeof AlertDialogPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(function AlertDialogTitle({ className, ...props }, ref) {
+  return (
+    <AlertDialogPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold text-[var(--foreground)]', className)}
+      {...props}
+    />
+  );
+});
+
+export const AlertDialogDescription = forwardRef<
+  ElementRef<typeof AlertDialogPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(function AlertDialogDescription({ className, ...props }, ref) {
+  return (
+    <AlertDialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-[var(--muted-foreground)]', className)}
+      {...props}
+    />
+  );
+});
+
+export const AlertDialogAction = forwardRef<
+  ElementRef<typeof AlertDialogPrimitive.Action>,
+  ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(function AlertDialogAction({ className, ...props }, ref) {
+  return (
+    <AlertDialogPrimitive.Action
+      ref={ref}
+      className={cn(
+        'inline-flex h-9 items-center justify-center rounded-[var(--radius-md)] bg-[var(--primary)] px-4 py-2 text-sm font-medium text-[var(--primary-foreground)] ring-offset-background transition-colors hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+export const AlertDialogCancel = forwardRef<
+  ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(function AlertDialogCancel({ className, ...props }, ref) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      ref={ref}
+      className={cn(
+        'inline-flex h-9 items-center justify-center rounded-[var(--radius-md)] border border-[var(--border)] bg-transparent px-4 py-2 text-sm font-medium text-[var(--foreground)] ring-offset-background transition-colors hover:bg-[var(--accent)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/frontend/src/components/ui/MutationButton.tsx
+++ b/frontend/src/components/ui/MutationButton.tsx
@@ -10,7 +10,7 @@ import {
 
 import { cn } from '@/lib/cn';
 
-import { Button } from './Button';
+import { Button, type ButtonProps } from './Button';
 
 /**
  * Story 2.7 — 4-state slice of the lifecycle. Story 2.8 widened the union to add {@code
@@ -32,6 +32,8 @@ export interface MutationButtonProps extends Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
   'children'
 > {
+  /** Story 6.1 — optional visual variant, forwarded to the inner Button. */
+  variant?: ButtonProps['variant'];
   state: MutationButtonState;
   /** Idle-state children. */
   children: ReactNode;
@@ -66,6 +68,7 @@ export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>
       announcement,
       className,
       disabled,
+      variant,
       ...rest
     },
     ref,
@@ -125,6 +128,7 @@ export const MutationButton = forwardRef<HTMLButtonElement, MutationButtonProps>
         <Button
           ref={ref}
           type={rest.type ?? 'submit'}
+          variant={variant}
           aria-busy={state === 'confirming' || state === 'processing' ? true : undefined}
           aria-disabled={buttonDisabled || undefined}
           disabled={buttonDisabled}

--- a/frontend/src/components/workspace/CaseActionBar.test.tsx
+++ b/frontend/src/components/workspace/CaseActionBar.test.tsx
@@ -44,7 +44,7 @@ describe('CaseActionBar (Story 2.8 AC8/AC10)', () => {
     );
     render(wrap(<CaseActionBar caseId={CASE_ID} />));
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Draft application' })).toBeInTheDocument(),
+      expect(screen.getByRole('button', { name: 'Save section' })).toBeInTheDocument(),
     );
   });
 

--- a/frontend/src/components/workspace/CaseDetailPanel.actionBar.test.tsx
+++ b/frontend/src/components/workspace/CaseDetailPanel.actionBar.test.tsx
@@ -94,7 +94,7 @@ describe('CaseDetailPanel — action bar slot integration (Story 2.8 AC8/AC11)',
     );
     const { container } = render(wrap(<CaseDetailPanel caseId={CASE_ID} onClose={() => {}} />));
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Draft application' })).toBeInTheDocument(),
+      expect(screen.getByRole('button', { name: 'Save section' })).toBeInTheDocument(),
     );
     // The panel owns one polite live region (the heading announcement). MutationButton owns its
     // own sr-only polite span (single primary CTA → exactly one). No extra region in the action

--- a/frontend/src/components/workspace/StageTimeline.test.tsx
+++ b/frontend/src/components/workspace/StageTimeline.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { TooltipProvider } from '@/components/ui/Tooltip';
 import type { StageView } from '@/types/case';
+import type { StageDefinitionView } from '@/types/caseType';
 
 import { StageTimeline } from './StageTimeline';
 
@@ -161,5 +162,100 @@ describe('StageTimeline — render-state matrix (AC1, AC2, AC11.1)', () => {
     const msg = warn.mock.calls[0]?.[0] as string;
     expect(msg).toMatch(/WKS-UI-2001/);
     warn.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Story 6.1 AC5 — archetype terminal-accent on stage nodes
+// ---------------------------------------------------------------------------
+
+describe('StageTimeline — Story 6.1 AC5: archetype terminal-accent', () => {
+  function stageView(stageId: string, displayName: string, ordinal: number): StageView {
+    return {
+      stageId,
+      displayName,
+      ordinal,
+      state: 'COMPLETED',
+      enteredAt: '2026-04-01T09:00:00Z',
+      exitedAt: '2026-04-02T13:00:00Z',
+      source: 'manual',
+      sourceRef: null,
+    };
+  }
+
+  it('sets data-archetype-terminal="true" on a stage node whose def has archetype=business_final', () => {
+    const stages: StageView[] = [stageView('final-approval', 'Final Approval', 0)];
+    const stageDefs: StageDefinitionView[] = [
+      {
+        id: 'final-approval',
+        displayName: 'Final Approval',
+        ordinal: 0,
+        archetype: 'business_final',
+      },
+    ];
+    const { container } = wrap(<StageTimeline stages={stages} caseTypeStageDefs={stageDefs} />);
+    const li = container.querySelector('li[data-stage-id="final-approval"]');
+    expect(li).toBeInTheDocument();
+    expect(li?.getAttribute('data-archetype-terminal')).toBe('true');
+  });
+
+  it('does NOT set data-archetype-terminal on a stage with archetype=draft_section (postActionState=idle)', () => {
+    const stages: StageView[] = [stageView('drafting', 'Drafting', 0)];
+    const stageDefs: StageDefinitionView[] = [
+      {
+        id: 'drafting',
+        displayName: 'Drafting',
+        ordinal: 0,
+        archetype: 'draft_section',
+      },
+    ];
+    const { container } = wrap(<StageTimeline stages={stages} caseTypeStageDefs={stageDefs} />);
+    const li = container.querySelector('li[data-stage-id="drafting"]');
+    expect(li).toBeInTheDocument();
+    expect(li?.getAttribute('data-archetype-terminal')).toBeNull();
+  });
+
+  it('does NOT set data-archetype-terminal on a stage with no archetype (null/undefined)', () => {
+    const stages: StageView[] = [stageView('intake', 'Intake', 0)];
+    const stageDefs: StageDefinitionView[] = [
+      {
+        id: 'intake',
+        displayName: 'Intake',
+        ordinal: 0,
+        archetype: null,
+      },
+    ];
+    const { container } = wrap(<StageTimeline stages={stages} caseTypeStageDefs={stageDefs} />);
+    const li = container.querySelector('li[data-stage-id="intake"]');
+    expect(li).toBeInTheDocument();
+    expect(li?.getAttribute('data-archetype-terminal')).toBeNull();
+  });
+
+  it('appends terminal suffix to aria-label for business_final stage', () => {
+    const stages: StageView[] = [stageView('final-approval', 'Final Approval', 0)];
+    const stageDefs: StageDefinitionView[] = [
+      {
+        id: 'final-approval',
+        displayName: 'Final Approval',
+        ordinal: 0,
+        archetype: 'business_final',
+      },
+    ];
+    const { container } = wrap(<StageTimeline stages={stages} caseTypeStageDefs={stageDefs} />);
+    // The trigger button holds the aria-label
+    const btn = container.querySelector('li[data-stage-id="final-approval"] button');
+    expect(btn).toBeInTheDocument();
+    const ariaLabel = btn?.getAttribute('aria-label') ?? '';
+    // Should include the stage name and the terminal suffix
+    expect(ariaLabel).toMatch(/Final Approval/);
+    expect(ariaLabel).toMatch(/\s—\s/);
+  });
+
+  it('works without caseTypeStageDefs — no terminal marker applied', () => {
+    const stages: StageView[] = [stageView('underwriting', 'Underwriting', 0)];
+    const { container } = wrap(<StageTimeline stages={stages} />);
+    const li = container.querySelector('li[data-stage-id="underwriting"]');
+    expect(li).toBeInTheDocument();
+    expect(li?.getAttribute('data-archetype-terminal')).toBeNull();
   });
 });

--- a/frontend/src/components/workspace/StageTimeline.tsx
+++ b/frontend/src/components/workspace/StageTimeline.tsx
@@ -11,6 +11,7 @@ import {
 
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover';
 import { t } from '@/i18n';
+import { getArchetypeAffordance } from '@/lib/archetypes';
 import { cn } from '@/lib/cn';
 import { formatDate, formatDateTime } from '@/lib/formatDate';
 import type { StageState, StageView } from '@/types/case';
@@ -225,6 +226,8 @@ interface StageNodeProps {
   isFocused: boolean;
   layout: LayoutMode;
   onFocus: () => void;
+  /** Story 6.1 AC5 — optional archetype from the YAML stage def. */
+  archetype?: string | null;
 }
 
 /**
@@ -232,7 +235,7 @@ interface StageNodeProps {
  * same popover content. The trigger is a `<button>` for native focus + activation semantics.
  */
 const StageNode = forwardRef<HTMLButtonElement, StageNodeProps>(function StageNode(
-  { stage, isFocused, layout, onFocus },
+  { stage, isFocused, layout, onFocus, archetype },
   ref,
 ) {
   const cls = stateClass(stage.state);
@@ -273,12 +276,19 @@ const StageNode = forwardRef<HTMLButtonElement, StageNodeProps>(function StageNo
     });
   };
 
+  // Story 6.1 AC5 — terminal-accent for terminal-archetype stages.
+  // Uses the registry to avoid archetype literal strings in renderer code (AC2 contract).
+  const isTerminalArchetype =
+    getArchetypeAffordance(archetype).postActionState === 'locked' ||
+    getArchetypeAffordance(archetype).postActionState === 'terminal-accent';
+
   return (
     <li
       role="listitem"
       aria-current={stage.state === 'ACTIVE' ? 'step' : undefined}
       data-stage-state={cls}
       data-stage-id={stage.stageId}
+      data-archetype-terminal={isTerminalArchetype ? 'true' : undefined}
       className={cn(
         'wks-stage-item',
         layout === 'horizontal'
@@ -308,11 +318,21 @@ const StageNode = forwardRef<HTMLButtonElement, StageNodeProps>(function StageNo
               toggleSticky();
             }}
             data-state={cls}
-            aria-label={t('stageTimeline.aria.itemSummary', {
-              ordinal: String(stage.ordinal + 1),
-              name: stage.displayName,
-              state: stateLabel(stage.state),
-            })}
+            aria-label={
+              isTerminalArchetype
+                ? t('stageTimeline.aria.itemSummary', {
+                    ordinal: String(stage.ordinal + 1),
+                    name: stage.displayName,
+                    state: stateLabel(stage.state),
+                  }) +
+                  ' — ' +
+                  t('stage.terminal.suffix')
+                : t('stageTimeline.aria.itemSummary', {
+                    ordinal: String(stage.ordinal + 1),
+                    name: stage.displayName,
+                    state: stateLabel(stage.state),
+                  })
+            }
             className={cn(
               'wks-stage-node relative inline-flex shrink-0 rounded-full border-2 transition-colors',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-4',
@@ -442,8 +462,18 @@ export function StageTimeline({
   caseTypeStageDefs,
   experimental_animate = false,
 }: StageTimelineProps) {
-  void caseTypeStageDefs; // reserved for fallback; current backend always populates displayName
   void experimental_animate; // wired by Story 4.3 — Phase 0 keeps animation a no-op
+
+  // Story 6.1 AC5 — build a lookup map from stageId → archetype so StageNode can render
+  // terminal-accent affordances without importing archetype literals itself.
+  const archetypeByStageId = useMemo<Map<string, string | null | undefined>>(() => {
+    if (!caseTypeStageDefs || caseTypeStageDefs.length === 0) return new Map();
+    const m = new Map<string, string | null | undefined>();
+    for (const def of caseTypeStageDefs) {
+      m.set(def.id, def.archetype);
+    }
+    return m;
+  }, [caseTypeStageDefs]);
 
   // Defensive observability — emit before any layout work runs.
   warnIfInconsistent(stages);
@@ -553,6 +583,7 @@ export function StageTimeline({
               isFocused={i === focusIdx}
               layout={layout}
               onFocus={() => setFocusIdx(i)}
+              archetype={archetypeByStageId.get(stage.stageId)}
             />
           </Slot>
         ))}

--- a/frontend/src/components/workspace/TaskLifecycleButton.test.tsx
+++ b/frontend/src/components/workspace/TaskLifecycleButton.test.tsx
@@ -9,6 +9,7 @@ import type { TaskDto } from '@/types/task';
 
 import { TaskLifecycleButton } from './TaskLifecycleButton';
 
+/** Task with draft_section archetype — Story 6.1 AC3: label = "Save section" */
 const TASK: TaskDto = {
   id: 't1',
   processInstanceId: 'pi-1',
@@ -23,23 +24,43 @@ const TASK: TaskDto = {
   dueAt: null,
 };
 
+/** Task with no archetype — pre-6.1 backward-compat path uses actionLabel / name */
+const TASK_NO_ARCHETYPE: TaskDto = {
+  ...TASK,
+  archetype: null,
+};
+
 function wrap(node: ReactNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return <QueryClientProvider client={client}>{node}</QueryClientProvider>;
 }
 
 describe('TaskLifecycleButton (Story 2.8 AC2/AC3/AC5)', () => {
-  it('renders idle state with the task actionLabel', () => {
+  // Story 6.1 AC3 — archetype-driven label overrides actionLabel.
+  it('renders idle state with the archetype-driven label for draft_section', () => {
     render(wrap(<TaskLifecycleButton task={TASK} />));
+    expect(screen.getByRole('button', { name: 'Save section' })).toBeInTheDocument();
+  });
+
+  it('falls back to task.actionLabel when archetype is null', () => {
+    render(
+      wrap(
+        <TaskLifecycleButton task={{ ...TASK_NO_ARCHETYPE, actionLabel: 'Draft application' }} />,
+      ),
+    );
     expect(screen.getByRole('button', { name: 'Draft application' })).toBeInTheDocument();
   });
 
-  it('falls back to task.name when actionLabel is null', () => {
-    render(wrap(<TaskLifecycleButton task={{ ...TASK, actionLabel: null, name: 'Review' }} />));
+  it('falls back to task.name when archetype is null and actionLabel is null', () => {
+    render(
+      wrap(
+        <TaskLifecycleButton task={{ ...TASK_NO_ARCHETYPE, actionLabel: null, name: 'Review' }} />,
+      ),
+    );
     expect(screen.getByRole('button', { name: 'Review' })).toBeInTheDocument();
   });
 
-  it('transitions idle → confirming → confirmed on REST 2xx', async () => {
+  it('transitions idle → confirming → confirmed on REST 2xx (draft_section — inline flow)', async () => {
     server.use(
       http.post('/api/tasks/t1/complete', () =>
         HttpResponse.json(
@@ -59,7 +80,8 @@ describe('TaskLifecycleButton (Story 2.8 AC2/AC3/AC5)', () => {
       ),
     );
     render(wrap(<TaskLifecycleButton task={TASK} />));
-    fireEvent.click(screen.getByRole('button', { name: 'Draft application' }));
+    // draft_section: inline flow — no dialog; click fires directly
+    fireEvent.click(screen.getByRole('button', { name: 'Save section' }));
     await waitFor(() =>
       expect(screen.getByRole('button')).toHaveAttribute('data-state', 'confirmed'),
     );
@@ -82,7 +104,7 @@ describe('TaskLifecycleButton (Story 2.8 AC2/AC3/AC5)', () => {
       ),
     );
     render(wrap(<TaskLifecycleButton task={TASK} />));
-    fireEvent.click(screen.getByRole('button', { name: 'Draft application' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save section' }));
     await waitFor(() => expect(screen.getByText('Refresh case')).toBeInTheDocument());
     expect(screen.queryByText('Retry')).not.toBeInTheDocument();
   });
@@ -97,8 +119,58 @@ describe('TaskLifecycleButton (Story 2.8 AC2/AC3/AC5)', () => {
       ),
     );
     render(wrap(<TaskLifecycleButton task={TASK} />));
-    fireEvent.click(screen.getByRole('button', { name: 'Draft application' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save section' }));
     await waitFor(() => expect(screen.getByText('Retry')).toBeInTheDocument());
     expect(screen.queryByText('Refresh case')).not.toBeInTheDocument();
+  });
+});
+
+// Story 6.1 AC3 — three archetype scenarios with distinct affordances.
+describe('TaskLifecycleButton — Story 6.1 AC3 archetype scenarios', () => {
+  it('draft_section: renders "Save section" with secondary (ghost) tone', () => {
+    const task: TaskDto = { ...TASK, archetype: 'draft_section' };
+    render(wrap(<TaskLifecycleButton task={task} />));
+    const btn = screen.getByRole('button', { name: 'Save section' });
+    expect(btn).toBeInTheDocument();
+    // ghost variant has "hover:bg-[var(--muted)]" class
+    expect(btn.className).toMatch(/hover:bg-\[var\(--muted\)\]/);
+  });
+
+  it('submit_for_processing: renders "Submit for processing" with primary tone', () => {
+    const task: TaskDto = { ...TASK, archetype: 'submit_for_processing' };
+    render(wrap(<TaskLifecycleButton task={task} />));
+    expect(screen.getByRole('button', { name: 'Submit for processing' })).toBeInTheDocument();
+  });
+
+  it('business_final: renders "Submit for final approval" and shows AlertDialog on click', async () => {
+    const task: TaskDto = { ...TASK, archetype: 'business_final' };
+    render(wrap(<TaskLifecycleButton task={task} />));
+    const triggerBtn = screen.getByRole('button', { name: 'Submit for final approval' });
+    expect(triggerBtn).toBeInTheDocument();
+    // Click the trigger — should open the dialog (confirmation-dialog flow)
+    fireEvent.click(triggerBtn);
+    // Dialog should appear
+    await waitFor(() => expect(screen.getByText('Confirm submission')).toBeInTheDocument());
+    expect(screen.getByText(/final action/i)).toBeInTheDocument();
+    // Cancel button present
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('business_final: cancel dialog returns to idle without firing mutation', async () => {
+    const task: TaskDto = { ...TASK, archetype: 'business_final' };
+    render(wrap(<TaskLifecycleButton task={task} />));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit for final approval' }));
+    await waitFor(() => expect(screen.getByText('Confirm submission')).toBeInTheDocument());
+    // Cancel
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    // Dialog should close; trigger button still visible
+    await waitFor(() => expect(screen.queryByText('Confirm submission')).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Submit for final approval' })).toBeInTheDocument();
+  });
+
+  it('no archetype: renders pre-6.1 default label from actionLabel', () => {
+    const task: TaskDto = { ...TASK, archetype: null, actionLabel: 'Process claim' };
+    render(wrap(<TaskLifecycleButton task={task} />));
+    expect(screen.getByRole('button', { name: 'Process claim' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/workspace/TaskLifecycleButton.tsx
+++ b/frontend/src/components/workspace/TaskLifecycleButton.tsx
@@ -2,10 +2,20 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useReducer, useRef } from 'react';
 
 import { ApiError } from '@/api/client';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/AlertDialog';
 import { Button } from '@/components/ui/Button';
 import { MutationButton, type MutationButtonState } from '@/components/ui/MutationButton';
 import { useCompleteTask } from '@/hooks/useTasks';
 import { t } from '@/i18n';
+import { getArchetypeAffordance } from '@/lib/archetypes';
 import { caseQueryKeys, taskQueryKeys } from '@/lib/queryKeys';
 import type { ConflictReason, TaskActionResponse, TaskDto } from '@/types/task';
 
@@ -309,30 +319,75 @@ export function TaskLifecycleButton({ task, onCompleted, onConflict }: TaskLifec
       </Button>
     ) : null;
 
-  const idleLabel = task.actionLabel ?? task.name;
+  // Story 6.1 — archetype-driven affordance. All renderer decisions go through the registry;
+  // no archetype literal strings appear here.
+  const affordance = getArchetypeAffordance(task.archetype);
+  const archetypeLabel = t(affordance.ctaLabelKey);
+  // Map ctaTone to Button variant — secondary tone uses 'ghost' styling for softer visual weight.
+  const archetypeVariant = affordance.ctaTone === 'secondary' ? 'ghost' : 'default';
+  const needsDialog = affordance.confirmationFlow === 'confirmation-dialog';
+  const isTerminal =
+    affordance.postActionState === 'locked' || affordance.postActionState === 'terminal-accent';
+
+  // The idle label comes from the archetype registry when an archetype is declared; falls back to
+  // task.actionLabel → task.name for un-typed tasks (backward-compat).
+  const idleLabel = task.archetype ? archetypeLabel : (task.actionLabel ?? task.name);
+
+  const mutationButton = (
+    <MutationButton
+      state={buttonState}
+      confirmingLabel={t('task.confirming')}
+      processingLabel={t('task.processing')}
+      confirmedLabel={t('task.confirmed')}
+      failedLabel={failedLabel}
+      announcement={announcement}
+      // variant is threaded via ...rest spread in MutationButton → Button
+      variant={archetypeVariant}
+      onClick={() => {
+        // Dialog flow: fire() is triggered by AlertDialogAction instead of the button click.
+        if (needsDialog) return;
+        if (state.kind === 'idle') fire();
+      }}
+      retryAction={
+        <>
+          {retryAction}
+          {refreshAction}
+          {viewUpdatedCaseAction}
+        </>
+      }
+    >
+      {idleLabel}
+    </MutationButton>
+  );
 
   return (
-    <div className="inline-flex items-center gap-2">
-      <MutationButton
-        state={buttonState}
-        confirmingLabel={t('task.confirming')}
-        processingLabel={t('task.processing')}
-        confirmedLabel={t('task.confirmed')}
-        failedLabel={failedLabel}
-        announcement={announcement}
-        onClick={() => {
-          if (state.kind === 'idle') fire();
-        }}
-        retryAction={
-          <>
-            {retryAction}
-            {refreshAction}
-            {viewUpdatedCaseAction}
-          </>
-        }
-      >
-        {idleLabel}
-      </MutationButton>
+    <div
+      className="inline-flex items-center gap-2"
+      data-archetype-terminal={isTerminal && state.kind === 'confirmed' ? 'true' : undefined}
+    >
+      {needsDialog && state.kind === 'idle' ? (
+        // Story 6.1 AC3 — business_final: AlertDialog interposes before fire().
+        // The trigger renders the MutationButton; confirmation fires the mutation.
+        <AlertDialog>
+          <AlertDialogTrigger asChild>{mutationButton}</AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogTitle>{t('task.confirm.title')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('task.confirm.description')}</AlertDialogDescription>
+            <div className="flex justify-end gap-2 pt-2">
+              <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  fire();
+                }}
+              >
+                {archetypeLabel}
+              </AlertDialogAction>
+            </div>
+          </AlertDialogContent>
+        </AlertDialog>
+      ) : (
+        mutationButton
+      )}
       {state.kind === 'processing' && takingLonger ? (
         <span className="text-xs text-[var(--muted-foreground)]">
           {t('task.processing.takingLonger')}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -148,6 +148,15 @@
   "task.conflict.completedByUnknown": "This task was already completed. No changes were made.",
   "task.conflict.refreshAnnouncement": "This task was already completed. Press Enter to refresh.",
 
+  "task.cta.complete": "Complete",
+  "task.cta.draft_section.complete": "Save section",
+  "task.cta.submit_for_processing.complete": "Submit for processing",
+  "task.cta.business_final.complete": "Submit for final approval",
+  "task.confirm.title": "Confirm submission",
+  "task.confirm.description": "This is a final action and cannot be undone after the case advances. Continue?",
+
+  "stage.terminal.suffix": "final stage",
+
   "cases.create.button": "New case",
   "cases.create.dialogTitle": "New {caseTypeName}",
   "cases.create.dialogClose": "Close create case dialog",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -96,3 +96,16 @@ h6 {
     --motion-slow: 0.01ms;
   }
 }
+
+/* Story 6.1 — archetype-terminal design token + CSS hook.
+ * --accent-terminal: distinct accent for business_final terminal-state affordances.
+ * Applied via [data-archetype-terminal="true"] on the surrounding container so tests
+ * assert attribute presence and CSS drives the visual — no DOM reads in logic code.
+ */
+:root {
+  --accent-terminal: #dc2626; /* red-600 — signals finality; fallback to primary below */
+}
+
+[data-archetype-terminal='true'] {
+  border-color: var(--accent-terminal, var(--primary));
+}

--- a/frontend/src/lib/archetypes.test.ts
+++ b/frontend/src/lib/archetypes.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Story 6.1 AC2 — Unit tests for the archetype affordance registry.
+ *
+ * Key assertions:
+ * 1. Registry and entries are frozen (immutable at module-init).
+ * 2. Each archetype id returns the expected affordance shape.
+ * 3. Null / undefined / unknown inputs return the default affordance.
+ * 4. No archetype literal strings leak into non-test renderer components
+ *    (`frontend/src/components/**\/*.{ts,tsx}` excluding `*.test.*` files).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { ARCHETYPE_IDS, DEFAULT_AFFORDANCE, getArchetypeAffordance } from './archetypes';
+
+describe('archetypes registry', () => {
+  it('ARCHETYPE_IDS array is frozen', () => {
+    expect(Object.isFrozen(ARCHETYPE_IDS)).toBe(true);
+  });
+
+  it('getArchetypeAffordance(undefined) returns default affordance', () => {
+    const aff = getArchetypeAffordance(undefined);
+    expect(aff).toEqual(DEFAULT_AFFORDANCE);
+    expect(aff.ctaLabelKey).toBe('task.cta.complete');
+    expect(aff.ctaTone).toBe('primary');
+    expect(aff.confirmationFlow).toBe('inline');
+    expect(aff.postActionState).toBe('idle');
+  });
+
+  it('getArchetypeAffordance(null) returns default affordance', () => {
+    expect(getArchetypeAffordance(null)).toEqual(DEFAULT_AFFORDANCE);
+  });
+
+  it('getArchetypeAffordance("unknown_xyz") returns default affordance', () => {
+    expect(getArchetypeAffordance('unknown_xyz')).toEqual(DEFAULT_AFFORDANCE);
+  });
+
+  it('draft_section affordance is correct', () => {
+    const aff = getArchetypeAffordance('draft_section');
+    expect(aff.ctaLabelKey).toBe('task.cta.draft_section.complete');
+    expect(aff.ctaTone).toBe('secondary');
+    expect(aff.confirmationFlow).toBe('inline');
+    expect(aff.postActionState).toBe('idle');
+    expect(Object.isFrozen(aff)).toBe(true);
+  });
+
+  it('submit_for_processing affordance is correct', () => {
+    const aff = getArchetypeAffordance('submit_for_processing');
+    expect(aff.ctaLabelKey).toBe('task.cta.submit_for_processing.complete');
+    expect(aff.ctaTone).toBe('primary');
+    expect(aff.confirmationFlow).toBe('processing-modal');
+    expect(aff.postActionState).toBe('idle');
+    expect(Object.isFrozen(aff)).toBe(true);
+  });
+
+  it('business_final affordance is correct', () => {
+    const aff = getArchetypeAffordance('business_final');
+    expect(aff.ctaLabelKey).toBe('task.cta.business_final.complete');
+    expect(aff.ctaTone).toBe('primary');
+    expect(aff.confirmationFlow).toBe('confirmation-dialog');
+    expect(aff.postActionState).toBe('locked');
+    expect(Object.isFrozen(aff)).toBe(true);
+  });
+
+  it('all archetype ids in ARCHETYPE_IDS return non-default affordance', () => {
+    for (const id of ARCHETYPE_IDS) {
+      const aff = getArchetypeAffordance(id);
+      expect(aff).not.toEqual(DEFAULT_AFFORDANCE);
+    }
+  });
+});
+
+/**
+ * AC2 contract: no archetype literal strings ('draft_section', 'submit_for_processing',
+ * 'business_final') must appear in renderer components (non-test files).
+ *
+ * Uses Node.js fs APIs (available in Vitest's Node environment) to scan files under
+ * `frontend/src/components/` recursively. This is equivalent to the CI grep check and
+ * runs as a standard unit test so it fails the build automatically.
+ */
+describe('AC2 data-driven contract — no archetype literals in component sources', () => {
+  const ARCHETYPE_LITERALS = ['draft_section', 'submit_for_processing', 'business_final'];
+
+  /**
+   * Recursively collect all .ts and .tsx files under a directory,
+   * excluding test files (*.test.ts, *.test.tsx).
+   */
+  function collectSourceFiles(dir: string): string[] {
+    const files: string[] = [];
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const st = statSync(full);
+      if (st.isDirectory()) {
+        files.push(...collectSourceFiles(full));
+      } else if (
+        (full.endsWith('.ts') || full.endsWith('.tsx')) &&
+        !full.endsWith('.test.ts') &&
+        !full.endsWith('.test.tsx')
+      ) {
+        files.push(full);
+      }
+    }
+    return files;
+  }
+
+  it('no archetype literal strings appear in non-test component files', () => {
+    // Resolve path relative to this test file: lib/ → components/ is ../components/
+    const componentsDir = join(import.meta.dirname ?? __dirname, '..', 'components');
+    const sourceFiles = collectSourceFiles(componentsDir);
+
+    const violations: string[] = [];
+    for (const filePath of sourceFiles) {
+      const content = readFileSync(filePath, 'utf-8');
+      for (const literal of ARCHETYPE_LITERALS) {
+        // Match the literal as a JS string literal (single or double quotes)
+        if (content.includes(`'${literal}'`) || content.includes(`"${literal}"`)) {
+          violations.push(`${filePath}: contains '${literal}'`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/frontend/src/lib/archetypes.ts
+++ b/frontend/src/lib/archetypes.ts
@@ -1,0 +1,100 @@
+/**
+ * Story 6.1 — Closed archetype catalog and data-driven affordance registry.
+ *
+ * The catalog is a closed set at Phase-0. Adding a fourth archetype in Phase-1 is a
+ * one-line change in the REGISTRY literal (add the id to ArchetypeId union + one entry
+ * in REGISTRY). No renderer component needs to change — the data-driven contract ensures
+ * zero archetype literals escape into `components/`.
+ *
+ * AC2 enforcement: `grep -rn "draft_section\|submit_for_processing\|business_final"
+ * frontend/src/components` must return matches ONLY in test files.
+ */
+
+/** Phase-0 archetype identifiers — matches the backend closed catalog. */
+export type ArchetypeId = 'draft_section' | 'submit_for_processing' | 'business_final';
+
+/** Ordered list for iteration / type guard use. */
+export const ARCHETYPE_IDS: readonly ArchetypeId[] = Object.freeze([
+  'draft_section',
+  'submit_for_processing',
+  'business_final',
+] as const);
+
+/**
+ * Per-archetype affordance contract. Renderers read ONLY this record — they never branch
+ * on archetype string literals themselves.
+ */
+export interface ArchetypeAffordance {
+  /** i18n key for the primary CTA label. */
+  ctaLabelKey: string;
+  /** Visual tone of the primary CTA button. */
+  ctaTone: 'primary' | 'secondary';
+  /**
+   * Confirmation interaction pattern before the actual mutation fires.
+   * - `inline`: existing confirming → confirmed lifecycle (no extra UI).
+   * - `processing-modal`: confirming → processing → confirmed (spinner visible).
+   * - `confirmation-dialog`: AlertDialog interposes between click and mutation.
+   */
+  confirmationFlow: 'inline' | 'processing-modal' | 'confirmation-dialog';
+  /**
+   * Post-completion state of the surrounding container.
+   * - `idle`: button resets to idle (re-editable, e.g. draft_section).
+   * - `locked`: button stays disabled + terminal-accent badge applied.
+   * - `terminal-accent`: same as locked (alias kept for CSS-hook clarity).
+   */
+  postActionState: 'idle' | 'locked' | 'terminal-accent';
+}
+
+/**
+ * Default affordance — preserves pre-6.1 behavior for tasks/forms/stages with no archetype
+ * declared. Matches the existing `MutationButton` idle → confirming → confirmed flow.
+ */
+const DEFAULT_AFFORDANCE: ArchetypeAffordance = Object.freeze({
+  ctaLabelKey: 'task.cta.complete',
+  ctaTone: 'primary',
+  confirmationFlow: 'inline',
+  postActionState: 'idle',
+});
+
+/** Frozen registry — reading by id is O(1); adding a new archetype is one line here. */
+const REGISTRY: Readonly<Record<ArchetypeId, ArchetypeAffordance>> = Object.freeze({
+  draft_section: Object.freeze({
+    ctaLabelKey: 'task.cta.draft_section.complete',
+    ctaTone: 'secondary',
+    confirmationFlow: 'inline',
+    postActionState: 'idle',
+  } satisfies ArchetypeAffordance),
+
+  submit_for_processing: Object.freeze({
+    ctaLabelKey: 'task.cta.submit_for_processing.complete',
+    ctaTone: 'primary',
+    confirmationFlow: 'processing-modal',
+    postActionState: 'idle',
+  } satisfies ArchetypeAffordance),
+
+  business_final: Object.freeze({
+    ctaLabelKey: 'task.cta.business_final.complete',
+    ctaTone: 'primary',
+    confirmationFlow: 'confirmation-dialog',
+    postActionState: 'locked',
+  } satisfies ArchetypeAffordance),
+});
+
+/**
+ * Look up the affordance for an archetype id.
+ *
+ * @param id - archetype string from the backend wire shape (nullable — omitted means default).
+ * @returns The matching {@link ArchetypeAffordance}, or the default when `id` is null, undefined,
+ *   or unrecognised (defensive: unknown values fall back rather than throw, matching the backend's
+ *   optional posture).
+ */
+export function getArchetypeAffordance(id: string | null | undefined): ArchetypeAffordance {
+  if (!id) return DEFAULT_AFFORDANCE;
+  if ((ARCHETYPE_IDS as readonly string[]).includes(id)) {
+    return REGISTRY[id as ArchetypeId];
+  }
+  return DEFAULT_AFFORDANCE;
+}
+
+/** Expose the default for test assertions. */
+export { DEFAULT_AFFORDANCE };

--- a/frontend/src/types/caseType.ts
+++ b/frontend/src/types/caseType.ts
@@ -72,6 +72,8 @@ export interface StageDefinitionView {
   id: string;
   displayName: string;
   ordinal: number;
+  /** Story 6.1 — optional archetype from the closed catalog. */
+  archetype?: string | null;
 }
 
 /**
@@ -100,6 +102,8 @@ export interface FormDefinitionView {
   fields: FieldDefinition[];
   /** Story 5.3 — sections declared for {@code dataModel: sectioned} forms. */
   sections?: FormSectionView[];
+  /** Story 6.1 — optional archetype from the closed catalog. */
+  archetype?: string | null;
 }
 
 export interface CaseTypeView {


### PR DESCRIPTION
## Summary

- **AC1 — Backend:** `archetype` field added to `RawStage`, `RawFormDefinition`, `StageDefinition`, `FormDefinition`. `ConfigValidator` validates against closed catalog `{draft_section, submit_for_processing, business_final}` and emits `WKS-ARCH-001` for unknown values. `ErrorCode.WKS_ARCH_001` allocated per wire-contract rules. `FormDefinitionView` and `StageView` DTOs expose `archetype` to the frontend.
- **AC2 — Frontend affordance registry:** `lib/archetypes.ts` — frozen `Record<ArchetypeId, ArchetypeAffordance>` registry. `getArchetypeAffordance()` returns default for null/undefined/unknown, preserving backward-compat. AC2 data-driven contract enforced by `archetypes.test.ts` (Node fs scan verifying zero archetype literals in `components/` non-test files).
- **AC3 — TaskLifecycleButton:** archetype-driven label/tone; `AlertDialog` interposes for `business_final`; `data-archetype-terminal` on confirmed state.
- **AC4 — Form renderers:** `SinglePageFormRenderer` and `MultiSectionFormRenderer` use affordance for submit CTA label/tone; `AlertDialog` for `business_final`; `data-archetype-terminal` on success.
- **AC5 — StageTimeline + seed:** `StageTimeline` renders `data-archetype-terminal` + `aria-label` terminal suffix for `business_final` stages. New `seed/j13-archetype-mix.yaml` covers all three archetypes for BFSI persona walkthrough.
- **AlertDialog.tsx:** new Radix UI primitive (shadcn-ui pattern) added to `components/ui/`.
- **CSS:** `--accent-terminal` design token + `[data-archetype-terminal="true"]` selector in `index.css`.

## Test plan

- [ ] Backend: `mvn verify -B` — 137 tests green (0 failures)
- [ ] Tenant invariant: `./backend/.ci/check-tenant-invariant.sh` — "Tenant invariant (D25) OK"
- [ ] Frontend: `npm run lint && npm run format:check && npm run test && npm run build` — 317 tests green
- [ ] Manual: load `seed/j13-archetype-mix.yaml` at frontend dev server :5173; verify three archetypes render with distinct CTAs, tones, and dialog flows
- [ ] AC2 grep: `grep -rn "draft_section\|submit_for_processing\|business_final" frontend/src/components` should match ONLY test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)