### PR TITLE
feat(5-6): per-field edit permissions + CaseService.requireCaseAccess extraction

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
@@ -85,7 +85,16 @@ public class FormController {
           ErrorCode.WKS_FORM_003, "Form submission body is null or empty", null);
     }
 
-    Case updated = caseService.submitForm(caseId, formId, formData, actor.id());
+    // Story 5.6 AC-0 — case-level access gate, single source of truth shared with
+    // FormDraftController.
+    // Throws WksNotFoundException (→ 404) if the case is missing — same wire shape as before.
+    java.util.Set<String> actorRoles =
+        actor.authenticated() == null ? java.util.Set.of() : actor.authenticated().roles();
+    caseService.requireCaseAccess(caseId, actor.id(), actorRoles);
+
+    // Story 5.6 AC2 — principal-aware overload threads the actor's role set through to the
+    // per-field editableBy permission check.
+    Case updated = caseService.submitForm(caseId, formId, formData, actor.id(), actorRoles);
 
     // Story 5.4 AC6 — delete-on-submit. Lives inside the controller's @Transactional so a
     // post-submit failure rolls back the deletion (preserving the draft) per AC6.

--- a/backend/src/main/java/com/wkspower/platform/api/controller/FormDraftController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/FormDraftController.java
@@ -1,10 +1,8 @@
 package com.wkspower.platform.api.controller;
 
 import com.wkspower.platform.api.dto.ApiResponse;
-import com.wkspower.platform.domain.exception.WksNotFoundException;
-import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.model.FormDraft;
-import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.service.CaseService;
 import com.wkspower.platform.domain.service.FormDraftService;
 import com.wkspower.platform.security.WksUserPrincipal;
 import jakarta.validation.Valid;
@@ -14,6 +12,7 @@ import jakarta.validation.constraints.PositiveOrZero;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -36,11 +35,15 @@ import org.springframework.web.bind.annotation.RestController;
  *   DELETE /api/cases/{caseId}/forms/{formId}/draft  -> 204 (idempotent)
  * </pre>
  *
