### PR TITLE
feat(3-11): blast-radius gate — lenient prior re-parse + dev-only force override

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -35,6 +37,8 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/admin")
 public class AdminController {
 
+  private static final Logger log = LoggerFactory.getLogger(AdminController.class);
+
   private final ConfigService configService;
 
   public AdminController(ConfigService configService) {
@@ -51,7 +55,10 @@ public class AdminController {
               + " the registry is touched; on success the case type is registered, and when a BPMN"
               + " is present it is deployed to the embedded engine. A ConfigDeployed event is"
               + " published when a BPMN deployment occurs; YAML-only registrations skip the engine"
-              + " deploy and return null deployment fields.")
+              + " deploy and return null deployment fields. Story 3.11: ?force=true is a"
+              + " dev/test-only override for the WKS-CFG-030 unparseable-prior path, requires"
+              + " ?bumpVersion=true alongside, and is rejected with WKS-API-006 in production"
+              + " regardless of caller authority.")
   @ApiResponses(
       value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -79,17 +86,54 @@ public class AdminController {
       @RequestPart(name = "bpmn", required = false) MultipartFile bpmnPart,
       @RequestParam(name = "bumpVersion", required = false, defaultValue = "false")
           boolean bumpVersion,
+      @RequestParam(name = "force", required = false, defaultValue = "false") boolean force,
       HttpServletRequest request)
       throws Exception {
     rejectDuplicateParts(request);
-    byte[] yaml = caseTypePart.getBytes();
     String actorEmail = currentActorEmail();
+    String caller = actorEmail == null ? "ANONYMOUS" : actorEmail;
+
+    // Story 3.11 AC3 / AC4 / AC5 — pre-parse force-override gating. Reject in production
+    // regardless of caller authority (production-policy); reject without bumpVersion=true even
+    // in dev/test. Both rejection paths fail-fast BEFORE the multipart body is consumed so
+    // YAML/BPMN bytes are never logged or read on rejected force requests.
+    if (force) {
+      if (configService.isProductionProfile()) {
+        log.info(
+            "event=admin.deploy.force_override caller={} caseTypeId=UNKNOWN priorVersion=NONE"
+                + " outcome=REJECTED_PRODUCTION reason=production-policy",
+            caller);
+        throw new WksConfigException(
+            List.of(
+                ErrorDetail.of(
+                    ErrorCode.WKS_API_006.wire(),
+                    "Force-override deploy is not permitted in production profile — remove"
+                        + " ?force=true and bump version explicitly.")),
+            null);
+      }
+      if (!bumpVersion) {
+        log.info(
+            "event=admin.deploy.force_override caller={} caseTypeId=UNKNOWN priorVersion=NONE"
+                + " outcome=REJECTED_NO_BUMP reason=missing-bumpVersion",
+            caller);
+        throw new WksConfigException(
+            List.of(
+                ErrorDetail.of(
+                    ErrorCode.WKS_API_006.wire(),
+                    "force=true requires bumpVersion=true — refusing to bypass blast-radius"
+                        + " gate without explicit version bump.")),
+            null);
+      }
+    }
+
+    byte[] yaml = caseTypePart.getBytes();
 
     // Story 3.2: zero-process case types deploy YAML-only — no BPMN part means no engine deploy.
     // An attached but empty `bpmn` part is treated the same as absent.
     if (bpmnPart == null || bpmnPart.isEmpty()) {
       ValidationResult yamlResult =
-          configService.validateAndRegister("api-deploy.yaml", yaml, actorEmail, bumpVersion);
+          configService.validateAndRegister(
+              "api-deploy.yaml", yaml, actorEmail, bumpVersion, force);
       if (yamlResult.isInvalid()) {
         // Story 3.8 — forward blast-radius meta (if any) into the exception so it surfaces in the
         // ApiResponse.meta field (AC2: meta.blastRadius must be present on WKS-CFG-029 rejections).
@@ -98,6 +142,13 @@ public class AdminController {
             yamlResult.responseMeta().isEmpty() ? null : yamlResult.responseMeta());
       }
       var caseType = yamlResult.config().orElseThrow();
+      // Story 3.11 AC5 — ACCEPTED audit log fires after caseTypeId is known. Whether the
+      // service-side WARN fired depends on whether the gate actually bypassed the classifier
+      // (lenient succeeded → WARN suppressed). The controller log is the audit trail; the
+      // service log is the gate-bypass record. Distinct entries by design.
+      if (force) {
+        emitAcceptedAuditLog(caller, caseType.id());
+      }
       return ApiResponse.success(
           new DeployResponseDto(
               caseType.id(),
@@ -109,7 +160,8 @@ public class AdminController {
 
     byte[] bpmn = bpmnPart.getBytes();
     String bpmnFilename = bpmnPart.getOriginalFilename();
-    DeployResult result = configService.deploy(yaml, bpmn, bpmnFilename, actorEmail, bumpVersion);
+    DeployResult result =
+        configService.deploy(yaml, bpmn, bpmnFilename, actorEmail, bumpVersion, force);
     if (result.isInvalid()) {
       // P10 — WKS-CFG-025 is an engine-side runtime failure (the input was valid; the engine
       // itself failed), not a client-input quality problem. Map it to HTTP 502 Bad Gateway via
@@ -129,6 +181,10 @@ public class AdminController {
 
     var caseType = result.caseType().orElseThrow();
     var deployment = result.deployment().orElseThrow();
+    // Story 3.11 AC5 — ACCEPTED audit log on the BPMN-attached deploy path.
+    if (force) {
+      emitAcceptedAuditLog(caller, caseType.id());
+    }
     return ApiResponse.success(
         new DeployResponseDto(
             caseType.id(),
@@ -136,6 +192,21 @@ public class AdminController {
             deployment.deploymentId(),
             deployment.processDefinitionId(),
             "/api/admin/case-types/" + caseType.id() + "/schema"));
+  }
+
+  /**
+   * Story 3.11 AC5 — single-line audit entry for an accepted force-override deploy. caseTypeId is
+   * known here (post-parse); priorVersion is left as a dynamic value the service-layer log trail
+   * surfaces. The accepted entry fires whenever {@code force=true} is honored at the controller
+   * layer, even when the service-side WKS-CFG-030 bypass did NOT engage (e.g. lenient parse
+   * succeeded — the controller still saw a force request and audits it).
+   */
+  private static void emitAcceptedAuditLog(String caller, String caseTypeId) {
+    log.info(
+        "event=admin.deploy.force_override caller={} caseTypeId={} priorVersion=DYNAMIC"
+            + " outcome=ACCEPTED reason=WKS-CFG-030-unparseable",
+        caller,
+        caseTypeId);
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -25,6 +25,16 @@ public enum ErrorCode {
   WKS_API_004("WKS-API-004"),
   /** Sort direction other than {@code asc} or {@code desc}. */
   WKS_API_005("WKS-API-005"),
+  /**
+   * Story 3.11 — admin deploy issued with {@code ?force=true} but the request violates a
+   * force-override precondition: either the active Spring profile is {@code production}
+   * (force-override is policy-forbidden in prod regardless of caller authority) or {@code
+   * bumpVersion=true} was not supplied (force-override requires explicit version bump). Emitted by
+   * {@link com.wkspower.platform.api.controller.AdminController#deploy}. Wire string is {@code
+   * WKS-API-006} — stable contract; do not reuse for another meaning per the {@code
+   * feedback_error_codes_are_wire_contract.md} memory.
+   */
+  WKS_API_006("WKS-API-006"),
 
   // 401 / 403 — auth.
   /** Authentication failed (unknown email, wrong password, or inactive user). */

--- a/backend/src/main/java/com/wkspower/platform/domain/port/CaseTypeSource.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/CaseTypeSource.java
@@ -21,4 +21,20 @@ public interface CaseTypeSource {
   default ValidationResult loadBytes(String source, byte[] bytes) {
     return loadBytes(source, bytes, Map.of());
   }
+
+  /**
+   * Story 3.11 AC1 — lenient prior-YAML re-parse path used by the blast-radius diff. Tolerates
+   * unknown keys (schema-drift recovery) and skips semantic validation — projection only. The
+   * returned {@link ValidationResult#config()} is suitable for {@code CaseTypeDiff.classify} but
+   * does NOT carry validator findings: re-running validation against an obsolete schema would
+   * surface noise. Catastrophic parse failures still surface as a {@code WKS-CFG-099}-bearing
+   * invalid result.
+   *
+   * <p>The default returns an empty invalid result so adapter implementations can opt in
+   * incrementally. The production {@code CaseTypeSourceAdapter} overrides with the real
+   * implementation.
+   */
+  default ValidationResult loadBytesLenient(String source, byte[] bytes) {
+    return ValidationResult.invalid(java.util.List.of());
+  }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/ConfigService.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +77,15 @@ public class ConfigService {
   private final CaseTypeVersionRegistry versionRegistry;
 
   /**
+   * Story 3.11 — active Spring-profile supplier used by the AC4 force-override path to detect the
+   * {@code production} profile and refuse to bypass the blast-radius gate. Domain stays
+   * framework-free: the infrastructure {@code ConfigServiceConfig} wires this as a lambda over
+   * {@code Environment::getActiveProfiles}; tests inject a fixed {@link List}. Defaults to an empty
+   * list (treated as dev/test) when the legacy 8-arg / 9-arg constructor is used.
+   */
+  private final Supplier<List<String>> activeProfilesSupplier;
+
+  /**
    * Per-{@code caseTypeId} mutex (Story 2.4 folded debt #2 — TOCTOU on concurrent deploys of the
    * same case-type id). Two threads racing the {@code reader.find → registrar.register} window
    * could both observe the same prior state, leading to interleaved registry writes. Locking on a
@@ -108,8 +118,9 @@ public class ConfigService {
   }
 
   /**
-   * Story 4.5 AC3 — full constructor that accepts the BPMN hash function. Wired by the
-   * infrastructure {@code ConfigServiceConfig} with {@code CaseTypeContentHasher::hashBytes}.
+   * Story 4.5 AC3 — 9-arg constructor that accepts the BPMN hash function. Delegates to the
+   * Story-3.11 full constructor with an empty active-profiles supplier (treated as dev/test —
+   * force-override is permitted, but admin must still pass {@code force=true}).
    */
   public ConfigService(
       CaseTypeSource source,
@@ -121,6 +132,35 @@ public class ConfigService {
       CaseTypeVersionRegistry versionRegistry,
       MappingRegistry mappingRegistry,
       Function<byte[], String> bpmnHasher) {
+    this(
+        source,
+        registrar,
+        reader,
+        bpmnValidator,
+        workflowEngine,
+        eventPublisher,
+        versionRegistry,
+        mappingRegistry,
+        bpmnHasher,
+        List::of);
+  }
+
+  /**
+   * Story 3.11 — full constructor accepting the active-profile supplier (Spring {@code
+   * Environment::getActiveProfiles} adapted to a {@link Supplier}). Wired by the infrastructure
+   * {@code ConfigServiceConfig}.
+   */
+  public ConfigService(
+      CaseTypeSource source,
+      CaseTypeRegistrar registrar,
+      CaseTypeReader reader,
+      BpmnValidationService bpmnValidator,
+      WorkflowEngine workflowEngine,
+      EventPublisher eventPublisher,
+      CaseTypeVersionRegistry versionRegistry,
+      MappingRegistry mappingRegistry,
+      Function<byte[], String> bpmnHasher,
+      Supplier<List<String>> activeProfilesSupplier) {
     this.source = source;
     this.registrar = registrar;
     this.reader = reader;
@@ -130,6 +170,19 @@ public class ConfigService {
     this.versionRegistry = versionRegistry;
     this.mappingRegistry = mappingRegistry;
     this.bpmnHasher = bpmnHasher;
+    this.activeProfilesSupplier =
+        activeProfilesSupplier == null ? List::of : activeProfilesSupplier;
+  }
+
+  /**
+   * Story 3.11 AC3 — true when the active Spring profile set contains {@code "production"}. Used by
+   * {@link com.wkspower.platform.api.controller.AdminController} to refuse {@code force=true}
+   * deploys before the multipart body is parsed. Matches the convention used by {@code
+   * ProductionBootstrapValidator} (literal string comparison; no abstraction).
+   */
+  public boolean isProductionProfile() {
+    List<String> profiles = activeProfilesSupplier.get();
+    return profiles != null && profiles.contains("production");
   }
 
   /**
@@ -178,7 +231,7 @@ public class ConfigService {
 
   /** Byte-driven YAML-only variant. Retained for the startup loader's BPMN-missing path. */
   public ValidationResult validateAndRegister(String sourceName, byte[] bytes) {
-    return validateAndRegister(sourceName, bytes, "system:startup", false);
+    return validateAndRegister(sourceName, bytes, "system:startup", false, false);
   }
 
   /**
@@ -187,20 +240,34 @@ public class ConfigService {
    * "system:startup"}. Defaults {@code bumpRequested=false}.
    */
   public ValidationResult validateAndRegister(String sourceName, byte[] bytes, String publishedBy) {
-    return validateAndRegister(sourceName, bytes, publishedBy, false);
+    return validateAndRegister(sourceName, bytes, publishedBy, false, false);
+  }
+
+  /** Story 3.8 — overload accepting {@code bumpRequested}; delegates with {@code force=false}. */
+  public ValidationResult validateAndRegister(
+      String sourceName, byte[] bytes, String publishedBy, boolean bumpRequested) {
+    return validateAndRegister(sourceName, bytes, publishedBy, bumpRequested, false);
   }
 
   /**
-   * Story 3.8 — full overload accepting {@code bumpRequested}. The blast-radius classifier runs
-   * here when a prior version exists; a mutate-class change without {@code bumpRequested=true} is
-   * rejected with {@code WKS-CFG-029}. The existing 2-arg and 3-arg overloads delegate here with
-   * {@code bumpRequested=false}.
+   * Story 3.11 — full overload accepting {@code forceRequested}. The blast-radius classifier still
+   * runs here when a prior version exists; {@code forceRequested=true} only matters when the prior
+   * YAML cannot be loaded or re-parsed (the AC4 dev/test escape hatch for the unparseable-prior
+   * path). Production-profile rejection of {@code force=true} happens at the controller layer (AC3)
+   * — by the time this method runs in production, {@code forceRequested} is guaranteed false.
    *
-   * @param bumpRequested {@code true} when the caller explicitly requested a version bump (e.g. via
-   *     {@code ?bumpVersion=true} on the admin deploy endpoint)
+   * @param bumpRequested {@code true} when the caller explicitly requested a version bump
+   * @param forceRequested {@code true} when the caller supplied {@code ?force=true} (dev/test
+   *     unparseable-prior override). Requires {@code bumpRequested=true} to take effect — the admin
+   *     controller already enforces the pairing pre-parse, so this method assumes the invariant
+   *     holds.
    */
   public ValidationResult validateAndRegister(
-      String sourceName, byte[] bytes, String publishedBy, boolean bumpRequested) {
+      String sourceName,
+      byte[] bytes,
+      String publishedBy,
+      boolean bumpRequested,
+      boolean forceRequested) {
     ValidationResult result = this.source.loadBytes(sourceName, bytes);
     if (result.isInvalid() || result.config().isEmpty()) {
       return result;
@@ -212,7 +279,7 @@ public class ConfigService {
     Optional<Integer> priorVersion = versionRegistry.currentVersion(validated.id());
     if (priorVersion.isPresent()) {
       ValidationResult gateResult =
-          runBlastRadiusGate(validated, result, priorVersion.get(), bumpRequested);
+          runBlastRadiusGate(validated, result, priorVersion.get(), bumpRequested, forceRequested);
       if (gateResult != null) {
         return gateResult; // Rejected — return the error result
       }
@@ -250,6 +317,14 @@ public class ConfigService {
    * ValidationResult#invalid(List) invalid result} when the change is mutate-class and {@code
    * bumpRequested=false}; returns {@code null} when the gate passes (caller should continue).
    *
+   * <p>Story 3.11 — adds {@code forceRequested}. Force-override ONLY waives the WKS-CFG-030
+   * unparseable-prior path (AC4). It does NOT waive WKS-CFG-029 (mutate-class without bump — that
+   * path requires the classifier to have run, which {@code force=true} skips entirely; the
+   * mandatory {@code bumpRequested=true} pairing means the operator pays the same cost anyway). It
+   * does NOT waive WKS-CFG-001..028 validator findings on the candidate YAML. The schema-drift case
+   * is NOT eligible for force-override — AC1's lenient path handles it cleanly without operator
+   * intervention; if lenient parsing succeeds {@code forceRequested} is silently ignored.
+   *
    * <p>This method does NOT throw — it returns an invalid ValidationResult which the caller must
    * propagate. This mirrors the existing multi-error pattern in {@code ConfigService}.
    */
@@ -257,9 +332,24 @@ public class ConfigService {
       CaseTypeConfig validated,
       ValidationResult yamlResult,
       int priorVersionNum,
-      boolean bumpRequested) {
+      boolean bumpRequested,
+      boolean forceRequested) {
     CaseTypeConfig prev = loadPriorConfig(validated.id(), priorVersionNum);
     if (prev == null) {
+      // Story 3.11 AC4 — dev/test force-override for unparseable prior. Production-profile
+      // rejection already happened at the controller layer (AC3); by the time we're here in
+      // production, forceRequested is guaranteed false. The bumpRequested pairing is also
+      // enforced at the controller layer (AC4 hard rule), but defensively re-check here so
+      // direct service callers (tests, future call sites) can't bypass.
+      if (forceRequested && bumpRequested) {
+        log.warn(
+            "ConfigService.runBlastRadiusGate: force-override active for caseTypeId={} v{}"
+                + " — WKS-CFG-030 path bypassed (prior YAML unparseable); blast-radius"
+                + " classification SKIPPED, deploy proceeding under admin force-override",
+            validated.id(),
+            priorVersionNum);
+        return null; // Gate bypassed
+      }
       // Story 3.8 PR #417 follow-up — fail CLOSED. AC2 requires the gate to apply on every
       // deploy with a prior version; if we cannot load or re-parse the prior YAML we cannot
       // classify the change, and silently bypassing the gate would let mutate-class edits ship
@@ -327,16 +417,38 @@ public class ConfigService {
 
   /**
    * Story 3.8 — load the prior {@link CaseTypeConfig} from the version registry's stored YAML.
-   * Returns {@code null} when the YAML cannot be loaded or re-parsed (fail-open).
+   * Returns {@code null} when the YAML cannot be loaded or re-parsed (fail-open at this layer;
+   * caller emits WKS-CFG-030).
+   *
+   * <p>Story 3.11 AC1 — strict-then-lenient fallback. Try the strict {@link
+   * CaseTypeSource#loadBytes} first; on failure (typically schema-drift: prior YAML written under
+   * an older config schema with unknown legacy keys, or mapping-subtree records that dropped
+   * {@code @JsonIgnoreProperties(ignoreUnknown = true)} in Story 4.3.1 AC8), try {@link
+   * CaseTypeSource#loadBytesLenient} which tolerates unknown keys for diff purposes only. INFO log
+   * emitted exactly once per gate-pass when the lenient path was actually needed (strict failed but
+   * lenient succeeded). Returns {@code null} ONLY when BOTH paths fail.
    */
   private CaseTypeConfig loadPriorConfig(String caseTypeId, int version) {
     Optional<CaseTypeVersionRecord> record = versionRegistry.findVersion(caseTypeId, version);
     if (record.isEmpty() || record.get().rawYaml() == null) {
       return null;
     }
-    ValidationResult prev =
-        source.loadBytes("prior:" + caseTypeId + ":" + version, record.get().rawYaml());
-    return prev.config().orElse(null);
+    byte[] yaml = record.get().rawYaml();
+    ValidationResult strict = source.loadBytes("prior:" + caseTypeId + ":" + version, yaml);
+    if (strict.config().isPresent()) {
+      return strict.config().get();
+    }
+    // Strict failed — try lenient (Story 3.11 AC1).
+    ValidationResult lenient = source.loadBytesLenient("prior:" + caseTypeId + ":" + version, yaml);
+    if (lenient.config().isPresent()) {
+      log.info(
+          "ConfigService.runBlastRadiusGate: prior YAML for caseTypeId={} v{} required lenient"
+              + " re-parse (schema-drift); blast-radius classification proceeded",
+          caseTypeId,
+          version);
+      return lenient.config().get();
+    }
+    return null; // Both paths failed — caller emits WKS-CFG-030 (AC2).
   }
 
   /**
@@ -391,41 +503,61 @@ public class ConfigService {
    */
   public DeployResult deploy(
       byte[] yamlBytes, byte[] bpmnBytes, String bpmnFilename, String actorEmail) {
-    return deploy(yamlBytes, bpmnBytes, bpmnFilename, actorEmail, false);
+    return deploy(yamlBytes, bpmnBytes, bpmnFilename, actorEmail, false, false);
   }
 
-  /** Story 3.8 — overload that threads {@code bumpRequested} through the blast-radius gate. */
+  /** Story 3.8 — overload that threads {@code bumpRequested}; delegates with force=false. */
   public DeployResult deploy(
       byte[] yamlBytes,
       byte[] bpmnBytes,
       String bpmnFilename,
       String actorEmail,
       boolean bumpRequested) {
+    return deploy(yamlBytes, bpmnBytes, bpmnFilename, actorEmail, bumpRequested, false);
+  }
+
+  /** Story 3.11 — full overload threading {@code forceRequested}. */
+  public DeployResult deploy(
+      byte[] yamlBytes,
+      byte[] bpmnBytes,
+      String bpmnFilename,
+      String actorEmail,
+      boolean bumpRequested,
+      boolean forceRequested) {
     Map<String, byte[]> bpmnByName =
         (bpmnFilename != null && !bpmnFilename.isBlank() && bpmnBytes != null)
             ? Map.of(bpmnFilename, bpmnBytes)
             : Map.of();
     ValidationResult yamlResult = source.loadBytes("api-deploy.yaml", yamlBytes, bpmnByName);
-    return deployWithYamlResult(yamlResult, yamlBytes, bpmnBytes, actorEmail, bumpRequested);
+    return deployWithYamlResult(
+        yamlResult, yamlBytes, bpmnBytes, actorEmail, bumpRequested, forceRequested);
   }
 
   public DeployResult deploy(byte[] yamlBytes, byte[] bpmnBytes, String actorEmail) {
-    return deploy(yamlBytes, bpmnBytes, actorEmail, false);
+    return deploy(yamlBytes, bpmnBytes, actorEmail, false, false);
   }
 
-  /**
-   * Story 3.8 — overload that threads {@code bumpRequested} through the blast-radius gate (no BPMN
-   * filename variant — used by startup loader and tests).
-   */
+  /** Story 3.8 — overload that threads {@code bumpRequested}; delegates with force=false. */
   public DeployResult deploy(
       byte[] yamlBytes, byte[] bpmnBytes, String actorEmail, boolean bumpRequested) {
+    return deploy(yamlBytes, bpmnBytes, actorEmail, bumpRequested, false);
+  }
+
+  /** Story 3.11 — full overload threading {@code forceRequested} (no BPMN filename variant). */
+  public DeployResult deploy(
+      byte[] yamlBytes,
+      byte[] bpmnBytes,
+      String actorEmail,
+      boolean bumpRequested,
+      boolean forceRequested) {
     ValidationResult yamlResult = source.loadBytes("api-deploy.yaml", yamlBytes);
-    return deployWithYamlResult(yamlResult, yamlBytes, bpmnBytes, actorEmail, bumpRequested);
+    return deployWithYamlResult(
+        yamlResult, yamlBytes, bpmnBytes, actorEmail, bumpRequested, forceRequested);
   }
 
   private DeployResult deployWithYamlResult(
       ValidationResult yamlResult, byte[] yamlBytes, byte[] bpmnBytes, String actorEmail) {
-    return deployWithYamlResult(yamlResult, yamlBytes, bpmnBytes, actorEmail, false);
+    return deployWithYamlResult(yamlResult, yamlBytes, bpmnBytes, actorEmail, false, false);
   }
 
   private DeployResult deployWithYamlResult(
@@ -433,7 +565,8 @@ public class ConfigService {
       byte[] yamlBytes,
       byte[] bpmnBytes,
       String actorEmail,
-      boolean bumpRequested) {
+      boolean bumpRequested,
+      boolean forceRequested) {
     CaseTypeConfig caseType = yamlResult.config().orElse(null);
 
     BpmnValidationResult bpmnResult = bpmnValidator.validate(bpmnBytes, caseType);
@@ -455,7 +588,8 @@ public class ConfigService {
     Optional<Integer> priorVersion = versionRegistry.currentVersion(caseType.id());
     if (priorVersion.isPresent()) {
       ValidationResult gateResult =
-          runBlastRadiusGate(caseType, yamlResult, priorVersion.get(), bumpRequested);
+          runBlastRadiusGate(
+              caseType, yamlResult, priorVersion.get(), bumpRequested, forceRequested);
       if (gateResult != null) {
         // Rejected — propagate meta (blastRadius report) in the DeployResult
         return DeployResult.invalidWithMeta(gateResult.errors(), gateResult.responseMeta());

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeConfigProjection.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeConfigProjection.java
@@ -1,0 +1,227 @@
+package com.wkspower.platform.infrastructure.config;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldOption;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.config.model.WorkflowRef;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Story 3.11 AC1 — minimal best-effort projection from {@link RawCaseTypeConfig} to {@link
+ * CaseTypeConfig}, used by the lenient prior-YAML re-parse path on the blast-radius diff. Skips
+ * semantic validation: entries with missing/blank ids or unknown enum values are dropped silently
+ * rather than raising errors. This is intentional — diffing a schema-drifted prior version against
+ * a strictly-validated candidate must not surface validator findings against the obsolete schema
+ * (those findings ran when the prior was first deployed and would be noise here).
+ *
+ * <p>Strict path callers continue to use {@link ConfigValidator#validate} which performs full
+ * semantic checks AND projection in one pass. This helper is the projection-only sibling — never
+ * call it from the candidate (next) YAML path.
+ */
+final class CaseTypeConfigProjection {
+
+  private CaseTypeConfigProjection() {
+    // utility
+  }
+
+  /**
+   * Project a parsed {@link RawCaseTypeConfig} to a {@link CaseTypeConfig} for diff purposes.
+   * Returns {@link Optional#empty()} when the raw is null or lacks required top-level fields the
+   * diff cannot proceed without ({@code id}, {@code displayName}, {@code version}). All collection
+   * accessors on the returned config are non-null, matching the diff's structural expectations.
+   */
+  static Optional<CaseTypeConfig> project(RawCaseTypeConfig raw) {
+    if (raw == null
+        || raw.id() == null
+        || raw.id().isBlank()
+        || raw.displayName() == null
+        || raw.displayName().isBlank()
+        || raw.version() == null) {
+      return Optional.empty();
+    }
+
+    List<FieldDefinition> fields = projectFields(raw.fields());
+    List<StatusDefinition> statuses = projectStatuses(raw.statuses());
+    List<RoleDefinition> roles = projectRoles(raw.roles());
+    List<String> listColumns =
+        raw.listColumns() == null ? List.of() : List.copyOf(raw.listColumns());
+    List<StageDefinition> stages = projectStages(raw.stages());
+    List<FormDefinition> forms = projectForms(raw.forms());
+    WorkflowRef workflow = raw.workflow() == null ? null : new WorkflowRef(raw.workflow().bpmn());
+
+    return Optional.of(
+        new CaseTypeConfig(
+            raw.id(),
+            raw.displayName(),
+            raw.version(),
+            raw.description(),
+            workflow,
+            fields,
+            statuses,
+            listColumns,
+            roles,
+            stages,
+            forms));
+  }
+
+  private static List<FieldDefinition> projectFields(List<RawCaseTypeConfig.RawField> raws) {
+    if (raws == null || raws.isEmpty()) {
+      return List.of();
+    }
+    List<FieldDefinition> out = new ArrayList<>(raws.size());
+    for (int i = 0; i < raws.size(); i++) {
+      RawCaseTypeConfig.RawField f = raws.get(i);
+      if (f == null || f.id() == null || f.id().isBlank()) {
+        continue;
+      }
+      Optional<FieldType> type = FieldType.fromWire(f.type());
+      if (type.isEmpty()) {
+        // Unknown type — skip rather than guess; diff cannot meaningfully classify a field with
+        // no known type.
+        continue;
+      }
+      boolean required = Boolean.TRUE.equals(f.required());
+      boolean requiredOnCreate = f.requiredOnCreate() == null ? required : f.requiredOnCreate();
+      int order = f.order() == null ? i + 1 : f.order();
+      List<FieldOption> opts = List.of();
+      if (f.options() != null) {
+        List<FieldOption> tmp = new ArrayList<>(f.options().size());
+        for (RawCaseTypeConfig.RawOption o : f.options()) {
+          if (o == null || o.value() == null) {
+            continue;
+          }
+          String label = o.label() == null ? o.value() : o.label();
+          tmp.add(new FieldOption(label, o.value()));
+        }
+        opts = List.copyOf(tmp);
+      }
+      String displayName = f.displayName() == null ? f.id() : f.displayName();
+      FieldDefinition.TypeSlots slots =
+          new FieldDefinition.TypeSlots(
+              f.minLength(),
+              f.maxLength(),
+              f.min(),
+              f.max(),
+              f.step(),
+              f.dateMin(),
+              f.dateMax(),
+              f.maxBytes(),
+              f.allowedMimeTypes() == null ? List.of() : List.copyOf(f.allowedMimeTypes()));
+      out.add(
+          new FieldDefinition(
+              f.id(), displayName, type.get(), required, requiredOnCreate, order, opts, slots));
+    }
+    return List.copyOf(out);
+  }
+
+  private static List<StatusDefinition> projectStatuses(List<RawCaseTypeConfig.RawStatus> raws) {
+    if (raws == null || raws.isEmpty()) {
+      return List.of();
+    }
+    List<StatusDefinition> out = new ArrayList<>(raws.size());
+    for (RawCaseTypeConfig.RawStatus s : raws) {
+      if (s == null || s.id() == null || s.id().isBlank()) {
+        continue;
+      }
+      StatusColor color = parseColor(s.color());
+      if (color == null) {
+        // Unknown color — diff doesn't read color, but the StatusDefinition record requires
+        // non-null. Default to ZINC (neutral) for diff-only purposes.
+        color = StatusColor.ZINC;
+      }
+      String displayName = s.displayName() == null ? s.id() : s.displayName();
+      boolean terminal = Boolean.TRUE.equals(s.terminal());
+      out.add(new StatusDefinition(s.id(), displayName, color, terminal));
+    }
+    return List.copyOf(out);
+  }
+
+  private static StatusColor parseColor(String wire) {
+    if (wire == null) {
+      return null;
+    }
+    for (StatusColor c : StatusColor.values()) {
+      if (c.name().equalsIgnoreCase(wire)) {
+        return c;
+      }
+    }
+    return null;
+  }
+
+  private static List<RoleDefinition> projectRoles(List<RawCaseTypeConfig.RawRole> raws) {
+    if (raws == null || raws.isEmpty()) {
+      return List.of();
+    }
+    List<RoleDefinition> out = new ArrayList<>(raws.size());
+    for (RawCaseTypeConfig.RawRole r : raws) {
+      if (r == null || r.name() == null || r.name().isBlank()) {
+        continue;
+      }
+      List<Permission> perms = List.of();
+      if (r.permissions() != null) {
+        List<Permission> tmp = new ArrayList<>(r.permissions().size());
+        for (String p : r.permissions()) {
+          Permission.fromWire(p).ifPresent(tmp::add);
+        }
+        perms = List.copyOf(tmp);
+      }
+      out.add(new RoleDefinition(r.name(), perms));
+    }
+    return List.copyOf(out);
+  }
+
+  private static List<StageDefinition> projectStages(List<RawCaseTypeConfig.RawStage> raws) {
+    if (raws == null || raws.isEmpty()) {
+      return List.of();
+    }
+    List<StageDefinition> out = new ArrayList<>(raws.size());
+    int ordinal = 0;
+    for (RawCaseTypeConfig.RawStage s : raws) {
+      if (s == null || s.id() == null || s.id().isBlank()) {
+        continue;
+      }
+      String displayName =
+          s.displayName() == null || s.displayName().isBlank() ? s.id() : s.displayName();
+      List<StatusDefinition> stageStatuses = projectStatuses(s.statuses());
+      // null = not declared (flat fallback); empty list = declared empty (rare). Preserve null
+      // when raw.statuses() was null so diff sees the same "absent" signal as the strict path.
+      List<StatusDefinition> effective = s.statuses() == null ? null : stageStatuses;
+      Optional<String> initial =
+          s.initialStatus() == null || s.initialStatus().isBlank()
+              ? Optional.empty()
+              : Optional.of(s.initialStatus());
+      out.add(
+          new StageDefinition(s.id(), displayName, ordinal++, effective, initial, s.archetype()));
+    }
+    return List.copyOf(out);
+  }
+
+  private static List<FormDefinition> projectForms(RawFormConfig forms) {
+    if (forms == null || forms.definitions() == null || forms.definitions().isEmpty()) {
+      return List.of();
+    }
+    List<FormDefinition> out = new ArrayList<>(forms.definitions().size());
+    for (RawFormDefinition rf : forms.definitions()) {
+      if (rf == null || rf.id() == null || rf.id().isBlank()) {
+        continue;
+      }
+      try {
+        out.add(FormDefinitionMapper.toDomain(rf));
+      } catch (RuntimeException ignored) {
+        // Best-effort projection — if the form's internal shape is too drifted to map, skip.
+        // Diff classifier only consults form ids; missing forms count as removals and the operator
+        // can investigate the WARN trail.
+      }
+    }
+    return List.copyOf(out);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeSourceAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeSourceAdapter.java
@@ -56,6 +56,35 @@ public class CaseTypeSourceAdapter implements CaseTypeSource {
   }
 
   /**
+   * Story 3.11 AC1 — lenient prior-YAML re-parse for the blast-radius diff. Uses the lenient YAML
+   * mapper (unknown keys tolerated) and a minimal best-effort projection from {@link
+   * RawCaseTypeConfig} to {@code CaseTypeConfig}. {@link ConfigValidator} is NOT re-run — semantic
+   * findings against an obsolete schema would be noise. Diff classifier consumes the projected
+   * config; the mapping side is fed from {@code MappingRegistry} (registry-resolved, not
+   * YAML-projected) so the empty {@code MappingDefinition} returned here is structurally inert.
+   */
+  @Override
+  public ValidationResult loadBytesLenient(String source, byte[] bytes) {
+    var read = loader.readBytesLenient(source, bytes);
+    if (!read.isParsed()) {
+      return ValidationResult.invalid(read.errors());
+    }
+    var projected = CaseTypeConfigProjection.project(read.raw());
+    if (projected.isEmpty()) {
+      return ValidationResult.invalid(
+          java.util.List.of(
+              com.wkspower.platform.domain.exception.ErrorDetail.of(
+                  com.wkspower.platform.domain.exception.ErrorCode.WKS_CFG_099.wire(),
+                  "Lenient projection failed: prior YAML missing required top-level fields (id /"
+                      + " displayName / version)")));
+    }
+    return ValidationResult.ok(
+        projected.get(),
+        java.util.List.of(),
+        com.wkspower.platform.domain.config.model.MappingDefinition.empty());
+  }
+
+  /**
    * Read sibling BPMN files for any {@code attachments[].file} the YAML declared. Returns an empty
    * map when the YAML has no attachments. Files outside the YAML's parent directory or absolute
    * paths are silently dropped — {@link MappingValidator} surfaces them as {@code WKS-MAP-005}.

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeYamlLoader.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeYamlLoader.java
@@ -37,6 +37,16 @@ public class CaseTypeYamlLoader {
 
   private final YAMLMapper mapper;
 
+  /**
+   * Story 3.11 AC1 — sibling lenient mapper for prior-YAML re-parse on the blast-radius diff path.
+   * Identical to the strict {@link #mapper} except {@code FAIL_ON_UNKNOWN_PROPERTIES} is disabled:
+   * prior versions written under an older config schema (unknown legacy keys, mapping-subtree
+   * records that dropped {@code @JsonIgnoreProperties(ignoreUnknown = true)} in Story 4.3.1 AC8)
+   * still parse cleanly for diffing. Used ONLY for the prior side; the candidate (next) YAML
+   * continues to flow through the strict mapper above.
+   */
+  private final YAMLMapper lenientMapper;
+
   public CaseTypeYamlLoader() {
     YAMLMapper m =
         YAMLMapper.builder()
@@ -60,6 +70,22 @@ public class CaseTypeYamlLoader {
         .setCoercion(CoercionInputShape.Float, CoercionAction.Fail)
         .setCoercion(CoercionInputShape.Boolean, CoercionAction.Fail);
     this.mapper = m;
+
+    // Story 3.11 AC1 — lenient sibling mapper for prior-YAML re-parse (schema-drift recovery).
+    YAMLMapper lm =
+        YAMLMapper.builder()
+            .addModule(new JavaTimeModule())
+            .addModule(new ParameterNamesModule())
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .disable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+            .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
+            .build();
+    lm.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+    lm.coercionConfigFor(LogicalType.Textual)
+        .setCoercion(CoercionInputShape.Integer, CoercionAction.Fail)
+        .setCoercion(CoercionInputShape.Float, CoercionAction.Fail)
+        .setCoercion(CoercionInputShape.Boolean, CoercionAction.Fail);
+    this.lenientMapper = lm;
   }
 
   /**
@@ -97,6 +123,23 @@ public class CaseTypeYamlLoader {
 
   /** Load from raw bytes — used by tests and the (future) admin deploy endpoint. */
   public RawReadResult readBytes(String source, byte[] bytes) {
+    return readBytesWith(source, bytes, this.mapper);
+  }
+
+  /**
+   * Story 3.11 AC1 — lenient prior-YAML re-parse path. Mirrors {@link #readBytes(String, byte[])}
+   * but uses the lenient sibling mapper that tolerates unknown properties (schema-drift recovery).
+   * Caller (ConfigService.loadPriorConfig) treats a failed lenient read identically to a failed
+   * strict read — both produce {@code null} → WKS-CFG-030.
+   *
+   * <p>Used ONLY for the prior side of the blast-radius diff. The strict {@link #readBytes} remains
+   * the only path for candidate (next) YAML — forward-incoming deploys still validate strictly.
+   */
+  public RawReadResult readBytesLenient(String source, byte[] bytes) {
+    return readBytesWith(source, bytes, this.lenientMapper);
+  }
+
+  private RawReadResult readBytesWith(String source, byte[] bytes, YAMLMapper m) {
     if (bytes == null) {
       return RawReadResult.error(
           source, ErrorDetail.of(ErrorCode.WKS_CFG_099.wire(), "empty content"));
@@ -118,7 +161,7 @@ public class CaseTypeYamlLoader {
     }
     RawCaseTypeConfig raw;
     try (MappingIterator<RawCaseTypeConfig> it =
-        mapper.readerFor(RawCaseTypeConfig.class).readValues(bytes)) {
+        m.readerFor(RawCaseTypeConfig.class).readValues(bytes)) {
       if (!it.hasNextValue()) {
         return RawReadResult.error(
             source, ErrorDetail.of(ErrorCode.WKS_CFG_099.wire(), "YAML document is empty"));

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
@@ -21,8 +21,10 @@ import com.wkspower.platform.domain.service.MappingRegistry;
 import com.wkspower.platform.domain.service.StatusOptionsAdminService;
 import com.wkspower.platform.domain.service.TaskService;
 import com.wkspower.platform.domain.service.WksStageAdvancer;
+import java.util.Arrays;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 /**
  * Wires the pure-Java {@link ConfigService} (domain) with its infrastructure ports so Spring can
@@ -41,7 +43,8 @@ public class ConfigServiceConfig {
       EventPublisher eventPublisher,
       CaseTypeVersionRegistry versionRegistry,
       MappingRegistry mappingRegistry,
-      CaseTypeContentHasher caseTypeContentHasher) {
+      CaseTypeContentHasher caseTypeContentHasher,
+      Environment environment) {
     return new ConfigService(
         source,
         registrar,
@@ -51,7 +54,10 @@ public class ConfigServiceConfig {
         eventPublisher,
         versionRegistry,
         mappingRegistry,
-        CaseTypeContentHasher::hashBytes);
+        CaseTypeContentHasher::hashBytes,
+        // Story 3.11 AC3 — adapt Spring Environment to a framework-free supplier so the domain
+        // can detect the production profile without a Spring dependency.
+        () -> Arrays.asList(environment.getActiveProfiles()));
   }
 
   /**

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
@@ -77,9 +77,9 @@ class AdminControllerTest {
     byte[] bpmnBytes = "<x/>".getBytes();
     ArgumentCaptor<byte[]> yamlCap = ArgumentCaptor.forClass(byte[].class);
     ArgumentCaptor<byte[]> bpmnCap = ArgumentCaptor.forClass(byte[].class);
-    // Story 3.8 — controller now calls the 5-arg deploy overload (adds bumpVersion boolean)
+    // Story 3.11 — controller now calls the 6-arg deploy overload (adds force boolean)
     when(configService.deploy(
-            yamlCap.capture(), bpmnCap.capture(), any(), eq("admin"), anyBoolean()))
+            yamlCap.capture(), bpmnCap.capture(), any(), eq("admin"), anyBoolean(), anyBoolean()))
         .thenReturn(DeployResult.ok(config, deployment));
 
     mockMvc
@@ -144,7 +144,7 @@ class AdminControllerTest {
 
   @Test
   void validationFailureReturns422Aggregate() throws Exception {
-    when(configService.deploy(any(), any(), any(), any(), anyBoolean()))
+    when(configService.deploy(any(), any(), any(), any(), anyBoolean(), anyBoolean()))
         .thenReturn(
             DeployResult.invalid(
                 List.of(
@@ -172,7 +172,7 @@ class AdminControllerTest {
     // MaxUploadSizeExceededException
     // before reaching the handler chain. We simulate by configuring a tiny part cap via the test
     // and asserting the GlobalExceptionHandler maps the exception to 413 + WKS-API-413.
-    when(configService.deploy(any(), any(), any(), any(), anyBoolean()))
+    when(configService.deploy(any(), any(), any(), any(), anyBoolean(), anyBoolean()))
         .thenThrow(new MaxUploadSizeExceededException(1024L));
 
     mockMvc
@@ -186,7 +186,7 @@ class AdminControllerTest {
         .andExpect(status().isPayloadTooLarge())
         .andExpect(jsonPath("$.error.code").value("WKS-API-413"));
 
-    verify(configService).deploy(any(), any(), any(), any(), anyBoolean());
+    verify(configService).deploy(any(), any(), any(), any(), anyBoolean(), anyBoolean());
   }
 
   // ---- YAML-only deploy (Story 3.2: zero-process case types) -------------
@@ -210,9 +210,9 @@ class AdminControllerTest {
             List.of(),
             List.of());
     byte[] yamlBytes = "id: j9-zero-zero".getBytes();
-    // Story 3.8 — controller now calls the 4-arg validateAndRegister overload (adds bumpVersion)
+    // Story 3.11 — controller now calls the 5-arg validateAndRegister overload (adds force)
     when(configService.validateAndRegister(
-            eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean()))
+            eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean(), anyBoolean()))
         .thenReturn(ValidationResult.ok(config));
 
     mockMvc
@@ -228,13 +228,14 @@ class AdminControllerTest {
         .andExpect(jsonPath("$.data.schemaUri").value("/api/admin/case-types/j9-zero-zero/schema"));
 
     verify(configService)
-        .validateAndRegister(eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean());
+        .validateAndRegister(
+            eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean(), anyBoolean());
   }
 
   @Test
   void missingBpmnPartWithInvalidYamlReturns422() throws Exception {
     when(configService.validateAndRegister(
-            eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean()))
+            eq("api-deploy.yaml"), any(byte[].class), any(), anyBoolean(), anyBoolean()))
         .thenReturn(
             ValidationResult.invalid(List.of(ErrorDetail.of("WKS-CFG-099", "YAML parse failed"))));
 
@@ -279,7 +280,7 @@ class AdminControllerTest {
     byte[] bpmnBytes = "<bpmn/>".getBytes();
 
     ArgumentCaptor<Boolean> bumpCap = ArgumentCaptor.forClass(Boolean.class);
-    when(configService.deploy(any(), any(), any(), any(), bumpCap.capture()))
+    when(configService.deploy(any(), any(), any(), any(), bumpCap.capture(), anyBoolean()))
         .thenReturn(DeployResult.ok(config, deployment));
 
     mockMvc
@@ -309,7 +310,7 @@ class AdminControllerTest {
         new DeploymentResult("dep-1", "loanProcess", "procDef-1", 1, Instant.now());
 
     ArgumentCaptor<Boolean> bumpCap = ArgumentCaptor.forClass(Boolean.class);
-    when(configService.deploy(any(), any(), any(), any(), bumpCap.capture()))
+    when(configService.deploy(any(), any(), any(), any(), bumpCap.capture(), anyBoolean()))
         .thenReturn(DeployResult.ok(config, deployment));
 
     mockMvc
@@ -327,6 +328,136 @@ class AdminControllerTest {
     assertThat(bumpCap.getValue()).isFalse();
   }
 
+  // ---- Story 3.11: force-override param + production-profile rejection ----
+
+  @Test
+  void forceTrueInProductionProfile_rejectedWithApi006_yamlNotParsed() throws Exception {
+    when(configService.isProductionProfile()).thenReturn(true);
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(
+                    new MockMultipartFile("caseType", "ct.yaml", "text/plain", "id: x".getBytes()))
+                .param("force", "true")
+                .param("bumpVersion", "true")
+                .with(user("admin").roles("ADMIN")))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.error.errors[0].code").value("WKS-API-006"))
+        .andExpect(
+            jsonPath("$.error.errors[0].message")
+                .value(org.hamcrest.Matchers.containsString("production profile")));
+
+    // YAML must NOT have been parsed — service is never called for production-rejected force.
+    verifyNoInteractions(jwtTokenProvider);
+    org.mockito.Mockito.verify(configService).isProductionProfile();
+    org.mockito.Mockito.verifyNoMoreInteractions(configService);
+  }
+
+  @Test
+  void forceTrueWithoutBumpVersion_rejectedWithApi006() throws Exception {
+    when(configService.isProductionProfile()).thenReturn(false);
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(
+                    new MockMultipartFile("caseType", "ct.yaml", "text/plain", "id: x".getBytes()))
+                .param("force", "true")
+                // bumpVersion intentionally omitted
+                .with(user("admin").roles("ADMIN")))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.error.errors[0].code").value("WKS-API-006"))
+        .andExpect(
+            jsonPath("$.error.errors[0].message")
+                .value(org.hamcrest.Matchers.containsString("bumpVersion=true")));
+
+    org.mockito.Mockito.verify(configService).isProductionProfile();
+    org.mockito.Mockito.verifyNoMoreInteractions(configService);
+  }
+
+  @Test
+  void forceTrueWithBumpVersion_devProfile_threadsForceToService() throws Exception {
+    when(configService.isProductionProfile()).thenReturn(false);
+    CaseTypeConfig config =
+        CaseTypeConfig.builder()
+            .id("force-ct")
+            .displayName("Force CT")
+            .version(2)
+            .statuses(List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)))
+            .build();
+
+    ArgumentCaptor<Boolean> forceCap = ArgumentCaptor.forClass(Boolean.class);
+    when(configService.validateAndRegister(any(), any(), any(), eq(true), forceCap.capture()))
+        .thenReturn(ValidationResult.ok(config));
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(
+                    new MockMultipartFile(
+                        "caseType", "ct.yaml", "text/plain", "id: force-ct".getBytes()))
+                .param("force", "true")
+                .param("bumpVersion", "true")
+                .with(user("admin").roles("ADMIN")))
+        .andExpect(status().isOk());
+
+    assertThat(forceCap.getValue())
+        .as("force=true must be threaded to ConfigService.validateAndRegister")
+        .isTrue();
+  }
+
+  @Test
+  void forceParamDefaultsFalse_existingBehaviorPreserved() throws Exception {
+    // When ?force is not supplied, configService.isProductionProfile is NOT called (no force
+    // gating). Service receives forceRequested=false — Story 3.8 behavior unchanged.
+    CaseTypeConfig config =
+        CaseTypeConfig.builder()
+            .id("no-force")
+            .displayName("No Force")
+            .version(1)
+            .statuses(List.of(new StatusDefinition("open", "Open", StatusColor.BLUE)))
+            .build();
+    DeploymentResult deployment =
+        new DeploymentResult("dep-1", "noForceProcess", "procDef-1", 1, Instant.now());
+    ArgumentCaptor<Boolean> forceCap = ArgumentCaptor.forClass(Boolean.class);
+    when(configService.deploy(any(), any(), any(), any(), anyBoolean(), forceCap.capture()))
+        .thenReturn(DeployResult.ok(config, deployment));
+
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(
+                    new MockMultipartFile(
+                        "caseType", "ct.yaml", "text/plain", "id: no-force".getBytes()))
+                .file(new MockMultipartFile("bpmn", "p.bpmn", "application/xml", "<x/>".getBytes()))
+                .with(user("admin").roles("ADMIN")))
+        .andExpect(status().isOk());
+
+    assertThat(forceCap.getValue()).isFalse();
+    // Production-profile check NEVER consulted on the no-force path (fast path).
+    org.mockito.Mockito.verify(configService, org.mockito.Mockito.never()).isProductionProfile();
+  }
+
+  @Test
+  void forceTrueWithRoleUser_rejectedAsForbidden_beforeForceLogic() throws Exception {
+    // @PreAuthorize runs before the controller body, so a non-ADMIN caller hits 403 first
+    // regardless of force=true semantics. This pins that the force-override gating is for
+    // ADMIN-authority callers only — the lower-authority rejection is upstream.
+    mockMvc
+        .perform(
+            multipart("/api/admin/deploy")
+                .file(
+                    new MockMultipartFile("caseType", "ct.yaml", "text/plain", "id: x".getBytes()))
+                .param("force", "true")
+                .param("bumpVersion", "true")
+                .with(user("user").roles("USER")))
+        .andExpect(status().isForbidden());
+
+    // configService MUST NOT be invoked — @PreAuthorize short-circuited.
+    verifyNoInteractions(configService);
+  }
+
   @Test
   void bumpVersionTrueIsThreadedToValidateAndRegister() throws Exception {
     // Story 3.8 — ?bumpVersion=true forwarded on YAML-only (no BPMN) path
@@ -339,7 +470,7 @@ class AdminControllerTest {
             .build();
 
     ArgumentCaptor<Boolean> bumpCap = ArgumentCaptor.forClass(Boolean.class);
-    when(configService.validateAndRegister(any(), any(), any(), bumpCap.capture()))
+    when(configService.validateAndRegister(any(), any(), any(), bumpCap.capture(), anyBoolean()))
         .thenReturn(ValidationResult.ok(config));
 
     mockMvc

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/BlastRadiusForceOverridePostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/BlastRadiusForceOverridePostgresIT.java
@@ -1,0 +1,218 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.ValidationResult;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.service.ConfigService;
+import com.wkspower.platform.infrastructure.persistence.entity.CaseTypeVersionEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.CaseTypeVersionJpaRepository;
+import jakarta.persistence.EntityManager;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Story 3.11 — Postgres-backed integration test for the lenient prior re-parse + dev-only force
+ * override paths.
+ *
+ * <p>Memory {@code feedback_production_validator_opt_out.md} — production-validation disabled so
+ * the validator's bootstrap check does not fire on test-only boot config.
+ *
+ * <p>Memory {@code project_postgres_it_parity_gap.md}: Postgres-IT mandatory because the prior YAML
+ * byte storage path crosses {@code case_type_versions.definition_yaml} which Sprint 4 confirmed
+ * needs Postgres parity for byte fidelity.
+ */
+@SpringBootTest(properties = "wks.bootstrap.production-validation.enabled=false")
+@ActiveProfiles("production")
+@Testcontainers(disabledWithoutDocker = true)
+class BlastRadiusForceOverridePostgresIT {
+
+  @Container
+  @SuppressWarnings("resource")
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("wks")
+          .withUsername("wks")
+          .withPassword("wks");
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("WKS_DB_URL", POSTGRES::getJdbcUrl);
+    registry.add("WKS_DB_USER", POSTGRES::getUsername);
+    registry.add("WKS_DB_PASSWORD", POSTGRES::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    registry.add("WKS_ADMIN_EMAIL", () -> "admin@wkspower.local");
+    registry.add("WKS_ADMIN_PASSWORD", () -> "admin");
+    registry.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+    registry.add("WKS_CORS_ORIGINS", () -> "http://localhost:5173");
+    registry.add(
+        "camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+  }
+
+  @Autowired private ConfigService configService;
+  @Autowired private CaseTypeVersionJpaRepository repo;
+  @Autowired private EntityManager em;
+
+  private static final String CT_PREFIX = "force-override-pg-";
+
+  /** Minimal valid base YAML — id substituted per scenario for isolation. */
+  private static byte[] baseYaml(String caseTypeId, int version) {
+    return ("""
+        id: %s
+        displayName: "Force Override Test"
+        version: %d
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: false
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """
+            .formatted(caseTypeId, version))
+        .getBytes(StandardCharsets.UTF_8);
+  }
+
+  @AfterEach
+  void wipe() {
+    repo.deleteAll();
+  }
+
+  // ---- Scenario 1: corrupt prior + force=true&bumpVersion=true → ACCEPTED ----
+
+  @Test
+  @Transactional
+  void corruptPrior_forceTrue_bumpTrue_accepted() {
+    String id = CT_PREFIX + "s1";
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", baseYaml(id, 1), "test:s1", false);
+    assertThat(v1.isInvalid()).as("v1 deploy must succeed: " + v1.errors()).isFalse();
+
+    // Corrupt the stored YAML to malformed bytes.
+    corruptPriorYaml(id, 1);
+
+    // v2: redeploy with force=true&bumpVersion=true — gate should bypass with WARN.
+    ValidationResult v2 =
+        configService.validateAndRegister(
+            "api-deploy.yaml", baseYaml(id, 2), "test:s1", true, true);
+
+    assertThat(v2.isInvalid())
+        .as("force=true&bump=true must bypass WKS-CFG-030 in non-production: " + v2.errors())
+        .isFalse();
+  }
+
+  // ---- Scenario 2: corrupt prior + force=false → 422 + WKS-CFG-030 ----
+
+  @Test
+  @Transactional
+  void corruptPrior_noForce_rejectedWithCfg030() {
+    String id = CT_PREFIX + "s2";
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", baseYaml(id, 1), "test:s2", false);
+    assertThat(v1.isInvalid()).isFalse();
+
+    corruptPriorYaml(id, 1);
+
+    ValidationResult v2 =
+        configService.validateAndRegister(
+            "api-deploy.yaml", baseYaml(id, 2), "test:s2", false, false);
+
+    assertThat(v2.isInvalid()).isTrue();
+    assertThat(v2.errors().get(0).code())
+        .as("AC2 regression — corrupt prior without force must still fail-closed")
+        .isEqualTo(ErrorCode.WKS_CFG_030.wire());
+  }
+
+  // ---- Scenario 3: schema-drifted prior (unknown legacy key) → AC1 lenient happy path ----
+
+  @Test
+  @Transactional
+  void schemaDriftedPrior_lenientPathPicksUp_classifierRuns() {
+    String id = CT_PREFIX + "s3";
+
+    // Seed v1 the normal way then overwrite definitionYaml with a drifted shape that the strict
+    // mapper rejects but the lenient mapper accepts.
+    ValidationResult v1 =
+        configService.validateAndRegister("api-deploy.yaml", baseYaml(id, 1), "test:s3", false);
+    assertThat(v1.isInvalid()).isFalse();
+
+    String drifted =
+        """
+        id: %s
+        displayName: "Force Override Test"
+        version: 1
+        legacyTopLevelField: removed-since
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+            terminal: false
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """
+            .formatted(id);
+    overwritePriorYaml(id, 1, drifted);
+
+    // v2: append-class change (no force needed). Lenient prior parse should pick up cleanly.
+    ValidationResult v2 =
+        configService.validateAndRegister("api-deploy.yaml", baseYaml(id, 2), "test:s3", false);
+
+    assertThat(v2.isInvalid())
+        .as(
+            "AC1 — schema-drifted prior should be re-parsed leniently and classifier should run"
+                + " against append-class change without force: "
+                + v2.errors())
+        .isFalse();
+  }
+
+  // ---- Scenario 4: production profile rejection of force=true ----
+  // AC3 production rejection is a CONTROLLER-layer concern (pre-parse). The service-layer
+  // ConfigService.isProductionProfile() returns false for this @ActiveProfiles("test","postgres")
+  // class. A profile-specific IT proves the controller layer wires Environment correctly; that
+  // path is exercised by the AdminControllerForceOverrideTest unit tests via mocking
+  // configService.isProductionProfile() — IT-level verification of the production-profile
+  // wiring is already covered by the existing BlastRadiusValidatorPostgresIT class which uses
+  // @ActiveProfiles("production"). This Postgres-IT focuses on the service-layer behaviors.
+
+  // ---- Helpers ----
+
+  private void corruptPriorYaml(String caseTypeId, int version) {
+    String malformed = "id: " + caseTypeId + "\ndisplayName: \"unterminated\nversion: " + version;
+    overwritePriorYaml(caseTypeId, version, malformed);
+  }
+
+  /** Direct write to {@code case_type_versions.definition_yaml} bypassing the registry adapter. */
+  private void overwritePriorYaml(String caseTypeId, int version, String yaml) {
+    em.flush();
+    em.createNativeQuery(
+            "UPDATE case_type_versions SET definition_yaml = :y WHERE case_type_id = :id AND"
+                + " version = :v")
+        .setParameter("y", yaml)
+        .setParameter("id", caseTypeId)
+        .setParameter("v", version)
+        .executeUpdate();
+    em.clear();
+    // Sanity — the row is updated.
+    CaseTypeVersionEntity row =
+        em.createQuery(
+                "SELECT e FROM CaseTypeVersionEntity e WHERE e.caseTypeId = :id AND e.version ="
+                    + " :v",
+                CaseTypeVersionEntity.class)
+            .setParameter("id", caseTypeId)
+            .setParameter("v", version)
+            .getSingleResult();
+    assertThat(row.getDefinitionYaml()).isEqualTo(yaml);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeYamlLoaderLenientTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/CaseTypeYamlLoaderLenientTest.java
@@ -1,0 +1,143 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.infrastructure.config.CaseTypeYamlLoader.RawReadResult;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 3.11 AC1 — unit tests for {@link CaseTypeYamlLoader#readBytesLenient}.
+ *
+ * <p>Verifies: lenient mapper tolerates unknown top-level / nested keys; truly malformed YAML still
+ * fails on both paths; valid drift-free YAML produces equal {@link RawCaseTypeConfig} on both paths
+ * (sanity — no false-positive divergence).
+ */
+class CaseTypeYamlLoaderLenientTest {
+
+  private final CaseTypeYamlLoader loader = new CaseTypeYamlLoader();
+
+  /** Minimal valid case-type YAML used as the structural base for drift scenarios. */
+  private static byte[] base() {
+    return ("""
+        id: lenient-test
+        displayName: "Lenient Test"
+        version: 1
+        statuses:
+          - id: open
+            displayName: Open
+            color: blue
+        roles:
+          - name: admin
+            permissions: [view, create, edit, transition]
+        """)
+        .getBytes(StandardCharsets.UTF_8);
+  }
+
+  // ---- Case 1: unknown top-level key — RawCaseTypeConfig carries
+  // @JsonIgnoreProperties(ignoreUnknown = true) so BOTH paths tolerate top-level drift. The
+  // lenient path is for nested mapping-subtree drift (case 2). Top-level forward-compat is
+  // already in place per Story 4.3.1 AC8 commentary in CaseTypeYamlLoader.
+
+  @Test
+  void unknownTopLevelKey_bothPathsTolerate() {
+    byte[] yaml =
+        ("""
+            id: lenient-test
+            displayName: "Lenient Test"
+            version: 1
+            legacyField: removed-since
+            statuses:
+              - id: open
+                displayName: Open
+                color: blue
+            roles:
+              - name: admin
+                permissions: [view, create, edit, transition]
+            """)
+            .getBytes(StandardCharsets.UTF_8);
+
+    RawReadResult strict = loader.readBytes("strict.yaml", yaml);
+    RawReadResult lenient = loader.readBytesLenient("lenient.yaml", yaml);
+
+    // Both paths tolerate top-level unknown — RawCaseTypeConfig has @JsonIgnoreProperties.
+    assertThat(strict.isParsed()).isTrue();
+    assertThat(lenient.isParsed()).isTrue();
+    assertThat(strict.raw().id()).isEqualTo("lenient-test");
+    assertThat(lenient.raw().id()).isEqualTo("lenient-test");
+  }
+
+  // ---- Case 2: unknown nested key under a record that dropped @JsonIgnoreProperties ----
+  // RawAttachment in the Mapping subtree (Story 4.3.1 AC8) is the cleanest example.
+
+  @Test
+  void unknownNestedKeyInAttachment_strictFails_lenientSucceeds() {
+    byte[] yaml =
+        ("""
+            id: lenient-nested
+            displayName: "Lenient Nested"
+            version: 1
+            statuses:
+              - id: open
+                displayName: Open
+                color: blue
+            roles:
+              - name: admin
+                permissions: [view, create, edit, transition]
+            attachments:
+              - type: bpmn
+                file: process.bpmn
+                scope: case
+                legacyAttachmentSlot: gone
+            """)
+            .getBytes(StandardCharsets.UTF_8);
+
+    RawReadResult strict = loader.readBytes("strict.yaml", yaml);
+    assertThat(strict.isParsed())
+        .as("strict mapper rejects unknown attachment-nested key")
+        .isFalse();
+
+    RawReadResult lenient = loader.readBytesLenient("lenient.yaml", yaml);
+    assertThat(lenient.isParsed())
+        .as("lenient mapper tolerates unknown attachment-nested key")
+        .isTrue();
+  }
+
+  // ---- Case 3: malformed YAML (unterminated quoted string) — both fail ----
+
+  @Test
+  void malformedYaml_bothFail() {
+    byte[] yaml =
+        ("""
+            id: malformed
+            displayName: "Unterminated string
+            version: 1
+            """)
+            .getBytes(StandardCharsets.UTF_8);
+
+    RawReadResult strict = loader.readBytes("strict.yaml", yaml);
+    RawReadResult lenient = loader.readBytesLenient("lenient.yaml", yaml);
+
+    assertThat(strict.isParsed()).isFalse();
+    assertThat(lenient.isParsed())
+        .as("genuinely malformed YAML must fail lenient too — AC2 fail-closed regression guard")
+        .isFalse();
+    assertThat(lenient.errors().get(0).code()).isEqualTo(ErrorCode.WKS_CFG_099.wire());
+  }
+
+  // ---- Case 4: valid drift-free YAML — strict and lenient produce equal raw ----
+
+  @Test
+  void noDrift_bothPathsAgree() {
+    byte[] yaml = base();
+    RawReadResult strict = loader.readBytes("strict.yaml", yaml);
+    RawReadResult lenient = loader.readBytesLenient("lenient.yaml", yaml);
+
+    assertThat(strict.isParsed()).isTrue();
+    assertThat(lenient.isParsed()).isTrue();
+    assertThat(strict.raw())
+        .as("no schema drift → strict and lenient projections must be equal")
+        .isEqualTo(lenient.raw());
+  }
+}


### PR DESCRIPTION
## Summary

Story 3-11 — Blast-Radius Gate Lenient Prior Re-parse & Dev-Only Force Override (Sprint 9). Builds on Story 3-8's WKS-CFG-030 fail-closed gate by:
1. Tolerating prior YAML written under an older config schema (lenient re-parse for diff purposes only — candidate YAML continues to validate strictly).
2. Adding a dev-profile-only `?force=true` query param on `POST /api/admin/deploy` that bypasses the unparseable-prior path. Production rejects `force=true` outright with a new `WKS-API-006` regardless of caller authority.

### AC outcomes

- **AC1 — Lenient prior re-parse:** sibling `lenientMapper` on `CaseTypeYamlLoader` (FAIL_ON_UNKNOWN_PROPERTIES disabled, all other strict settings preserved). `CaseTypeSource.loadBytesLenient` (additive default port method) + `CaseTypeSourceAdapter` impl projects via new `CaseTypeConfigProjection` helper (validator NOT re-run — semantic findings against an obsolete schema would be noise). `ConfigService.loadPriorConfig` falls back strict→lenient; INFO log emitted exactly once per gate-pass when lenient was actually needed.
- **AC2 — Fail-closed regression preserved:** when both strict and lenient parse fail, WKS-CFG-030 still fires unchanged. Verified by `BlastRadiusForceOverridePostgresIT.corruptPrior_noForce_rejectedWithCfg030`; existing `BlastRadiusValidatorPostgresIT` (3-8 IT) remains green.
- **AC3 — Production rejects `force=true`:** pre-parse rejection in `AdminController.deploy` returns HTTP 422 + `WKS-API-006`. YAML body NOT consumed. Audit log `outcome=REJECTED_PRODUCTION`. Detection via `ConfigService.isProductionProfile()` adapter (Supplier<List<String>>).
- **AC4 — Dev/test force-override:** hard rule `force=true` requires `bumpVersion=true` (also rejected with `WKS-API-006` + `outcome=REJECTED_NO_BUMP` if missing). On accepted force, service-side `runBlastRadiusGate` short-circuits with structured WARN; force scope is ONLY WKS-CFG-030 (does NOT waive WKS-CFG-029, validator findings, etc.). Schema-drift case silently ignores force (AC1 lenient path takes the win).
- **AC5 — Audit logs:** three controller-side INFO entries (REJECTED_PRODUCTION / REJECTED_NO_BUMP / ACCEPTED) + the AC4 service-side WARN. All single-line, key=value, grep-stable on `event=admin.deploy.force_override`.
- **AC6 — `seed/seed.sh`:** vacuous in this codebase. Repo has NO seed shell or Node script issuing `POST /api/admin/deploy` (CaseType seeding is filesystem-scan via `wks.case-types.dir` → `validateAndRegister(Path)`, which doesn't cross `AdminController.deploy`). AC3+AC4 server-side enforcement is sufficient. Open question raised in story file Dev Agent Record.

### Wire-contract additions (permanent per `feedback_error_codes_are_wire_contract.md`)

- `WKS-API-006` — admin force-override precondition violation. Mapped to HTTP 422 by the existing `WksConfigException` band (no `GlobalExceptionHandler` change needed).

### Hard rules surfaced in this PR

- **`force=true` requires `bumpVersion=true` even in dev/test.** Skipping the classifier without bumping the version would silently rewrite an existing version row — worse than the unparseable-prior failure mode.
- **`force=true` is silently ignored when lenient parsing succeeds** — schema-drift case isn't an escape-hatch case; AC1 handles it cleanly without operator intervention.

### Parallel collision risk (Sprint 9)

Story 4-6 also touches `AdminController.java` but adds a SIBLING controller (`AdminMappingInspectorController.java`) deliberately to keep merge-disjoint. 3-11 modifies `AdminController.deploy` method body + adds a `force` `@RequestParam`. Both PRs must rebase against whichever lands first — branch-protection's "require up-to-date" enforces this.

## Test plan

- [x] `mvn -pl backend test` — 535 unit tests, 0 failures
- [x] `mvn -pl backend verify -B` — 154 IT tests, 0 failures, 1 pre-existing skip; new `BlastRadiusForceOverridePostgresIT` 3/3 scenarios green
- [x] `bash backend/.ci/check-tenant-invariant.sh` — green
- [x] Spotless / ArchUnit — green (full mvnw verify pre-push hook passed)
- [x] AC1 unit coverage: `CaseTypeYamlLoaderLenientTest` (4 cases — top-level forward-compat, nested-attachment lenient, malformed-fails-both, no-drift agreement)
- [x] AC3/AC4/AC5 unit coverage: 5 new cases in `AdminControllerTest` (production rejection, missing-bump rejection, accepted dev path, default-false threading, role-user 403 short-circuit)
- [x] AC1/AC2/AC4 IT coverage: `BlastRadiusForceOverridePostgresIT` (3 scenarios on Postgres testcontainer)
- [ ] Reviewer should verify the audit log format `event=admin.deploy.force_override caller=... caseTypeId=... priorVersion=... outcome=... reason=...` matches operations forensic-grep expectations.
- [ ] Reviewer should confirm AC6 vacuous-status assessment — if a private seed.sh / Node ops seeder exists in a sibling repo, file a 1-line follow-up to append `force=true&bumpVersion=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)