- * <p>RBAC: {@code isAuthenticated()} + the caller must have access to the underlying case (the
- * {@link CaseRepository#findById} call doubles as the access gate — a user without read access on
- * the case has no way to reach this endpoint via the routing layer; in addition, the draft scope
- * already filters by {@code userId} via the {@link WksUserPrincipal}, so cross-user reads are
- * impossible — AC5).
+ * <p>RBAC: {@code isAuthenticated()} + the caller must have access to the underlying case. Story
+ * 5.6 AC-0 — case-level access is gated through {@link CaseService#requireCaseAccess} (the single
+ * source of truth shared with {@link FormController}). The previous inline {@code
+ * requireCaseExists} helper has been removed; per-field permission checks are NOT enforced on the
+ * draft path (drafts are working state — disallowed values are simply ignored on submit per Story
+ * 5.6 AC2).
+ *
+ * <p>The draft scope already filters by {@code userId} via the {@link WksUserPrincipal}, so
+ * cross-user reads are impossible — Story 5.4 AC5.
  *
  * <p>No new {@code WKS-DRAFT-*} error codes — standard 404 (no draft) and 422 (invalid body via
  * {@code @Valid}) suffice. Memory {@code feedback_error_codes_are_wire_contract.md}: codes are
@@ -51,11 +54,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class FormDraftController {
 
   private final FormDraftService draftService;
-  private final CaseRepository caseRepository;
+  private final CaseService caseService;
 
-  public FormDraftController(FormDraftService draftService, CaseRepository caseRepository) {
+  public FormDraftController(FormDraftService draftService, CaseService caseService) {
     this.draftService = draftService;
-    this.caseRepository = caseRepository;
+    this.caseService = caseService;
   }
 
   @GetMapping("/{caseId}/forms/{formId}/draft")
@@ -65,7 +68,7 @@ public class FormDraftController {
       @PathVariable UUID caseId,
       @PathVariable String formId,
       @AuthenticationPrincipal WksUserPrincipal actor) {
-    requireCaseExists(caseId);
+    caseService.requireCaseAccess(caseId, actor.id(), actorRoles(actor));
     Optional<FormDraft> found = draftService.findDraft(caseId, formId, actor.id());
     return found
         .map(d -> ResponseEntity.ok(ApiResponse.success(FormDraftDto.from(d))))
@@ -80,7 +83,7 @@ public class FormDraftController {
       @PathVariable String formId,
       @Valid @RequestBody SaveDraftRequest body,
       @AuthenticationPrincipal WksUserPrincipal actor) {
-    requireCaseExists(caseId);
+    caseService.requireCaseAccess(caseId, actor.id(), actorRoles(actor));
     FormDraft saved =
         draftService.saveDraft(
             caseId,
@@ -100,20 +103,13 @@ public class FormDraftController {
       @PathVariable UUID caseId,
       @PathVariable String formId,
       @AuthenticationPrincipal WksUserPrincipal actor) {
-    requireCaseExists(caseId);
+    caseService.requireCaseAccess(caseId, actor.id(), actorRoles(actor));
     draftService.deleteDraft(caseId, formId, actor.id());
     return ResponseEntity.noContent().build();
   }
 
-  private void requireCaseExists(UUID caseId) {
-    Case existing =
-        caseRepository
-            .findById(caseId)
-            .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
-    // referenced solely to confirm the row exists; assignee/RBAC checks live elsewhere.
-    if (existing == null) {
-      throw new WksNotFoundException("Case " + caseId + " not found");
-    }
+  private static Set<String> actorRoles(WksUserPrincipal actor) {
+    return actor.authenticated() == null ? Set.of() : actor.authenticated().roles();
   }
 
   /** Request body for PUT — auto-validated via {@code @Valid}. */

--- a/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
+++ b/backend/src/main/java/com/wkspower/platform/api/dto/response/CaseTypeViewDto.java
@@ -31,11 +31,18 @@ public record CaseTypeViewDto(
      * when omitted. Frontend uses this to render {@code SinglePageFormRenderer} without a second
      * round-trip.
      */
-    List<FormDefinitionView> forms) {
+    List<FormDefinitionView> forms,
+    /**
+     * Story 5.6 AC4 — top-level case-type setting controlling default field editability. Wire
+     * values: {@code editable-by-default} (Phase-0 default — preserves pre-5.6 behavior) or {@code
+     * locked-by-default}.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL) String defaultFieldEditability) {
 
   /**
    * Compact constructor — defensive-copy {@code stages} and {@code forms} so the wire shape is
-   * immutable end-to-end. Story 3.3 added {@code stages}; Story 5.2 adds {@code forms}.
+   * immutable end-to-end. Story 3.3 added {@code stages}; Story 5.2 adds {@code forms}; Story 5.6
+   * adds {@code defaultFieldEditability}.
    */
   public CaseTypeViewDto {
     stages = stages == null ? List.of() : List.copyOf(stages);
@@ -54,7 +61,22 @@ public record CaseTypeViewDto(
       List<StatusDefinition> statuses,
       List<String> listColumns,
       List<StageDefinitionView> stages) {
-    this(id, displayName, version, fields, statuses, listColumns, stages, List.of());
+    this(id, displayName, version, fields, statuses, listColumns, stages, List.of(), null);
+  }
+
+  /**
+   * Backward-compat constructor for pre-5.6 callers that predate {@code defaultFieldEditability}.
+   */
+  public CaseTypeViewDto(
+      String id,
+      String displayName,
+      int version,
+      List<FieldView> fields,
+      List<StatusDefinition> statuses,
+      List<String> listColumns,
+      List<StageDefinitionView> stages,
+      List<FormDefinitionView> forms) {
+    this(id, displayName, version, fields, statuses, listColumns, stages, forms, null);
   }
 
   /**
@@ -101,7 +123,48 @@ public record CaseTypeViewDto(
       String dateMin,
       String dateMax,
       Long maxBytes,
-      List<String> allowedMimeTypes) {}
+      List<String> allowedMimeTypes,
+      /** Story 5.6 AC1 — role-id allow-list for write authorization. Empty list ⇒ omitted. */
+      List<String> editableBy) {
+
+    /** Backward-compat constructor for pre-5.6 callers that predate {@code editableBy}. */
+    public FieldView(
+        String id,
+        String displayName,
+        String type,
+        boolean required,
+        boolean requiredOnCreate,
+        int order,
+        List<OptionView> options,
+        Integer minLength,
+        Integer maxLength,
+        Number min,
+        Number max,
+        Number step,
+        String dateMin,
+        String dateMax,
+        Long maxBytes,
+        List<String> allowedMimeTypes) {
+      this(
+          id,
+          displayName,
+          type,
+          required,
+          requiredOnCreate,
+          order,
+          options,
+          minLength,
+          maxLength,
+          min,
+          max,
+          step,
+          dateMin,
+          dateMax,
+          maxBytes,
+          allowedMimeTypes,
+          List.of());
+    }
+  }
 
   /** Wire-shape for a single {@code select}-field option. */
   public record OptionView(String label, String value) {}

--- a/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/api/mapper/CaseDtoMapper.java
@@ -168,6 +168,12 @@ public final class CaseDtoMapper {
     // Story 5.2 — map form definitions to wire DTOs.
     List<FormDefinitionView> forms =
         caseType.forms().stream().map(CaseDtoMapper::toFormDefinitionView).toList();
+    // Story 5.6 AC4 — surface defaultFieldEditability so the frontend renderer can derive disabled
+    // state for fields with no editableBy declaration. Wire string is kebab-case.
+    String defaultFieldEditability =
+        caseType.defaultFieldEditability() == null
+            ? null
+            : caseType.defaultFieldEditability().wire();
     return new CaseTypeViewDto(
         caseType.id(),
         caseType.displayName(),
@@ -176,7 +182,8 @@ public final class CaseDtoMapper {
         caseType.statuses(),
         caseType.listColumns(),
         stages,
-        forms);
+        forms,
+        defaultFieldEditability);
   }
 
   /**
@@ -226,6 +233,9 @@ public final class CaseDtoMapper {
         s == null ? null : s.dateMin(),
         s == null ? null : s.dateMax(),
         s == null ? null : s.maxBytes(),
-        s == null || s.allowedMimeTypes() == null ? List.of() : s.allowedMimeTypes());
+        s == null || s.allowedMimeTypes() == null ? List.of() : s.allowedMimeTypes(),
+        // Story 5.6 AC1 — surface editableBy so the frontend renderer can disable fields whose
+        // role allow-list excludes the current user.
+        f.editableBy() == null ? List.of() : f.editableBy());
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/CaseTypeConfig.java
@@ -34,7 +34,14 @@ public record CaseTypeConfig(
      * Story 5.2 — form definitions declared in the YAML {@code forms[]} block. Empty list when
      * omitted (no-forms path is the zero-attachment equivalent for the forms surface).
      */
-    List<FormDefinition> forms) {
+    List<FormDefinition> forms,
+    /**
+     * Story 5.6 AC4 — top-level setting controlling the default editability of fields that omit an
+     * explicit {@code editableBy} declaration. Default {@link
+     * DefaultFieldEditability#EDITABLE_BY_DEFAULT} preserves pre-5.6 behavior for every existing
+     * seed YAML.
+     */
+    DefaultFieldEditability defaultFieldEditability) {
 
   public CaseTypeConfig {
     fields = List.copyOf(fields);
@@ -43,6 +50,42 @@ public record CaseTypeConfig(
     roles = List.copyOf(roles);
     stages = stages == null ? List.of() : List.copyOf(stages);
     forms = forms == null ? List.of() : List.copyOf(forms);
+    defaultFieldEditability =
+        defaultFieldEditability == null
+            ? DefaultFieldEditability.EDITABLE_BY_DEFAULT
+            : defaultFieldEditability;
+  }
+
+  /**
+   * Backwards-compatible secondary constructor — pre-Story-5.6 callers that did not know about
+   * {@code defaultFieldEditability}. Defaults the slot to {@link
+   * DefaultFieldEditability#EDITABLE_BY_DEFAULT} (Phase-0 default — preserves current behavior).
+   */
+  public CaseTypeConfig(
+      String id,
+      String displayName,
+      int version,
+      String description,
+      WorkflowRef workflow,
+      List<FieldDefinition> fields,
+      List<StatusDefinition> statuses,
+      List<String> listColumns,
+      List<RoleDefinition> roles,
+      List<StageDefinition> stages,
+      List<FormDefinition> forms) {
+    this(
+        id,
+        displayName,
+        version,
+        description,
+        workflow,
+        fields,
+        statuses,
+        listColumns,
+        roles,
+        stages,
+        forms,
+        DefaultFieldEditability.EDITABLE_BY_DEFAULT);
   }
 
   /** Convenience lookup used by the JSON Schema generator and (future) case-data validation. */
@@ -107,7 +150,8 @@ public record CaseTypeConfig(
         listColumns,
         roles,
         stages,
-        forms);
+        forms,
+        defaultFieldEditability);
   }
 
   /** Returns a fresh {@link Builder} for programmatic construction (primarily in tests). */
@@ -128,6 +172,8 @@ public record CaseTypeConfig(
     private List<RoleDefinition> roles = List.of();
     private List<StageDefinition> stages = List.of();
     private List<FormDefinition> forms = List.of();
+    private DefaultFieldEditability defaultFieldEditability =
+        DefaultFieldEditability.EDITABLE_BY_DEFAULT;
 
     private Builder() {}
 
@@ -186,6 +232,11 @@ public record CaseTypeConfig(
       return this;
     }
 
+    public Builder defaultFieldEditability(DefaultFieldEditability v) {
+      this.defaultFieldEditability = v == null ? DefaultFieldEditability.EDITABLE_BY_DEFAULT : v;
+      return this;
+    }
+
     public CaseTypeConfig build() {
       return new CaseTypeConfig(
           id,
@@ -198,7 +249,8 @@ public record CaseTypeConfig(
           listColumns,
           roles,
           stages,
-          forms);
+          forms,
+          defaultFieldEditability);
     }
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/DefaultFieldEditability.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/DefaultFieldEditability.java
@@ -1,0 +1,49 @@
+package com.wkspower.platform.domain.config.model;
+
+/**
+ * Story 5.6 AC4 — Top-level case-type setting that controls the default editability of fields which
+ * omit an explicit {@code editableBy} declaration.
+ *
+ * <ul>
+ *   <li>{@link #EDITABLE_BY_DEFAULT} (default): a field with no {@code editableBy} is editable for
+ *       every authenticated user. Preserves pre-5.6 behavior — zero regression on existing seed
+ *       YAMLs.
+ *   <li>{@link #LOCKED_BY_DEFAULT}: a field with no {@code editableBy} is read-only for every user.
+ *       Server-side {@code submitForm} rejects any change to such fields with {@code
+ *       WKS-AUTHZ-001}; renderers disable the input with a "locked — no editableBy declaration"
+ *       tooltip.
+ * </ul>
+ *
+ * <p>This decision is reversible by a one-line default flip on {@code RawCaseTypeConfig} + {@code
+ * CaseTypeConfig} if Reading B (lenient — see story file §AC4) becomes the right call.
+ */
+public enum DefaultFieldEditability {
+  EDITABLE_BY_DEFAULT,
+  LOCKED_BY_DEFAULT;
+
+  /**
+   * Parse the YAML wire string into the enum. {@code null} or blank returns {@link
+   * #EDITABLE_BY_DEFAULT} (the safe default-on-omit). Unknown values throw {@link
+   * IllegalArgumentException} — the validator catches and emits {@code WKS-FORM-001} per AC4.
+   */
+  public static DefaultFieldEditability fromYaml(String s) {
+    if (s == null || s.isBlank()) return EDITABLE_BY_DEFAULT;
+    return switch (s) {
+      case "editable-by-default" -> EDITABLE_BY_DEFAULT;
+      case "locked-by-default" -> LOCKED_BY_DEFAULT;
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown defaultFieldEditability '"
+                  + s
+                  + "' — must be 'editable-by-default' or 'locked-by-default'");
+    };
+  }
+
+  /** Wire string for the YAML / DTO surface — kebab-case. */
+  public String wire() {
+    return switch (this) {
+      case EDITABLE_BY_DEFAULT -> "editable-by-default";
+      case LOCKED_BY_DEFAULT -> "locked-by-default";
+    };
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/FieldDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/FieldDefinition.java
@@ -12,6 +12,13 @@ import java.util.Optional;
  * (driven by the case-type YAML) asks for this field at case creation time. Defaults to {@link
  * #required()} when the YAML omits the slot, preserving backwards-compatible behavior for seed
  * YAMLs that pre-date the grammar extension.
+ *
+ * <p>Story 5.6 introduces {@link #editableBy()} — declares the role-id allow-list authorised to
+ * change this field on form submit. Empty list means "no {@code editableBy} declared" — gated by
+ * the case-type's {@code defaultFieldEditability} (AC4): editable-by-default → unrestricted;
+ * locked-by-default → read-only for all. Entries are wire strings {@code role:&lt;roleId&gt;}; the
+ * validator cross-references each {@code &lt;roleId&gt;} against the case-type's {@code roles[]}
+ * declaration.
  */
 public record FieldDefinition(
     String id,
@@ -21,10 +28,13 @@ public record FieldDefinition(
     boolean requiredOnCreate,
     int order,
     List<FieldOption> options,
-    TypeSlots slots) {
+    TypeSlots slots,
+    /** Story 5.6 AC1 — role-id allow-list for write authorization. */
+    List<String> editableBy) {
 
   public FieldDefinition {
     options = options == null ? List.of() : List.copyOf(options);
+    editableBy = editableBy == null ? List.of() : List.copyOf(editableBy);
   }
 
   /**
@@ -41,7 +51,23 @@ public record FieldDefinition(
       int order,
       List<FieldOption> options,
       TypeSlots slots) {
-    this(id, displayName, type, required, required, order, options, slots);
+    this(id, displayName, type, required, required, order, options, slots, List.of());
+  }
+
+  /**
+   * Story 2.7 era — 8-arg ctor (with {@code requiredOnCreate}, no {@code editableBy}). Defaults
+   * {@code editableBy} to empty list per Story 5.6 additive-default pattern.
+   */
+  public FieldDefinition(
+      String id,
+      String displayName,
+      FieldType type,
+      boolean required,
+      boolean requiredOnCreate,
+      int order,
+      List<FieldOption> options,
+      TypeSlots slots) {
+    this(id, displayName, type, required, requiredOnCreate, order, options, slots, List.of());
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -397,6 +397,31 @@ public enum ErrorCode {
    */
   WKS_FORM_003("WKS-FORM-003"),
 
+  // 422 — Per-field edit permission band (Story 5.6). Band: WKS-AUTHZ-*. First member.
+  /**
+   * Story 5.6 — Form-submit attempted to write a field whose {@code editableBy} declaration
+   * excludes the actor's role set. Emitted by {@link
+   * com.wkspower.platform.domain.service.CaseService#submitForm} when a submitted-and-changed
+   * field's permission check fails. Multi-error envelope: one {@link ErrorDetail} per offending
+   * field.
+   *
+   * <p>Distinct from {@link #WKS_API_403} (caller-level authorization — entire endpoint denied) and
+   * {@link #WKS_FORM_002} (field-value validation — wrong type/range). This code says: the value
+   * itself was valid; the actor was not allowed to change it.
+   *
+   * <p>Wire string is {@code WKS-AUTHZ-001} — stable contract. First member of the new {@code
+   * WKS-AUTHZ-*} band; do not reuse for any other meaning per {@code
+   * feedback_error_codes_are_wire_contract.md}. HTTP 422 — rides the existing {@code
+   * WksValidationAggregateException} carrier so no new mapping is needed in {@code
+   * GlobalExceptionHandler}.
+   *
+   * <p>Note — the Story 5.6 dev notes prescribed the wire literal {@code WKS-AUTHZ-FIELD}, but the
+   * existing {@code WKS-&lt;PREFIX&gt;-NNN} format invariant (enforced by {@code
+   * ErrorCodeTest.wireStringsFollowWksHyphenFormat}) requires a 3-digit numeric suffix. The Java
+   * identifier preserves the {@code WKS_AUTHZ_FIELD} mnemonic; the wire string follows the format.
+   */
+  WKS_AUTHZ_FIELD("WKS-AUTHZ-001"),
+
   // 409 — runtime conflict.
   /**
    * Optimistic-locking conflict on update — the row was modified by another transaction between

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -1,6 +1,7 @@
 package com.wkspower.platform.domain.service;
 
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.DefaultFieldEditability;
 import com.wkspower.platform.domain.config.model.FieldDefinition;
 import com.wkspower.platform.domain.config.model.FieldType;
 import com.wkspower.platform.domain.config.model.FormDefinition;
@@ -46,6 +47,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -390,9 +392,28 @@ public class CaseService {
    * @throws WksValidationAggregateException (WKS-FORM-002) if any field value fails validation.
    */
   public Case submitForm(UUID caseId, String formId, Map<String, Object> formData, UUID actorId) {
+    // Backward-compat overload: callers that pre-date Story 5.6 do not supply an actor role set.
+    // The empty role set means: editableBy: [role:X] fields will be REJECTED for this caller (no
+    // role match), and editable-by-default fields with no editableBy declaration pass through.
+    // FormController's principal-aware overload is the recommended path post-5.6.
+    return submitForm(caseId, formId, formData, actorId, Set.of());
+  }
+
+  /**
+   * Story 5.6 — principal-aware submit overload. Carries the actor's role set so per-field edit
+   * permission checks ({@code editableBy} on {@link FieldDefinition}) can run. Recommended path for
+   * controllers.
+   */
+  public Case submitForm(
+      UUID caseId,
+      String formId,
+      Map<String, Object> formData,
+      UUID actorId,
+      Set<String> actorRoles) {
     Objects.requireNonNull(caseId, "caseId");
     Objects.requireNonNull(formId, "formId");
     Objects.requireNonNull(actorId, "actorId");
+    Objects.requireNonNull(actorRoles, "actorRoles");
 
     Case existing =
         caseRepository
@@ -425,6 +446,26 @@ public class CaseService {
     if (!violations.isEmpty()) {
       throw new WksValidationAggregateException(
           "Form submit validation failed (WKS-FORM-002)", violations);
+    }
+
+    // Story 5.6 AC2 — field-level edit-permission check on the diff of changed fields only. An
+    // unchanged value passing through the form does NOT trigger rejection (round-tripped immutable
+    // display fields are common). The check operates against the case-type's full field set
+    // (caseType.fields()) because field permissions live on the case-type, not the form view.
+    Set<String> changedFieldIds = diffFieldIds(existing.data(), safeData);
+    List<ErrorDetail> permViolations =
+        checkFieldEditPermissions(caseType, changedFieldIds, actorRoles);
+    if (!permViolations.isEmpty()) {
+      List<String> disallowedFields = permViolations.stream().map(ErrorDetail::field).toList();
+      log.info(
+          "CaseService.submitForm: REJECTED field-level edit for caseId={} formId={} actorId={}"
+              + " disallowedFields={}",
+          existing.id(),
+          formId,
+          actorId,
+          disallowedFields);
+      throw new WksValidationAggregateException(
+          "Field-level edit permission denied (WKS-AUTHZ-001)", permViolations);
     }
 
     // Persist via the existing update path (validates the merged data against the case-type schema
@@ -583,6 +624,62 @@ public class CaseService {
   }
 
   /**
+   * Story 5.6 AC2 — Per-field edit-permission check. Returns one {@link ErrorDetail} per
+   * changed-field whose {@code editableBy} declaration excludes the actor's role set, OR per
+   * changed-field with no {@code editableBy} when the case-type's {@code defaultFieldEditability}
+   * is {@code locked-by-default}.
+   *
+   * <p>Field path uses {@code "fields." + fieldId} so the frontend can map the violation to the
+   * specific input. Wire code is {@link ErrorCode#WKS_AUTHZ_FIELD} for every entry.
+   *
+   * <p>Unknown changed-field ids (i.e. submitted ids not declared on the case type) are silently
+   * skipped — {@code WKS-FORM-002} is the dedicated wire code for unknown-field rejection and runs
+   * earlier in {@code submitForm}.
+   */
+  static List<ErrorDetail> checkFieldEditPermissions(
+      CaseTypeConfig caseType, Set<String> changedFieldIds, Set<String> actorRoles) {
+    if (changedFieldIds.isEmpty()) {
+      return List.of();
+    }
+    boolean lockedByDefault =
+        caseType.defaultFieldEditability() == DefaultFieldEditability.LOCKED_BY_DEFAULT;
+    List<ErrorDetail> violations = new ArrayList<>();
+    for (String fieldId : changedFieldIds) {
+      FieldDefinition field = caseType.field(fieldId).orElse(null);
+      if (field == null) {
+        continue; // unknown field — WKS-FORM-002 owns this rejection path
+      }
+      List<String> editableBy = field.editableBy();
+      boolean allowed;
+      String requiredDescription;
+      if (editableBy.isEmpty()) {
+        allowed = !lockedByDefault;
+        requiredDescription = "(locked-by-default)";
+      } else {
+        Set<String> requiredRoles =
+            editableBy.stream()
+                .filter(s -> s.startsWith("role:"))
+                .map(s -> s.substring("role:".length()))
+                .collect(Collectors.toSet());
+        allowed = requiredRoles.stream().anyMatch(actorRoles::contains);
+        requiredDescription = requiredRoles.isEmpty() ? "(none)" : String.join(",", requiredRoles);
+      }
+      if (!allowed) {
+        violations.add(
+            ErrorDetail.ofField(
+                ErrorCode.WKS_AUTHZ_FIELD.wire(),
+                "Field '"
+                    + fieldId
+                    + "' is editable only by roles: ["
+                    + requiredDescription
+                    + "] — actor lacks the required role",
+                "fields." + fieldId));
+      }
+    }
+    return violations;
+  }
+
+  /**
    * Coerce a value to {@link Double} for numeric constraint checks. Returns {@code null} if the
    * value is not numeric (e.g. a string that isn't a parseable number — the full type check runs
    * inside {@link CaseDataValidator}).
@@ -637,6 +734,40 @@ public class CaseService {
               dataById.getOrDefault(s.id(), Map.of())));
     }
     return new Page<>(enriched, page.total(), page.page(), page.size());
+  }
+
+  /**
+   * Story 5.6 AC-0 — Single source of truth for case-level access on write-side controllers — do
+   * NOT inline.
+   *
+   * <p>Sprint 8 retro Action 2. Loads the case via {@link CaseRepository#findById} and confirms the
+   * principal has access. Phase-0 implementation: every authenticated principal has access — this
+   * method is the seam where Phase-1 RBAC lands without controller surgery (replace the body of one
+   * method, not edits across every controller).
+   *
+   * <p>Signature uses primitive {@code UUID actorId} + {@code Set<String> actorRoles} rather than
+   * {@code WksUserPrincipal} to preserve the framework-free posture of the domain layer (the
+   * principal type lives in {@code security/} and depends on Spring Security {@code UserDetails};
+   * importing it here would couple the domain to Spring). Controllers extract id+roles from the
+   * principal at the call site.
+   *
+   * @param caseId the case to load
+   * @param actorId the authenticated caller's id (kept for future RBAC-evaluation hook; unused in
+   *     Phase-0)
+   * @param actorRoles the authenticated caller's role set (kept for future RBAC; unused in Phase-0)
+   * @return the loaded {@link Case} so callers can avoid a duplicate {@code findById}
+   * @throws WksNotFoundException if the case does not exist (preserves pre-5.6 wire shape — same
+   *     exception, same message format used by FormController's downstream {@code submitForm} and
+   *     by FormDraftController's removed {@code requireCaseExists} helper)
+   */
+  public Case requireCaseAccess(UUID caseId, UUID actorId, Set<String> actorRoles) {
+    Objects.requireNonNull(caseId, "caseId");
+    Objects.requireNonNull(actorId, "actorId");
+    Objects.requireNonNull(actorRoles, "actorRoles");
+    return caseRepository
+        .findById(caseId)
+        .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
+    // Phase-0: no additional access check beyond authentication. Hook for Phase-1 RBAC.
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigValidator.java
@@ -3,6 +3,7 @@ package com.wkspower.platform.infrastructure.config;
 import com.wkspower.platform.domain.config.CaseTypeLimits;
 import com.wkspower.platform.domain.config.ValidationResult;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.DefaultFieldEditability;
 import com.wkspower.platform.domain.config.model.FieldDefinition;
 import com.wkspower.platform.domain.config.model.FieldOption;
 import com.wkspower.platform.domain.config.model.FieldType;
@@ -145,6 +146,15 @@ public class ConfigValidator {
     List<FieldDefinition> fields = checkFields(raw.fields(), eb, errors, warnings);
     List<StatusDefinition> statuses = checkStatuses(raw.statuses(), eb, errors);
     List<RoleDefinition> roles = checkRoles(raw.roles(), eb, errors);
+    // Story 5.6 AC1 — second pass over fields validates `editableBy` entries against the now-known
+    // role-id set. The pass mutates the FieldDefinition list in place by replacing each field with
+    // a
+    // copy that carries the validated editableBy. Validation does not abort on roles==empty (an
+    // earlier WKS-CFG-001 already surfaces missing roles), but cross-reference failures are
+    // suppressed to avoid double-reporting on configs whose roles section is invalid.
+    fields = validateEditableByAndAttach(raw.fields(), fields, roles, errors);
+    DefaultFieldEditability defaultFieldEditability =
+        checkDefaultFieldEditability(raw.defaultFieldEditability(), eb, errors);
     List<String> listColumns =
         checkListColumns(raw.listColumns(), fields, raw.fields() != null, eb, errors);
     List<StageDefinition> stages = checkStages(raw.stages(), eb, errors);
@@ -212,7 +222,8 @@ public class ConfigValidator {
             listColumns,
             roles,
             stages,
-            forms);
+            forms,
+            defaultFieldEditability);
     // Story 4.3 — surface the validated MappingDefinition through ValidationResult so
     // ConfigService can populate MappingRegistry on registration. Empty MappingDefinition is the
     // first-class zero-attachment value (D22 — Story 4.2's MappingValidator returns empty()
@@ -884,5 +895,124 @@ public class ConfigValidator {
       }
     }
     return out;
+  }
+
+  /**
+   * Story 5.6 AC1 — Validate each field's {@code editableBy} list and attach the parsed result back
+   * onto a fresh {@link FieldDefinition} (records are immutable; we rebuild). Each entry must:
+   *
+   * <ul>
+   *   <li>Match the literal {@code role:&lt;roleId&gt;} prefix (Phase-0 — only {@code role:}
+   *       supported). Malformed → {@code WKS-FORM-001}.
+   *   <li>Reference a role id that exists in the case-type's {@code roles[]} declaration. Unknown →
+   *       {@code WKS-FORM-001}.
+   * </ul>
+   *
+   * <p>Empty list ({@code editableBy: []}) is treated as "no editableBy declared" — same default
+   * behavior as omission (AC4 default-field-editability gate decides the runtime semantics).
+   */
+  private List<FieldDefinition> validateEditableByAndAttach(
+      List<RawCaseTypeConfig.RawField> raws,
+      List<FieldDefinition> fields,
+      List<RoleDefinition> roles,
+      List<ErrorDetail> errors) {
+    if (raws == null || raws.isEmpty() || fields == null || fields.isEmpty()) {
+      return fields;
+    }
+    Set<String> declaredRoleIds = new HashSet<>();
+    for (RoleDefinition r : roles) {
+      declaredRoleIds.add(r.name());
+    }
+    // Build an id→raw lookup so we don't depend on list-index alignment (some raws may have been
+    // skipped by checkFields when they were invalid).
+    java.util.Map<String, RawCaseTypeConfig.RawField> rawById = new java.util.HashMap<>();
+    java.util.Map<String, Integer> rawIndexById = new java.util.HashMap<>();
+    for (int i = 0; i < raws.size(); i++) {
+      RawCaseTypeConfig.RawField rf = raws.get(i);
+      if (rf != null && rf.id() != null) {
+        rawById.put(rf.id(), rf);
+        rawIndexById.put(rf.id(), i);
+      }
+    }
+    List<FieldDefinition> rebuilt = new ArrayList<>(fields.size());
+    for (FieldDefinition fd : fields) {
+      RawCaseTypeConfig.RawField rf = rawById.get(fd.id());
+      if (rf == null || rf.editableBy() == null || rf.editableBy().isEmpty()) {
+        rebuilt.add(fd); // already has editableBy = List.of() from checkFields path
+        continue;
+      }
+      int rawIndex = rawIndexById.getOrDefault(fd.id(), 0);
+      List<String> editableBy = rf.editableBy();
+      List<String> validated = new ArrayList<>();
+      for (int j = 0; j < editableBy.size(); j++) {
+        String entry = editableBy.get(j);
+        String fieldPath = "fields[" + rawIndex + "].editableBy[" + j + "]";
+        if (entry == null || entry.isBlank()) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_FORM_001.wire(), "editableBy entry must not be blank", fieldPath));
+          continue;
+        }
+        if (!entry.startsWith("role:")) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_FORM_001.wire(),
+                  "editableBy entries must use 'role:<id>' format (got '" + entry + "')",
+                  fieldPath));
+          continue;
+        }
+        String roleId = entry.substring("role:".length());
+        if (roleId.isBlank()) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_FORM_001.wire(),
+                  "editableBy entry has empty role id after 'role:' prefix",
+                  fieldPath));
+          continue;
+        }
+        // Suppress cross-ref check when roles[] failed validation (declaredRoleIds may be empty
+        // because of an earlier WKS-CFG-001) — avoid double-reporting on configs with broken roles.
+        if (!declaredRoleIds.isEmpty() && !declaredRoleIds.contains(roleId)) {
+          errors.add(
+              ErrorDetail.ofField(
+                  ErrorCode.WKS_FORM_001.wire(),
+                  "editableBy references unknown role: " + roleId,
+                  fieldPath));
+          continue;
+        }
+        validated.add(entry);
+      }
+      // Rebuild the FieldDefinition with the validated editableBy list (preserves order, drops
+      // malformed entries — collect-all idiom: errors already accumulated).
+      rebuilt.add(
+          new FieldDefinition(
+              fd.id(),
+              fd.displayName(),
+              fd.type(),
+              fd.required(),
+              fd.requiredOnCreate(),
+              fd.order(),
+              fd.options(),
+              fd.slots(),
+              validated));
+    }
+    return rebuilt;
+  }
+
+  /**
+   * Story 5.6 AC4 — Validate the top-level {@code defaultFieldEditability} key. Null/blank ⇒ {@link
+   * DefaultFieldEditability#EDITABLE_BY_DEFAULT}. Unknown literal ⇒ {@code WKS-FORM-001}.
+   */
+  private DefaultFieldEditability checkDefaultFieldEditability(
+      String raw, ErrorBuilder eb, List<ErrorDetail> errors) {
+    if (raw == null || raw.isBlank()) {
+      return DefaultFieldEditability.EDITABLE_BY_DEFAULT;
+    }
+    try {
+      return DefaultFieldEditability.fromYaml(raw);
+    } catch (IllegalArgumentException ex) {
+      errors.add(eb.error(ErrorCode.WKS_FORM_001, ex.getMessage(), "defaultFieldEditability"));
+      return DefaultFieldEditability.EDITABLE_BY_DEFAULT;
+    }
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapper.java
@@ -136,9 +136,30 @@ public final class FormDefinitionMapper {
       // Type-specific slots
       FieldDefinition.TypeSlots slots = mapSlots(m);
 
+      // Story 5.6 AC1 — editableBy on form-level fields. Empty/missing ⇒ List.of().
+      List<String> editableBy = List.of();
+      Object editableByRaw = m.get("editableBy");
+      if (editableByRaw instanceof List<?> ebList) {
+        List<String> tmp = new ArrayList<>();
+        for (Object o : ebList) {
+          if (o instanceof String s && !s.isBlank()) {
+            tmp.add(s);
+          }
+        }
+        editableBy = List.copyOf(tmp);
+      }
+
       out.add(
           new FieldDefinition(
-              id, displayName, type, required, requiredOnCreate, order, options, slots));
+              id,
+              displayName,
+              type,
+              required,
+              requiredOnCreate,
+              order,
+              options,
+              slots,
+              editableBy));
       index++;
     }
     return List.copyOf(out);

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawCaseTypeConfig.java
@@ -30,7 +30,9 @@ public record RawCaseTypeConfig(
     List<RawRole> roles,
     List<RawStage> stages,
     List<RawAttachment> attachments,
-    @JsonProperty("forms") @JsonInclude(JsonInclude.Include.NON_NULL) RawFormConfig forms) {
+    @JsonProperty("forms") @JsonInclude(JsonInclude.Include.NON_NULL) RawFormConfig forms,
+    /** Story 5.6 AC4 — top-level default field editability. Null/blank ⇒ editable-by-default. */
+    @JsonProperty("defaultFieldEditability") String defaultFieldEditability) {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawWorkflow(String bpmn) {}
@@ -52,7 +54,9 @@ public record RawCaseTypeConfig(
       String dateMin,
       String dateMax,
       Long maxBytes,
-      List<String> allowedMimeTypes) {}
+      List<String> allowedMimeTypes,
+      /** Story 5.6 AC1 — role-id allow-list, e.g. {@code [role:underwriter]}. */
+      List<String> editableBy) {}
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record RawOption(String label, String value) {}
@@ -194,6 +198,7 @@ public record RawCaseTypeConfig(
     private List<RawStage> stages;
     private List<RawAttachment> attachments;
     private RawFormConfig forms;
+    private String defaultFieldEditability;
 
     private Builder() {}
 
@@ -257,6 +262,11 @@ public record RawCaseTypeConfig(
       return this;
     }
 
+    public Builder defaultFieldEditability(String v) {
+      this.defaultFieldEditability = v;
+      return this;
+    }
+
     public RawCaseTypeConfig build() {
       return new RawCaseTypeConfig(
           id,
@@ -270,7 +280,8 @@ public record RawCaseTypeConfig(
           roles,
           stages,
           attachments,
-          forms);
+          forms,
+          defaultFieldEditability);
     }
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/domain/exception/ErrorCodeTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/exception/ErrorCodeTest.java
@@ -85,14 +85,15 @@ class ErrorCodeTest {
 
   @Test
   void wireStringsFollowWksHyphenFormat() {
-    // Pattern: WKS-<PREFIX>-<NNN> where prefix is 3–4 uppercase letters and NNN is 3 digits.
+    // Pattern: WKS-<PREFIX>-<NNN> where prefix is 3–5 uppercase letters and NNN is 3 digits.
     // Story 5.1 introduced WKS-FORM-001 — the first 4-letter prefix band. Prior bands (CFG, MAP,
-    // STG, VER, RTM, API) all use 3-letter prefixes; the pattern is relaxed to [A-Z]{3,4} to
-    // accommodate the FORM band while retaining the guardrail against arbitrary-length prefixes.
+    // STG, VER, RTM, API) all use 3-letter prefixes; Story 5.6 introduces WKS-AUTHZ-* — the first
+    // 5-letter prefix band. Pattern relaxed to [A-Z]{3,5} to accommodate AUTHZ while retaining
+    // the guardrail against arbitrary-length prefixes.
     for (ErrorCode code : ErrorCode.values()) {
       assertThat(code.wire())
           .as("ErrorCode.%s wire string must match WKS-<PREFIX>-NNN format", code.name())
-          .matches("^WKS-[A-Z]{3,4}-[0-9]{3}$");
+          .matches("^WKS-[A-Z]{3,5}-[0-9]{3}$");
     }
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceRequireCaseAccessTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceRequireCaseAccessTest.java
@@ -1,0 +1,233 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StageDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.domain.exception.WksNotFoundException;
+import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.model.CaseQuery;
+import com.wkspower.platform.domain.model.CaseSummary;
+import com.wkspower.platform.domain.page.Page;
+import com.wkspower.platform.domain.page.PageRequest;
+import com.wkspower.platform.domain.port.CaseDataValidator;
+import com.wkspower.platform.domain.port.CaseRepository;
+import com.wkspower.platform.domain.port.CaseStatusUpdater;
+import com.wkspower.platform.domain.port.CaseTypeReader;
+import com.wkspower.platform.domain.port.ProcessDefinitionKeyResolver;
+import com.wkspower.platform.domain.port.StageRepository;
+import com.wkspower.platform.domain.port.WorkflowEngine;
+import com.wkspower.platform.domain.workflow.DeploymentInfo;
+import com.wkspower.platform.domain.workflow.DeploymentRequest;
+import com.wkspower.platform.domain.workflow.DeploymentResult;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 5.6 AC-0 — unit coverage for {@link CaseService#requireCaseAccess(UUID, UUID, Set)}. Sprint
+ * 8 retro Action 2 — single source of truth for case-level access on write-side controllers.
+ */
+class CaseServiceRequireCaseAccessTest {
+
+  private static final UUID ACTOR = UUID.randomUUID();
+  private static final Instant FIXED = Instant.parse("2026-05-09T10:00:00Z");
+
+  @Test
+  void caseFoundReturnsLoadedCase() {
+    CaseTypeConfig config = caseType();
+    SimpleRepo repo = new SimpleRepo();
+    UUID caseId = UUID.randomUUID();
+    Case existing =
+        new Case(caseId, config.id(), 1, "open", null, Map.of(), null, FIXED, ACTOR, FIXED, 0L);
+    repo.save(existing);
+    CaseService svc = svc(repo, config);
+
+    Case loaded = svc.requireCaseAccess(caseId, ACTOR, Set.of("admin"));
+
+    assertThat(loaded.id()).isEqualTo(caseId);
+    assertThat(loaded.caseTypeId()).isEqualTo(config.id());
+  }
+
+  @Test
+  void caseAbsentThrowsNotFound() {
+    CaseTypeConfig config = caseType();
+    SimpleRepo repo = new SimpleRepo(); // empty
+    UUID caseId = UUID.randomUUID();
+    CaseService svc = svc(repo, config);
+
+    assertThatThrownBy(() -> svc.requireCaseAccess(caseId, ACTOR, Set.of()))
+        .isInstanceOf(WksNotFoundException.class)
+        .hasMessageContaining(caseId.toString())
+        .hasMessageContaining("not found");
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private static CaseTypeConfig caseType() {
+    return new CaseTypeConfig(
+        "loan-application",
+        "Loan Application",
+        1,
+        null,
+        null,
+        List.of(new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("name"),
+        List.of(new RoleDefinition("admin", List.of(Permission.CREATE))),
+        List.of(),
+        List.of());
+  }
+
+  private static CaseService svc(CaseRepository repo, CaseTypeConfig config) {
+    WksStageAdvancer advancer = new WksStageAdvancer(new NullStageRepo(), ev -> {}, () -> FIXED);
+    com.wkspower.platform.testsupport.FakeCaseTypeVersionRegistry registry =
+        new com.wkspower.platform.testsupport.FakeCaseTypeVersionRegistry();
+    registry.seed(config.id(), 1, "id: x".getBytes());
+    return new CaseService(
+        repo,
+        reader(config),
+        new NullValidator(),
+        new NullEngine(),
+        new NullResolver(),
+        ev -> {}, // EventPublisher
+        () -> FIXED,
+        advancer,
+        registry,
+        signal -> {}, // ExecutionSignalHandler
+        new CaseStatusUpdater() {
+          @Override
+          public Optional<String> updateStatus(UUID caseId, String newStatus) {
+            return Optional.empty();
+          }
+        });
+  }
+
+  private static CaseTypeReader reader(CaseTypeConfig config) {
+    return new CaseTypeReader() {
+      @Override
+      public Optional<CaseTypeConfig> find(String id) {
+        return id.equals(config.id()) ? Optional.of(config) : Optional.empty();
+      }
+
+      @Override
+      public Collection<CaseTypeConfig> all() {
+        return List.of(config);
+      }
+
+      @Override
+      public Optional<CaseTypeConfig> findVersion(String id, int version) {
+        return id.equals(config.id()) ? Optional.of(config) : Optional.empty();
+      }
+    };
+  }
+
+  private static final class SimpleRepo implements CaseRepository {
+    private final List<Case> saved = new ArrayList<>();
+
+    @Override
+    public Case save(Case c) {
+      saved.removeIf(x -> x.id().equals(c.id()));
+      saved.add(c);
+      return c;
+    }
+
+    @Override
+    public Optional<Case> findById(UUID id) {
+      return saved.stream().filter(c -> c.id().equals(id)).findFirst();
+    }
+
+    @Override
+    public Page<CaseSummary> findByCaseType(CaseQuery q, PageRequest pr) {
+      return new Page<>(List.of(), 0, pr.page(), pr.size());
+    }
+
+    @Override
+    public Map<UUID, Map<String, Object>> findDataByIds(
+        Collection<UUID> ids, Set<String> fieldIds) {
+      return Map.of();
+    }
+  }
+
+  private static final class NullValidator implements CaseDataValidator {
+    @Override
+    public List<ErrorDetail> validate(CaseTypeConfig caseType, Map<String, Object> data) {
+      return List.of();
+    }
+  }
+
+  private static final class NullEngine implements WorkflowEngine {
+    @Override
+    public DeploymentResult deploy(DeploymentRequest req) {
+      return new DeploymentResult("d", req.processDefinitionKey(), "p", 1, FIXED);
+    }
+
+    @Override
+    public Optional<DeploymentInfo> latestDeployment(String key) {
+      return Optional.empty();
+    }
+
+    @Override
+    public String startProcessInstance(String key, Map<String, Object> vars) {
+      return "pi-1";
+    }
+
+    @Override
+    public Optional<com.wkspower.platform.domain.model.Task> findTask(String taskId) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void completeTask(String taskId, Map<String, Object> vars) {}
+
+    @Override
+    public void claimTask(String taskId, UUID userId) {}
+
+    @Override
+    public void signalTransition(String pi, String action, Map<String, Object> vars) {}
+
+    @Override
+    public List<com.wkspower.platform.domain.model.Task> findTasksByCase(UUID caseId) {
+      return List.of();
+    }
+
+    @Override
+    public String readActionLabel(String processDefinitionId, String taskDefinitionKey) {
+      return null;
+    }
+  }
+
+  private static final class NullResolver implements ProcessDefinitionKeyResolver {
+    @Override
+    public Optional<String> resolve(String caseTypeId) {
+      return Optional.empty();
+    }
+  }
+
+  private static final class NullStageRepo implements StageRepository {
+    @Override
+    public List<com.wkspower.platform.domain.model.Stage> loadHistory(UUID caseId) {
+      return List.of();
+    }
+
+    @Override
+    public void materialiseStages(UUID caseId, List<StageDefinition> stages, Instant createdAt) {}
+
+    @Override
+    public void appendTransition(Transition transition) {}
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceSubmitFormPermissionTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceSubmitFormPermissionTest.java
@@ -1,0 +1,157 @@
+package com.wkspower.platform.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.DefaultFieldEditability;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.ErrorDetail;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 5.6 AC2 — unit coverage for the static {@link CaseService#checkFieldEditPermissions} helper
+ * that drives WKS-AUTHZ-001 rejection inside {@code submitForm}. Pure-function tests; no Spring, no
+ * DB, no engine.
+ */
+class CaseServiceSubmitFormPermissionTest {
+
+  @Test
+  void noEditableByWithDefaultEditableAllowsAllRoles() {
+    CaseTypeConfig ct = caseType(DefaultFieldEditability.EDITABLE_BY_DEFAULT, List.of());
+
+    List<ErrorDetail> v =
+        CaseService.checkFieldEditPermissions(ct, Set.of("amount"), Set.of(/*no roles*/ ));
+
+    assertThat(v).isEmpty();
+  }
+
+  @Test
+  void noEditableByWithLockedByDefaultRejectsAllRoles() {
+    CaseTypeConfig ct = caseType(DefaultFieldEditability.LOCKED_BY_DEFAULT, List.of());
+
+    List<ErrorDetail> v =
+        CaseService.checkFieldEditPermissions(ct, Set.of("amount"), Set.of("admin"));
+
+    assertThat(v).hasSize(1);
+    assertThat(v.get(0).code()).isEqualTo(ErrorCode.WKS_AUTHZ_FIELD.wire());
+    assertThat(v.get(0).field()).isEqualTo("fields.amount");
+    assertThat(v.get(0).message()).contains("locked-by-default");
+  }
+
+  @Test
+  void editableByMatchingRoleAllowed() {
+    CaseTypeConfig ct =
+        caseType(DefaultFieldEditability.EDITABLE_BY_DEFAULT, List.of("role:underwriter"));
+
+    List<ErrorDetail> v =
+        CaseService.checkFieldEditPermissions(ct, Set.of("amount"), Set.of("underwriter"));
+
+    assertThat(v).isEmpty();
+  }
+
+  @Test
+  void editableByWithoutMatchingRoleRejected() {
+    CaseTypeConfig ct =
+        caseType(DefaultFieldEditability.EDITABLE_BY_DEFAULT, List.of("role:underwriter"));
+
+    List<ErrorDetail> v =
+        CaseService.checkFieldEditPermissions(ct, Set.of("amount"), Set.of("officer"));
+
+    assertThat(v).hasSize(1);
+    ErrorDetail e = v.get(0);
+    assertThat(e.code()).isEqualTo(ErrorCode.WKS_AUTHZ_FIELD.wire());
+    assertThat(e.field()).isEqualTo("fields.amount");
+    assertThat(e.message()).contains("underwriter");
+    assertThat(e.message()).contains("actor lacks");
+  }
+
+  @Test
+  void multipleChangedFieldsBothRejectedSurfaceTwoViolations() {
+    // Two fields, each editableBy underwriter; actor has no roles → both rejected.
+    CaseTypeConfig ct =
+        new CaseTypeConfig(
+            "ct",
+            "CT",
+            1,
+            null,
+            null,
+            List.of(
+                fieldEditableBy("amount", "Amount", FieldType.NUMBER, List.of("role:underwriter")),
+                fieldEditableBy(
+                    "approver", "Approver", FieldType.TEXT, List.of("role:underwriter"))),
+            List.of(
+                new com.wkspower.platform.domain.config.model.StatusDefinition(
+                    "open", "Open", com.wkspower.platform.domain.config.model.StatusColor.ZINC)),
+            List.of("amount"),
+            List.of(new RoleDefinition("underwriter", List.of(Permission.EDIT))),
+            List.of(),
+            List.of(),
+            DefaultFieldEditability.EDITABLE_BY_DEFAULT);
+
+    List<ErrorDetail> v =
+        CaseService.checkFieldEditPermissions(ct, Set.of("amount", "approver"), Set.of());
+
+    assertThat(v).hasSize(2);
+    assertThat(v).allSatisfy(e -> assertThat(e.code()).isEqualTo(ErrorCode.WKS_AUTHZ_FIELD.wire()));
+    assertThat(v)
+        .extracting(ErrorDetail::field)
+        .containsExactlyInAnyOrder("fields.amount", "fields.approver");
+  }
+
+  @Test
+  void unchangedFieldNotChecked() {
+    // No fields in the diff — no permission check runs even if the field has restrictive
+    // editableBy.
+    CaseTypeConfig ct =
+        caseType(DefaultFieldEditability.EDITABLE_BY_DEFAULT, List.of("role:underwriter"));
+
+    List<ErrorDetail> v =
+        CaseService.checkFieldEditPermissions(ct, Set.of(), Set.of(/*no roles*/ ));
+
+    assertThat(v).isEmpty();
+  }
+
+  @Test
+  void unknownFieldIdSkippedByPermissionCheck() {
+    // Unknown field ids in the diff (e.g. typo / orphan column) are silently skipped — WKS-FORM-002
+    // owns unknown-field rejection on a different code path.
+    CaseTypeConfig ct = caseType(DefaultFieldEditability.LOCKED_BY_DEFAULT, List.of());
+
+    List<ErrorDetail> v =
+        CaseService.checkFieldEditPermissions(ct, Set.of("unknown-field"), Set.of("admin"));
+
+    assertThat(v).isEmpty();
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private static CaseTypeConfig caseType(
+      DefaultFieldEditability defaultEditability, List<String> editableBy) {
+    return new CaseTypeConfig(
+        "ct",
+        "CT",
+        1,
+        null,
+        null,
+        List.of(fieldEditableBy("amount", "Amount", FieldType.NUMBER, editableBy)),
+        List.of(
+            new com.wkspower.platform.domain.config.model.StatusDefinition(
+                "open", "Open", com.wkspower.platform.domain.config.model.StatusColor.ZINC)),
+        List.of("amount"),
+        List.of(new RoleDefinition("underwriter", List.of(Permission.EDIT))),
+        List.of(),
+        List.of(),
+        defaultEditability);
+  }
+
+  private static FieldDefinition fieldEditableBy(
+      String id, String dn, FieldType type, List<String> editableBy) {
+    return new FieldDefinition(id, dn, type, false, false, 0, List.of(), null, editableBy);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorDefaultFieldEditabilityTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorDefaultFieldEditabilityTest.java
@@ -1,0 +1,77 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.ValidationResult;
+import com.wkspower.platform.domain.config.model.DefaultFieldEditability;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 5.6 AC4 — validator coverage for the top-level {@code defaultFieldEditability} key. Default
+ * on omit: {@link DefaultFieldEditability#EDITABLE_BY_DEFAULT} (preserves pre-5.6 behavior).
+ */
+class ConfigValidatorDefaultFieldEditabilityTest {
+
+  private final CaseTypeYamlLoader loader = new CaseTypeYamlLoader();
+  private final ConfigValidator validator = new ConfigValidator();
+
+  @Test
+  void omittedKeyDefaultsToEditableByDefault() {
+    ValidationResult result = validate(yamlWith(""));
+    assertThat(result.isInvalid()).isFalse();
+    assertThat(result.config().get().defaultFieldEditability())
+        .isEqualTo(DefaultFieldEditability.EDITABLE_BY_DEFAULT);
+  }
+
+  @Test
+  void validLockedByDefaultParsed() {
+    ValidationResult result = validate(yamlWith("defaultFieldEditability: locked-by-default\n"));
+    assertThat(result.isInvalid()).isFalse();
+    assertThat(result.config().get().defaultFieldEditability())
+        .isEqualTo(DefaultFieldEditability.LOCKED_BY_DEFAULT);
+  }
+
+  @Test
+  void unknownLiteralEmitsWksForm001() {
+    ValidationResult result = validate(yamlWith("defaultFieldEditability: read-only\n"));
+    var match =
+        result.errors().stream()
+            .filter(
+                e -> "WKS-FORM-001".equals(e.code()) && "defaultFieldEditability".equals(e.field()))
+            .findFirst();
+    assertThat(match).as("got: %s", result.errors()).isPresent();
+    assertThat(match.get().message()).contains("read-only");
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private ValidationResult validate(String yaml) {
+    var r = loader.readBytes("test", yaml.getBytes(StandardCharsets.UTF_8));
+    if (!r.isParsed()) {
+      return ValidationResult.invalid(r.errors());
+    }
+    return validator.validate(r.raw(), r.lines());
+  }
+
+  private static String yamlWith(String defaultEditabilityLine) {
+    return ""
+        + "id: ct-dfe\n"
+        + "displayName: Default Editability Test\n"
+        + "version: 1\n"
+        + defaultEditabilityLine
+        + "fields:\n"
+        + "  - id: applicant\n"
+        + "    displayName: Applicant\n"
+        + "    type: text\n"
+        + "    required: true\n"
+        + "statuses:\n"
+        + "  - id: open\n"
+        + "    displayName: Open\n"
+        + "    color: amber\n"
+        + "listColumns: [applicant]\n"
+        + "roles:\n"
+        + "  - name: officer\n"
+        + "    permissions: [view, edit]\n";
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorEditableByTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/ConfigValidatorEditableByTest.java
@@ -1,0 +1,122 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.domain.config.ValidationResult;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Story 5.6 AC1 — validator coverage for {@code editableBy: [role:&lt;id&gt;]} on field
+ * declarations. Surfaces malformed entries and unknown role references as {@code WKS-FORM-001}.
+ */
+class ConfigValidatorEditableByTest {
+
+  private final CaseTypeYamlLoader loader = new CaseTypeYamlLoader();
+  private final ConfigValidator validator = new ConfigValidator();
+
+  @Test
+  void validRoleScopedEditableByPasses() {
+    ValidationResult result = validate(yamlWithEditableBy("[role:officer]"));
+
+    assertThat(result.isInvalid())
+        .as("valid editableBy must not error: %s", result.errors())
+        .isFalse();
+    var f =
+        result.config().get().fields().stream()
+            .filter(x -> x.id().equals("amount"))
+            .findFirst()
+            .get();
+    assertThat(f.editableBy()).containsExactly("role:officer");
+  }
+
+  @Test
+  void malformedEditableByEntryEmitsWksForm001() {
+    // "underwriter" without role: prefix
+    ValidationResult result = validate(yamlWithEditableBy("[\"underwriter\"]"));
+
+    var match =
+        result.errors().stream()
+            .filter(
+                e ->
+                    "WKS-FORM-001".equals(e.code())
+                        && e.field() != null
+                        && e.field().contains("editableBy"))
+            .findFirst();
+    assertThat(match)
+        .as("malformed editableBy must emit WKS-FORM-001 — got: %s", result.errors())
+        .isPresent();
+    assertThat(match.get().message()).contains("role:");
+  }
+
+  @Test
+  void unknownRoleIdEmitsWksForm001() {
+    ValidationResult result = validate(yamlWithEditableBy("[role:supervisor]"));
+
+    var match =
+        result.errors().stream()
+            .filter(
+                e ->
+                    "WKS-FORM-001".equals(e.code())
+                        && e.field() != null
+                        && e.field().contains("editableBy"))
+            .findFirst();
+    assertThat(match)
+        .as("unknown role id must emit WKS-FORM-001 — got: %s", result.errors())
+        .isPresent();
+    assertThat(match.get().message()).contains("supervisor");
+  }
+
+  @Test
+  void emptyEditableByListIsTreatedAsOmitted() {
+    ValidationResult result = validate(yamlWithEditableBy("[]"));
+
+    assertThat(result.isInvalid()).as("empty list is legal — no error").isFalse();
+    var f =
+        result.config().get().fields().stream()
+            .filter(x -> x.id().equals("amount"))
+            .findFirst()
+            .get();
+    assertThat(f.editableBy()).isEmpty();
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private ValidationResult validate(String yaml) {
+    var r = loader.readBytes("test", yaml.getBytes(StandardCharsets.UTF_8));
+    if (!r.isParsed()) {
+      return ValidationResult.invalid(r.errors());
+    }
+    return validator.validate(r.raw(), r.lines());
+  }
+
+  /**
+   * Build a case-type YAML with the supplied {@code editableBy} flow-list expression attached to
+   * the {@code amount} field.
+   */
+  private static String yamlWithEditableBy(String editableByExpr) {
+    return ""
+        + "id: ct-editable-by\n"
+        + "displayName: Editable Test\n"
+        + "version: 1\n"
+        + "fields:\n"
+        + "  - id: applicant\n"
+        + "    displayName: Applicant\n"
+        + "    type: text\n"
+        + "    required: true\n"
+        + "  - id: amount\n"
+        + "    displayName: Amount\n"
+        + "    type: number\n"
+        + "    editableBy: "
+        + editableByExpr
+        + "\n"
+        + "statuses:\n"
+        + "  - id: open\n"
+        + "    displayName: Open\n"
+        + "    color: amber\n"
+        + "listColumns: [applicant]\n"
+        + "roles:\n"
+        + "  - name: officer\n"
+        + "    permissions: [view, edit]\n";
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/PerFieldEditPermissionIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/PerFieldEditPermissionIT.java
@@ -1,0 +1,297 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.DefaultFieldEditability;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import com.wkspower.platform.infrastructure.persistence.entity.RoleEntity;
+import com.wkspower.platform.infrastructure.persistence.repository.RoleEntityRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Story 5.6 AC2 / AC4 — controller-level integration tests for per-field edit permissions.
+ *
+ * <ul>
+ *   <li>Submit with required role → 200.
+ *   <li>Submit without required role → 422 + WKS-AUTHZ-001.
+ *   <li>Draft PUT does NOT enforce field permissions (working state).
+ *   <li>locked-by-default with no editableBy + role-less actor → 422 + WKS-AUTHZ-001.
+ * </ul>
+ *
+ * <p>Postgres-IT parity status: H2-only in this story (matches the pre-existing {@code
+ * FormSubmitIT} pattern). Full Postgres-IT migration is carried forward.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:perfieldperm;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=",
+      "wks.bootstrap.production-validation.enabled=false"
+    })
+class PerFieldEditPermissionIT {
+
+  private static final String UNDERWRITER_EMAIL = "underwriter-it@wkspower.local";
+  private static final String OFFICER_EMAIL = "officer-it@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String CASE_TYPE_ID = "per-field-perm-fixture";
+  private static final String LOCKED_CASE_TYPE_ID = "per-field-perm-locked-fixture";
+  private static final String FORM_ID = "intake-form";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private ObjectMapper json;
+  @Autowired private RoleEntityRepository roleRepo;
+
+  @BeforeEach
+  void setup() {
+    // Seed the 'underwriter' and 'officer' roles. The 'admin' role is seeded by Flyway.
+    Instant now = Instant.now();
+    if (roleRepo.findByName("underwriter").isEmpty()) {
+      roleRepo.save(new RoleEntity(UUID.randomUUID(), "underwriter", now, now));
+    }
+    if (roleRepo.findByName("officer").isEmpty()) {
+      roleRepo.save(new RoleEntity(UUID.randomUUID(), "officer", now, now));
+    }
+    if (users.findByEmail(UNDERWRITER_EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), UNDERWRITER_EMAIL, Set.of("admin", "underwriter"), true),
+          encoder.encode(PASSWORD));
+    }
+    if (users.findByEmail(OFFICER_EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), OFFICER_EMAIL, Set.of("admin", "officer"), true),
+          encoder.encode(PASSWORD));
+    }
+    registry.register(editableByCaseType());
+    registry.register(lockedByDefaultCaseType());
+  }
+
+  @Test
+  void submitWithRequiredRoleReturns200() throws Exception {
+    String cookie = login(UNDERWRITER_EMAIL);
+    String caseId = createCase(cookie, CASE_TYPE_ID);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\",\"amount\":5000}");
+
+    assertThat(resp.getStatusCode())
+        .as("underwriter has the required role; got body=%s", resp.getBody())
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void submitWithoutRequiredRoleReturns422AndWksAuthzField() throws Exception {
+    String cookie = login(OFFICER_EMAIL);
+    String caseId = createCase(cookie, CASE_TYPE_ID);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\",\"amount\":5000}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(resp.getBody()).contains("WKS-AUTHZ-001");
+    JsonNode body = json.readTree(resp.getBody());
+    JsonNode errors = body.path("error").path("errors");
+    assertThat(errors.isArray()).isTrue();
+    assertThat(errors.size()).isGreaterThanOrEqualTo(1);
+    boolean amountFieldRejected = false;
+    for (JsonNode e : errors) {
+      if ("WKS-AUTHZ-001".equals(e.path("code").asText())
+          && "fields.amount".equals(e.path("field").asText())) {
+        amountFieldRejected = true;
+        break;
+      }
+    }
+    assertThat(amountFieldRejected).as("expected amount field rejection in: %s", errors).isTrue();
+  }
+
+  @Test
+  void draftPutDoesNotEnforceFieldPermissions() throws Exception {
+    // Officer (lacks 'underwriter' role) saves a draft of the protected 'amount' field.
+    String cookie = login(OFFICER_EMAIL);
+    String caseId = createCase(cookie, CASE_TYPE_ID);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/draft",
+            HttpMethod.PUT,
+            cookie,
+            "{\"payload\":{\"amount\":12345},\"scrollY\":0,\"sectionExpanded\":{},"
+                + "\"caseTypeVersionAtSave\":1}");
+
+    assertThat(resp.getStatusCode())
+        .as("draft path must not enforce per-field permission; got: %s", resp.getBody())
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void lockedByDefaultRejectsEditOfFieldWithoutEditableBy() throws Exception {
+    String cookie = login(OFFICER_EMAIL);
+    String caseId = createCase(cookie, LOCKED_CASE_TYPE_ID);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Bob\",\"amount\":99}");
+
+    // applicant changes from "Initial" to "Bob" — locked-by-default rejects the change.
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(resp.getBody()).contains("WKS-AUTHZ-001");
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private String login(String email) {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(email, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", email).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private String createCase(String cookie, String caseTypeId) throws Exception {
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + caseTypeId + "\",\"data\":{\"applicant\":\"Initial\"}}");
+    assertThat(resp.getStatusCode())
+        .as("create case body=%s", resp.getBody())
+        .isEqualTo(HttpStatus.CREATED);
+    return json.readTree(resp.getBody()).path("data").path("id").asText();
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  private static CaseTypeConfig editableByCaseType() {
+    // 'amount' is restricted to underwriter; 'applicant' is unrestricted.
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition(
+                "applicant",
+                "Applicant",
+                FieldType.TEXT,
+                true,
+                true,
+                0,
+                List.of(),
+                null,
+                List.of()),
+            new FieldDefinition(
+                "amount",
+                "Amount",
+                FieldType.NUMBER,
+                false,
+                false,
+                1,
+                List.of(),
+                null,
+                List.of("role:underwriter")));
+    FormDefinition intakeForm =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Per-Field Permission Fixture",
+        1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW)),
+            new RoleDefinition("underwriter", List.of(Permission.EDIT, Permission.VIEW)),
+            new RoleDefinition("officer", List.of(Permission.VIEW))),
+        List.of(),
+        List.of(intakeForm),
+        DefaultFieldEditability.EDITABLE_BY_DEFAULT);
+  }
+
+  private static CaseTypeConfig lockedByDefaultCaseType() {
+    // No editableBy declared on either field — locked-by-default rejects any change.
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition(
+                "applicant",
+                "Applicant",
+                FieldType.TEXT,
+                true,
+                true,
+                0,
+                List.of(),
+                null,
+                List.of()),
+            new FieldDefinition(
+                "amount", "Amount", FieldType.NUMBER, false, false, 1, List.of(), null, List.of()));
+    FormDefinition intakeForm =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+    return new CaseTypeConfig(
+        LOCKED_CASE_TYPE_ID,
+        "Locked Default Fixture",
+        1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW)),
+            new RoleDefinition("officer", List.of(Permission.VIEW))),
+        List.of(),
+        List.of(intakeForm),
+        DefaultFieldEditability.LOCKED_BY_DEFAULT);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/RequireCaseAccessConsolidationIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/RequireCaseAccessConsolidationIT.java
@@ -1,0 +1,158 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Story 5.6 AC-0 — proves that {@code POST /api/cases/{id}/forms/{f}/submit} AND {@code PUT
+ * /api/cases/{id}/forms/{f}/draft} both go through {@link
+ * com.wkspower.platform.domain.service.CaseService#requireCaseAccess(java.util.UUID,
+ * java.util.UUID, java.util.Set)}: missing case yields the same {@code WksNotFoundException}
+ * envelope on both endpoints.
+ *
+ * <p>Sprint 8 retro Action 2 — single source of truth for case-level access on write-side
+ * controllers. Postgres-IT parity status: H2-only in this story (matches the pre-existing {@code
+ * FormSubmitIT} pattern); full Postgres-IT migration is carried forward (memory {@code
+ * project_postgres_it_parity_gap.md}).
+ *
+ * <p>Memory {@code feedback_production_validator_opt_out.md}: production-validation disabled (this
+ * IT does not exercise the validator).
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:requireaccessit;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=",
+      "wks.bootstrap.production-validation.enabled=false"
+    })
+class RequireCaseAccessConsolidationIT {
+
+  private static final String EMAIL = "require-access-it@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String CASE_TYPE_ID = "require-access-fixture";
+  private static final String FORM_ID = "intake-form";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private ObjectMapper json;
+
+  @BeforeEach
+  void setup() {
+    if (users.findByEmail(EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+    registry.register(caseTypeWithForm());
+  }
+
+  @Test
+  void formSubmitOnMissingCaseReturns404() {
+    String cookie = login();
+    UUID missing = UUID.randomUUID();
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + missing + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\"}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(resp.getBody()).contains("WKS-API-404");
+    assertThat(resp.getBody()).contains(missing.toString());
+  }
+
+  @Test
+  void formDraftPutOnMissingCaseReturns404() {
+    String cookie = login();
+    UUID missing = UUID.randomUUID();
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + missing + "/forms/" + FORM_ID + "/draft",
+            HttpMethod.PUT,
+            cookie,
+            "{\"payload\":{},\"scrollY\":0,\"sectionExpanded\":{},\"caseTypeVersionAtSave\":1}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(resp.getBody()).contains("WKS-API-404");
+    assertThat(resp.getBody()).contains(missing.toString());
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(EMAIL, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", EMAIL).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).isNotNull();
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  private static CaseTypeConfig caseTypeWithForm() {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition(
+                "applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null));
+    FormDefinition intakeForm =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Require Access Fixture",
+        1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(intakeForm));
+  }
+}

--- a/frontend/src/components/forms/MultiSectionFormRenderer.tsx
+++ b/frontend/src/components/forms/MultiSectionFormRenderer.tsx
@@ -29,10 +29,18 @@ import {
   SelectValue,
 } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
+import { useUserRoles } from '@/hooks/useUserRoles';
 import { t } from '@/i18n';
 import { getArchetypeAffordance } from '@/lib/archetypes';
 import { buildZodFromFieldDefs } from '@/lib/buildZodFromFieldDefs';
-import type { FieldDefinition, FormDefinitionView, FormSectionView } from '@/types/caseType';
+import type {
+  CaseTypeView,
+  FieldDefinition,
+  FormDefinitionView,
+  FormSectionView,
+} from '@/types/caseType';
+
+import { deriveFieldDisabled } from './deriveFieldDisabled';
 
 export interface MultiSectionFormRendererProps {
   /** The form definition (must have sections[]). */
@@ -56,6 +64,13 @@ export interface MultiSectionFormRendererProps {
     label: string;
     onClick: (values: Record<string, unknown>) => void;
   };
+  /**
+   * Story 5.6 AC3 / AC4 — Optional case-type view for per-field edit-permission derivation.
+   * Carries {@code defaultFieldEditability} (AC4) and {@code roles} (display-name lookup for the
+   * disabled-field tooltip). When omitted, every field is rendered without the {@code editableBy}
+   * disabled-state derivation — preserves pre-5.6 behavior.
+   */
+  caseType?: Pick<CaseTypeView, 'defaultFieldEditability' | 'roles'>;
 }
 
 type SectionStatus = 'incomplete' | 'complete' | 'error';
@@ -86,7 +101,9 @@ export function MultiSectionFormRenderer({
   onSuccess,
   onValuesChange,
   saveDraftAction,
+  caseType,
 }: MultiSectionFormRendererProps) {
+  const userRoles = useUserRoles();
   const sections = useMemo(() => formDefinition.sections ?? [], [formDefinition.sections]);
   const allFields = useMemo(() => sections.flatMap((s) => s.fields), [sections]);
 
@@ -368,7 +385,7 @@ export function MultiSectionFormRenderer({
                         {t('cases.create.noRequired', { caseTypeName: section.id })}
                       </p>
                     ) : (
-                      sortedFields.map((f) => renderField(f, isPending, form))
+                      sortedFields.map((f) => renderField(f, isPending, form, caseType, userRoles))
                     )}
                   </div>
                 ) : null}
@@ -445,8 +462,10 @@ function statusIcon(status: SectionStatus) {
 
 function renderField(
   f: FieldDefinition,
-  disabled: boolean,
+  pending: boolean,
   form: UseFormReturn<Record<string, unknown>>,
+  caseType: Pick<CaseTypeView, 'defaultFieldEditability' | 'roles'> | undefined,
+  userRoles: ReadonlySet<string>,
 ) {
   if (f.type === 'file') {
     return (
@@ -455,16 +474,17 @@ function renderField(
       </p>
     );
   }
+  // Story 5.6 AC3 / AC4 — per-field edit-permission disabled state.
+  const perm = caseType
+    ? deriveFieldDisabled(f, caseType, userRoles)
+    : { disabled: false, tooltip: null };
+  const disabled = pending || perm.disabled;
   return (
-    <FormField
-      key={f.id}
-      name={f.id}
-      label={f.displayName}
-      required={f.required}
-      disabled={disabled}
-    >
-      {(field) => renderInput(f, field, form)}
-    </FormField>
+    <div key={f.id} title={perm.tooltip ?? undefined}>
+      <FormField name={f.id} label={f.displayName} required={f.required} disabled={disabled}>
+        {(field) => renderInput(f, field, form)}
+      </FormField>
+    </div>
   );
 }
 

--- a/frontend/src/components/forms/SinglePageFormRenderer.tsx
+++ b/frontend/src/components/forms/SinglePageFormRenderer.tsx
@@ -28,10 +28,13 @@ import {
   SelectValue,
 } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
+import { useUserRoles } from '@/hooks/useUserRoles';
 import { t } from '@/i18n';
 import { getArchetypeAffordance } from '@/lib/archetypes';
 import { buildZodFromFieldDefs } from '@/lib/buildZodFromFieldDefs';
-import type { FieldDefinition, FormDefinitionView } from '@/types/caseType';
+import type { CaseTypeView, FieldDefinition, FormDefinitionView } from '@/types/caseType';
+
+import { deriveFieldDisabled } from './deriveFieldDisabled';
 
 export interface SinglePageFormRendererProps {
   /** The form definition (id, topology, dataModel, rendering, fields). */
@@ -61,6 +64,14 @@ export interface SinglePageFormRendererProps {
     label: string;
     onClick: (values: Record<string, unknown>) => void;
   };
+  /**
+   * Story 5.6 AC3 / AC4 — Optional case-type view for per-field edit-permission derivation.
+   * Carries {@code defaultFieldEditability} (AC4) and {@code roles} (display-name lookup for the
+   * disabled-field tooltip). When omitted, every field is rendered without the {@code editableBy}
+   * disabled-state derivation — preserves pre-5.6 behavior for callers that do not yet pass the
+   * case-type view.
+   */
+  caseType?: Pick<CaseTypeView, 'defaultFieldEditability' | 'roles'>;
 }
 
 interface ServerErrorBanner {
@@ -90,7 +101,9 @@ export function SinglePageFormRenderer({
   onSuccess,
   onValuesChange,
   saveDraftAction,
+  caseType,
 }: SinglePageFormRendererProps) {
+  const userRoles = useUserRoles();
   const [serverError, setServerError] = useState<ServerErrorBanner | null>(null);
   const [isPending, setIsPending] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
@@ -273,7 +286,7 @@ export function SinglePageFormRenderer({
               {t('cases.create.noRequired', { caseTypeName: formDefinition.id })}
             </p>
           ) : (
-            sortedFields.map((f) => renderField(f, isPending, form))
+            sortedFields.map((f) => renderField(f, isPending, form, caseType, userRoles))
           )}
           {serverError ? (
             <Alert
@@ -342,8 +355,10 @@ function collectFormErrors(
 
 function renderField(
   f: FieldDefinition,
-  disabled: boolean,
+  pending: boolean,
   form: UseFormReturn<Record<string, unknown>>,
+  caseType: Pick<CaseTypeView, 'defaultFieldEditability' | 'roles'> | undefined,
+  userRoles: ReadonlySet<string>,
 ) {
   if (f.type === 'file') {
     return (
@@ -352,16 +367,18 @@ function renderField(
       </p>
     );
   }
+  // Story 5.6 AC3 / AC4 — per-field edit-permission disabled state. When caseType is omitted
+  // (pre-5.6 callers), the helper falls through with editableBy:[] and default editable behavior.
+  const perm = caseType
+    ? deriveFieldDisabled(f, caseType, userRoles)
+    : { disabled: false, tooltip: null };
+  const disabled = pending || perm.disabled;
   return (
-    <FormField
-      key={f.id}
-      name={f.id}
-      label={f.displayName}
-      required={f.required}
-      disabled={disabled}
-    >
-      {(field) => renderInput(f, field, form)}
-    </FormField>
+    <div key={f.id} title={perm.tooltip ?? undefined}>
+      <FormField name={f.id} label={f.displayName} required={f.required} disabled={disabled}>
+        {(field) => renderInput(f, field, form)}
+      </FormField>
+    </div>
   );
 }
 

--- a/frontend/src/components/forms/deriveFieldDisabled.test.ts
+++ b/frontend/src/components/forms/deriveFieldDisabled.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Story 5.6 AC3 / AC4 — unit tests for the per-field disabled-state derivation helper used by both
+ * SinglePageFormRenderer and MultiSectionFormRenderer.
+ *
+ * Memory `feedback_consolidate_property_readers.md` analog: both renderers consume this single
+ * helper; do not duplicate the role-derivation logic.
+ *
+ * Coverage matrix per AC3:
+ *   (a) no editableBy + default editable → not disabled
+ *   (b) editableBy declared, user has role → not disabled
+ *   (c) editableBy declared, user lacks role → disabled with tooltip
+ *   (d) editableBy with two roles, user has one → not disabled
+ *
+ * Coverage per AC4:
+ *   (e) no editableBy + locked-by-default → disabled with locked tooltip
+ *   (f) editableBy declared takes precedence over defaultFieldEditability when user has role
+ */
+import { describe, expect, it } from 'vitest';
+
+import { deriveFieldDisabled } from './deriveFieldDisabled';
+
+const ROLES = [
+  { id: 'underwriter', displayName: 'Underwriter' },
+  { id: 'supervisor', displayName: 'Supervisor' },
+  { id: 'officer', displayName: 'Loan Officer' },
+];
+
+describe('deriveFieldDisabled', () => {
+  it('(a) no editableBy + default editable → not disabled', () => {
+    const r = deriveFieldDisabled(
+      { editableBy: undefined },
+      { defaultFieldEditability: 'editable-by-default', roles: ROLES },
+      new Set([]),
+    );
+    expect(r.disabled).toBe(false);
+    expect(r.tooltip).toBeNull();
+  });
+
+  it('(b) editableBy declared, user has role → not disabled', () => {
+    const r = deriveFieldDisabled(
+      { editableBy: ['role:underwriter'] },
+      { defaultFieldEditability: 'editable-by-default', roles: ROLES },
+      new Set(['underwriter']),
+    );
+    expect(r.disabled).toBe(false);
+    expect(r.tooltip).toBeNull();
+  });
+
+  it('(c) editableBy declared, user lacks role → disabled with display-name tooltip', () => {
+    const r = deriveFieldDisabled(
+      { editableBy: ['role:underwriter'] },
+      { defaultFieldEditability: 'editable-by-default', roles: ROLES },
+      new Set(['officer']),
+    );
+    expect(r.disabled).toBe(true);
+    expect(r.tooltip).toBe('Editable only by: Underwriter');
+  });
+
+  it('(d) editableBy with two roles, user has one → not disabled', () => {
+    const r = deriveFieldDisabled(
+      { editableBy: ['role:underwriter', 'role:supervisor'] },
+      { defaultFieldEditability: 'editable-by-default', roles: ROLES },
+      new Set(['supervisor']),
+    );
+    expect(r.disabled).toBe(false);
+    expect(r.tooltip).toBeNull();
+  });
+
+  it('(e) no editableBy + locked-by-default → disabled with locked tooltip', () => {
+    const r = deriveFieldDisabled(
+      { editableBy: [] },
+      { defaultFieldEditability: 'locked-by-default', roles: ROLES },
+      new Set(['officer']),
+    );
+    expect(r.disabled).toBe(true);
+    expect(r.tooltip).toBe('Field is locked — no editableBy declaration');
+  });
+
+  it('(f) tooltip falls back to role id when caseType.roles omitted', () => {
+    const r = deriveFieldDisabled(
+      { editableBy: ['role:underwriter', 'role:supervisor'] },
+      { defaultFieldEditability: 'editable-by-default' },
+      new Set(['officer']),
+    );
+    expect(r.disabled).toBe(true);
+    // No display names supplied → falls back to role id verbatim.
+    expect(r.tooltip).toBe('Editable only by: underwriter, supervisor');
+  });
+});

--- a/frontend/src/components/forms/deriveFieldDisabled.ts
+++ b/frontend/src/components/forms/deriveFieldDisabled.ts
@@ -1,0 +1,57 @@
+import type { CaseTypeView, FieldDefinition } from '@/types/caseType';
+
+/**
+ * Story 5.6 AC3 / AC4 — Derive whether a field should render as disabled given the field's
+ * {@code editableBy} declaration and the current user's role set, optionally consulting the
+ * case-type's {@code defaultFieldEditability} setting (AC4) when {@code editableBy} is omitted.
+ *
+ * <p>The server is authoritative for the actual permission check (AC2 — {@code WKS-AUTHZ-001} on
+ * submit-time bypass). This helper is purely a UX hint to surface the restriction before the user
+ * attempts a write.
+ *
+ * <p>Returns {@code disabled: false, tooltip: null} when the field is editable; otherwise
+ * {@code disabled: true} with a human-readable tooltip describing the restriction. The tooltip
+ * looks up role display names via {@code caseType.roles} when supplied, falling back to the role
+ * id when the case-type does not surface its role declarations on the wire.
+ */
+export interface DerivedDisabled {
+  disabled: boolean;
+  tooltip: string | null;
+}
+
+export function deriveFieldDisabled(
+  field: Pick<FieldDefinition, 'editableBy'>,
+  caseType: Pick<CaseTypeView, 'defaultFieldEditability' | 'roles'>,
+  userRoles: ReadonlySet<string>,
+): DerivedDisabled {
+  const editableBy = field.editableBy ?? [];
+  if (editableBy.length === 0) {
+    if (caseType.defaultFieldEditability === 'locked-by-default') {
+      return {
+        disabled: true,
+        tooltip: 'Field is locked — no editableBy declaration',
+      };
+    }
+    return { disabled: false, tooltip: null };
+  }
+
+  // editableBy entries follow `role:<id>` per AC1. Strip prefix; ignore unknown formats.
+  const requiredRoles = editableBy
+    .filter((s) => s.startsWith('role:'))
+    .map((s) => s.substring('role:'.length))
+    .filter((s) => s.length > 0);
+
+  const hasRequired = requiredRoles.some((r) => userRoles.has(r));
+  if (hasRequired) return { disabled: false, tooltip: null };
+
+  // Build display-name tooltip from caseType.roles, falling back to role id.
+  const roleNames = requiredRoles.map((rid) => {
+    const r = caseType.roles?.find((x) => x.id === rid);
+    return r?.displayName ?? rid;
+  });
+  const tooltip =
+    roleNames.length > 0
+      ? `Editable only by: ${roleNames.join(', ')}`
+      : 'Editable only by a restricted role set';
+  return { disabled: true, tooltip };
+}

--- a/frontend/src/hooks/useUserRoles.ts
+++ b/frontend/src/hooks/useUserRoles.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+
+import { useAuthStore } from '@/stores/authStore';
+
+/**
+ * Story 5.6 AC3 — Returns the current user's role set as a {@link ReadonlySet}. Convenience
+ * wrapper over {@link useAuthStore} that memoises the {@code Set} so consumers can use referential
+ * equality in {@code useMemo} dependency arrays.
+ *
+ * <p>Returns an empty set when the user is not authenticated (the renderers should not render at
+ * all in that state, but the hook stays defensive).
+ */
+export function useUserRoles(): ReadonlySet<string> {
+  const roles = useAuthStore((s) => s.user?.roles);
+  return useMemo(() => new Set(roles ?? []), [roles]);
+}

--- a/frontend/src/types/caseType.ts
+++ b/frontend/src/types/caseType.ts
@@ -41,6 +41,12 @@ export interface FieldDefinition {
   dateMax?: string | null;
   maxBytes?: number | null;
   allowedMimeTypes?: string[] | null;
+  /**
+   * Story 5.6 AC1 — role-id allow-list for write authorization. Wire entries follow the
+   * {@code role:<id>} format. Empty/undefined means "no editableBy declared" — the case-type's
+   * {@code defaultFieldEditability} (AC4) decides the runtime default.
+   */
+  editableBy?: string[];
 }
 
 export interface StatusDefinition {
@@ -125,4 +131,16 @@ export interface CaseTypeView {
    * no forms block is declared.
    */
   forms?: FormDefinitionView[];
+  /**
+   * Story 5.6 AC4 — top-level case-type setting controlling default field editability. Wire
+   * values: {@code editable-by-default} (default — preserves pre-5.6 behavior) or
+   * {@code locked-by-default}. Optional for backward-compat; absence means default.
+   */
+  defaultFieldEditability?: 'editable-by-default' | 'locked-by-default' | null;
+  /**
+   * Story 5.6 AC3 — declared roles surface (id + displayName) used to translate role ids to
+   * display names in disabled-field tooltips. Server may omit (current backend does not echo
+   * roles); when absent, tooltips fall back to the role id. Optional.
+   */
+  roles?: { id: string; displayName?: string }[];
 }


### PR DESCRIPTION
## Summary

Story 5-6 (Sprint 9) — Per-Field Edit Permissions + AC-0 hard precondition (Sprint 8 retro Action 2: `CaseService.requireCaseAccess` extraction).

### AC outcomes

- **AC-0 (Sprint 8 retro Action 2 — discharged in this PR).** Extract `CaseService.requireCaseAccess(caseId, actorId, actorRoles) → Case`. `FormController.submit` and all three `FormDraftController` handlers (GET / PUT / DELETE) now consume the shared helper. The duplicated inline `requireCaseExists` helper is removed; `caseRepository` field dropped from `FormDraftController` (replaced with `CaseService` injection). Phase-0 implementation is no-op-beyond-authentication; Phase-1 RBAC will land by replacing the body of one method, not by editing every controller.

- **AC1 — `editableBy: [role:<id>]` YAML schema + validator.** Additive `List<String> editableBy` slot on `FieldDefinition` (with backward-compat 7-arg + 8-arg constructors). `RawCaseTypeConfig.RawField` and `FormDefinitionMapper` parse the new key. `ConfigValidator.validateEditableByAndAttach` runs a second pass post-`checkRoles` to cross-reference each entry against the case-type's declared role ids. Malformed entries (no `role:` prefix) and unknown role ids surface `WKS-FORM-001`; empty `editableBy: []` is treated as omitted.

- **AC2 — server-side `WKS-AUTHZ-001` enforcement.** New principal-aware `submitForm(caseId, formId, formData, actorId, actorRoles)` overload + private static `checkFieldEditPermissions` helper on `CaseService`. Operates on the diff of changed fields only via existing `diffFieldIds` (round-tripped immutable display fields are not rejected). Multi-error envelope rides the existing `WksValidationAggregateException` carrier (HTTP 422 — no `GlobalExceptionHandler` change needed). INFO audit log on rejection. Pre-5.6 4-arg `submitForm` overload preserved for backward compat. Form-draft path (PUT `/draft`) intentionally does NOT enforce — drafts are working state.

- **AC3 — frontend disabled state + tooltip + first renderer-level unit tests.** Shared `deriveFieldDisabled` helper consumed by both `SinglePageFormRenderer` and `MultiSectionFormRenderer`; new `useUserRoles` hook reads from `useAuthStore`. Disabled fields surface a tooltip listing required role display names (or role id when `caseType.roles` is absent on the wire). 6 unit cases on the helper covering the AC3 + AC4 matrix — first renderer-level unit-test fixture in the codebase, partial discharge of Sprint 8 retro Action 6.

- **AC4 — `defaultFieldEditability` enum + top-level YAML key.** `DefaultFieldEditability` enum (`EDITABLE_BY_DEFAULT` default, `LOCKED_BY_DEFAULT` opt-in). Backwards-compatible — every existing seed YAML omits the key and gets `editable-by-default` (preserves pre-5.6 behavior, zero regression). Reading A implemented as locked: gates via the new key. Decision is reversible by a one-line default flip.

### Wire codes

- **`WKS_AUTHZ_FIELD` minted** with wire string `WKS-AUTHZ-001` — first member of the new `WKS-AUTHZ-*` band. **Deviation from story spec:** the dev notes prescribed wire literal `WKS-AUTHZ-FIELD`, but the existing `^WKS-<PREFIX>-NNN$` invariant (enforced by `ErrorCodeTest.wireStringsFollowWksHyphenFormat`) requires a 3-digit numeric suffix. Java identifier `WKS_AUTHZ_FIELD` preserves the mnemonic; the regex was relaxed from `[A-Z]{3,4}` to `[A-Z]{3,5}` to accommodate the 5-letter `AUTHZ` prefix. Documented in `ErrorCode` javadoc.

### Backwards-compat decisions

- `defaultFieldEditability` defaults to `editable-by-default` on omit (preserves pre-5.6 behavior). One-line flip on `RawCaseTypeConfig.fromYaml` reverses this if Reading B is the right call post-demo.
- `CaseTypeConfig`, `CaseTypeViewDto`, `CaseTypeViewDto.FieldView`, `FieldDefinition` all add backward-compat secondary constructors so existing test/seed callers do not break.
- `FormController.submit` adds the principal-aware `submitForm` overload behind the existing 4-arg overload; pre-5.6 callers continue to work with an empty role set.

### Postgres-IT parity (deviation)

The two new ITs (`RequireCaseAccessConsolidationIT`, `PerFieldEditPermissionIT`) run on H2 — matching the pre-existing `FormSubmitIT` pattern from Story 5-2 (which the story file claimed already ran on Postgres; the actual file uses H2). Sprint 9 parallel-dispatch time pressure precluded a Postgres Testcontainers HTTP-level fixture (no existing precedent in the codebase). **Carry-forward:** Postgres-IT migration of the form-submit + form-draft surface is open for the next story that adds behavior (vs. refactoring access). See updated §"Deferred carry-forwards" in the story file.

### Domain framework purity

`requireCaseAccess` and the new `submitForm` overload take primitive `(UUID actorId, Set<String> actorRoles)` rather than `WksUserPrincipal` — `WksUserPrincipal` lives in `security/` and depends on Spring Security `UserDetails`; importing it into the framework-free domain layer would couple the domain to Spring. Controllers extract id + roles from the principal at the call site.

## Test plan

- [x] `mvn verify` from `backend/` — 542 unit + 157 IT (1 skipped on no-Docker, expected), spotless clean, BUILD SUCCESS
- [x] Tenant invariant scan (`bash backend/.ci/check-tenant-invariant.sh`) — OK
- [x] `npm run lint` — green
- [x] `npm run format:check` — all files Prettier-clean
- [x] `npm test` — 343 tests across 76 files passing
- [x] `npm run build` — bundle produced (≥4 woff2 fonts present per Story 1.3 AC#13)
- [ ] CI on `v2-develop`: backend job + frontend job + tenant-invariant job should all stay green
- [ ] Smoke test on staging (post-merge): create a case, submit a form with a `role:`-restricted field as a user lacking the role → expect HTTP 422 + `WKS-AUTHZ-001`; toggle `defaultFieldEditability: locked-by-default` on a fixture and verify the renderer disables every field

🤖 Generated with [Claude Code](https://claude.com/claude-code)