### PR TITLE
feat(7-5): wire auth.sso license gate into SecurityConfig + KeycloakSeamAnnouncer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,6 @@ jobs:
           WKS_CORS_ORIGINS=http://localhost:8080
           WKS_JWT_SECRET=${JWT_FIXTURE}
           WKS_OPENAPI_ENABLED=false
-          WKS_KEYCLOAK_ENABLED=false
           WKS_MINIO_ROOT_USER=ci-fixture-minio-user
           WKS_MINIO_ROOT_PASSWORD=ci-fixture-minio-password
           WKS_HOST_PORT=8080

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -490,7 +490,7 @@ public enum ErrorCode {
    * not exist for this license tier. HTTP 404. Story 7.5 AC1.
    */
   WKS_LIC_003("WKS-LIC-003"),
-   /**
+  /**
    * SSO/SAML availability could not be determined because the {@code LicenseService} threw while
    * being consulted by {@code SamlGatingFilter}. The filter fails CLOSED (404, treats SSO as
    * unavailable) and logs the underlying exception at WARN. HTTP 404. Story 7.5 review remediation.

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -484,6 +484,12 @@ public enum ErrorCode {
    * Story 7.1 AC3.
    */
   WKS_LIC_002("WKS-LIC-002"),
+  /**
+   * SSO/SAML endpoint accessed while the {@code auth.sso} feature is disabled by the current
+   * license (OSS, Team, Expired, or Degraded state). The platform responds 404 — the endpoint does
+   * not exist for this license tier. HTTP 404. Story 7.5 AC1.
+   */
+  WKS_LIC_003("WKS-LIC-003"),
 
   // ---------------------------------------------------------------------------
   // Archetype validation band (Story 6.1) — YAML-surface archetype violations.

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -490,6 +490,12 @@ public enum ErrorCode {
    * not exist for this license tier. HTTP 404. Story 7.5 AC1.
    */
   WKS_LIC_003("WKS-LIC-003"),
+   /**
+   * SSO/SAML availability could not be determined because the {@code LicenseService} threw while
+   * being consulted by {@code SamlGatingFilter}. The filter fails CLOSED (404, treats SSO as
+   * unavailable) and logs the underlying exception at WARN. HTTP 404. Story 7.5 review remediation.
+   */
+  WKS_LIC_004("WKS-LIC-004"),
 
   // ---------------------------------------------------------------------------
   // Archetype validation band (Story 6.1) — YAML-surface archetype violations.

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/KeycloakSeamAnnouncer.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/KeycloakSeamAnnouncer.java
@@ -1,26 +1,27 @@
 package com.wkspower.platform.infrastructure.config;
 
+import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.WksFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 /**
- * Announces the Keycloak/SSO compose seam on production-profile startup (Story 14.1 AC5).
+ * Announces the Keycloak/SSO compose seam on production-profile startup.
  *
- * <p>Two switches gate the seam: the compose flag {@code --profile production-sso} (provisions the
- * Keycloak container) and the env-driven property {@code wks.keycloak.enabled} ({@code
- * WKS_KEYCLOAK_ENABLED}). When the property is false (default) we log an INFO line stating built-in
- * auth (Story 1.2 cookie-JWT) remains active. When the property is true we additionally emit {@code
- * WKS-AUTH-001} at WARN to make explicit that the Keycloak container has been provisioned but
- * auth-provider integration is gated on Story 10.4 (SSO/SAML via Keycloak).
+ * <p>The seam is gated by {@link LicenseService#isFeatureEnabled(WksFeature)
+ * isFeatureEnabled(AUTH_SSO)}. When the feature is off (OSS / Team / Expired / Degraded), an INFO
+ * line states built-in cookie-JWT (Story 1.2) remains the sole auth gate. When the feature is on
+ * (Enterprise / Demo with a VALID license), {@code WKS-AUTH-001} is emitted at WARN to make
+ * explicit that the SAML provider is still gated on Story 10.4 — the license unlocks the surface
+ * but no enforcement code exists yet.
  *
- * <p>This class deliberately has NO dependency on {@code LicenseService} — Epic 7 has not shipped.
- * Story 7.3 (Feature Flag Registry) will subsume {@code wks.keycloak.enabled} under {@code
- * feature.sso} with license-tier gating; until then this property is the operator's direct toggle.
+ * <p>Story 7-5 (this story) flips the gate source from the operator-direct {@code
+ * wks.keycloak.enabled} env property to {@link LicenseService}; Story 10.4 will deliver the SAML
+ * provider and replace the 401 fallthrough behind the gate.
  */
 @Component
 @Profile("production")
@@ -28,30 +29,31 @@ public class KeycloakSeamAnnouncer {
 
   private static final Logger LOG = LoggerFactory.getLogger(KeycloakSeamAnnouncer.class);
 
-  private final Environment env;
+  private final LicenseService licenseService;
 
-  public KeycloakSeamAnnouncer(Environment env) {
-    this.env = env;
+  public KeycloakSeamAnnouncer(LicenseService licenseService) {
+    this.licenseService = licenseService;
   }
 
   @EventListener(ApplicationReadyEvent.class)
   public void announce() {
-    boolean enabled = env.getProperty("wks.keycloak.enabled", Boolean.class, Boolean.FALSE);
+    boolean enabled = licenseService.isFeatureEnabled(WksFeature.AUTH_SSO);
     if (enabled) {
       // Story 14.1.1 AC3 (finding C4): the WARN message MUST be explicit that the
       // seam is INERT today and that flipping the flag changes NOTHING about auth
       // enforcement. The previous message said "auth-provider integration is gated
       // on Epic 7" — too soft; operators were inferring "this WILL enforce SSO once
       // I set the second flag" and shipping production with built-in cookie-JWT
-      // believing the SSO posture was active.
+      // believing the SSO posture was active. The wire string `WKS-AUTH-001` is
+      // preserved verbatim — operators grep it.
       LOG.warn(
           "WKS-AUTH-001: Keycloak seam is currently INERT — built-in cookie-JWT remains the sole"
               + " auth gate. SSO enforcement requires Story 10.4 (SAML via Keycloak realm) to"
               + " land. To enforce auth posture, do NOT rely on this flag.");
     } else {
       LOG.info(
-          "WKS auth: built-in (Keycloak/SSO disabled — set WKS_KEYCLOAK_ENABLED=true and run"
-              + " with --profile production-sso to enable; license-gated in Epic 7).");
+          "WKS auth: built-in cookie-JWT (auth.sso disabled by license — Enterprise tier unlocks"
+              + " SSO; Story 10.4 will deliver the SAML provider).");
     }
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
+++ b/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
@@ -129,6 +129,11 @@ public class SamlGatingFilter extends OncePerRequestFilter {
     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    // The availability decision is per-request and license-tier-sensitive — must NOT be cached
+    // by intermediaries (CDN, browser, reverse proxy). Otherwise an upgrade from OSS → Enterprise
+    // would still serve cached 404s for the SAML surface.
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader("Pragma", "no-cache");
 
     Map<String, Object> body = new LinkedHashMap<>();
     body.put("code", code);

--- a/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
+++ b/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
@@ -63,6 +63,12 @@ public class SamlGatingFilter extends OncePerRequestFilter {
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain chain)
       throws ServletException, IOException {
+    // CORS preflights MUST reach SecurityConfig's `OPTIONS /** permitAll` rule untouched —
+    // a 404+JSON here would corrupt the preflight and break browser-side SAML init from the SPA.
+    if ("OPTIONS".equals(request.getMethod())) {
+      chain.doFilter(request, response);
+      return;
+    }
     String path = request.getRequestURI();
     if (!SAML_MATCHER.matches(request)) {
       chain.doFilter(request, response);

--- a/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
+++ b/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
@@ -39,12 +39,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * result internally — Story 7.1/7.2 design); no bean-construction-time snapshot is taken,
  * satisfying AC3 (hot-reload without restart).
  *
- * <p><b>Fail-closed policy.</b> If {@code LicenseService.isFeatureEnabled} throws (e.g. the
- * service is mid-reload, dependency-injected stub mis-wired, or any unexpected runtime fault),
- * the filter treats SSO as <em>unavailable</em> and emits 404 + {@code WKS-LIC-004}. This is
- * deliberately the same HTTP shape as the "feature off" response so a degraded license layer
- * cannot accidentally open the SAML surface to an unauthenticated caller. The underlying
- * exception is logged at WARN for operators.
+ * <p><b>Fail-closed policy.</b> If {@code LicenseService.isFeatureEnabled} throws (e.g. the service
+ * is mid-reload, dependency-injected stub mis-wired, or any unexpected runtime fault), the filter
+ * treats SSO as <em>unavailable</em> and emits 404 + {@code WKS-LIC-004}. This is deliberately the
+ * same HTTP shape as the "feature off" response so a degraded license layer cannot accidentally
+ * open the SAML surface to an unauthenticated caller. The underlying exception is logged at WARN
+ * for operators.
  *
  * <p>Story 7.5 AC1 / AC2 / AC3.
  */

--- a/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
+++ b/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
@@ -1,0 +1,88 @@
+package com.wkspower.platform.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.WksFeature;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Per-request gate for {@code /api/auth/saml/**} paths.
+ *
+ * <p>When {@link LicenseService#isFeatureEnabled(WksFeature) isFeatureEnabled(AUTH_SSO)} is {@code
+ * false} (OSS, Team, Expired, or Degraded state), the filter short-circuits the request with HTTP
+ * 404 and error-code {@code WKS-LIC-003} — the endpoint simply does not exist for the current
+ * license. When the feature is enabled, the filter is a no-op and the request proceeds down the
+ * Spring Security chain (currently returning 401 until Story 10.4 wires the SAML provider).
+ *
+ * <p>This filter is registered before {@link JwtAuthenticationFilter} in {@link SecurityConfig}.
+ * The per-request {@link LicenseService} call is constant-time (the service memoises the
+ * license-verification result internally — Story 7.1/7.2 design); no bean-construction-time
+ * snapshot is taken, satisfying AC3 (hot-reload without restart).
+ *
+ * <p>Story 7.5 AC1 / AC2 / AC3.
+ */
+public class SamlGatingFilter extends OncePerRequestFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SamlGatingFilter.class);
+  private static final String SAML_PATH_PREFIX = "/api/auth/saml/";
+  private static final String SAML_PATH_EXACT = "/api/auth/saml";
+
+  private final LicenseService licenseService;
+  private final ObjectMapper objectMapper;
+
+  public SamlGatingFilter(LicenseService licenseService, ObjectMapper objectMapper) {
+    this.licenseService = licenseService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+      throws ServletException, IOException {
+    String path = request.getRequestURI();
+    if (!isSamlPath(path)) {
+      chain.doFilter(request, response);
+      return;
+    }
+    if (licenseService.isFeatureEnabled(WksFeature.AUTH_SSO)) {
+      // Feature is licensed — pass through; Story 10.4 will add the actual SAML provider.
+      chain.doFilter(request, response);
+      return;
+    }
+    // Feature is off — 404 with WKS-LIC-003.
+    LOG.debug(
+        "event=saml.gate.blocked path={} licenseTier={} errorCode={}",
+        path,
+        licenseService.getTier(),
+        ErrorCode.WKS_LIC_003.wire());
+    rejectWithNotFound(response, path);
+  }
+
+  private static boolean isSamlPath(String path) {
+    return path != null
+        && (path.equals(SAML_PATH_EXACT) || path.startsWith(SAML_PATH_PREFIX));
+  }
+
+  private void rejectWithNotFound(HttpServletResponse response, String path) throws IOException {
+    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("errorCode", ErrorCode.WKS_LIC_003.wire());
+    body.put("message", "SSO/SAML is not available on the current license.");
+    objectMapper.writeValue(response.getWriter(), body);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
+++ b/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
@@ -26,13 +27,19 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * license. When the feature is enabled, the filter is a no-op and the request proceeds down the
  * Spring Security chain (currently returning 401 until Story 10.4 wires the SAML provider).
  *
- * <p>This filter is registered before {@link JwtAuthenticationFilter} in {@link SecurityConfig}.
- * The per-request {@link LicenseService} call is constant-time (the service memoises the
- * license-verification result internally — Story 7.1/7.2 design); no bean-construction-time
- * snapshot is taken, satisfying AC3 (hot-reload without restart).
+ * <p>The response envelope matches {@link WksAuthenticationEntryPoint} ({@code code} / {@code
+ * message} / {@code field}) so SI clients can deserialise both error paths with one DTO. (Story 7-5
+ * AC1 literal text said {@code errorCode}, but Task 1 binds the implementation to the existing
+ * envelope shape — kept consistent with the rest of the WKS error surface.)
+ *
+ * <p>Registered before {@link JwtAuthenticationFilter} in {@link SecurityConfig}. The per-request
+ * {@link LicenseService} call is constant-time (the service memoises the license-verification
+ * result internally — Story 7.1/7.2 design); no bean-construction-time snapshot is taken,
+ * satisfying AC3 (hot-reload without restart).
  *
  * <p>Story 7.5 AC1 / AC2 / AC3.
  */
+@Component
 public class SamlGatingFilter extends OncePerRequestFilter {
 
   private static final Logger LOG = LoggerFactory.getLogger(SamlGatingFilter.class);
@@ -71,8 +78,7 @@ public class SamlGatingFilter extends OncePerRequestFilter {
   }
 
   private static boolean isSamlPath(String path) {
-    return path != null
-        && (path.equals(SAML_PATH_EXACT) || path.startsWith(SAML_PATH_PREFIX));
+    return path != null && (path.equals(SAML_PATH_EXACT) || path.startsWith(SAML_PATH_PREFIX));
   }
 
   private void rejectWithNotFound(HttpServletResponse response, String path) throws IOException {
@@ -81,8 +87,9 @@ public class SamlGatingFilter extends OncePerRequestFilter {
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
     Map<String, Object> body = new LinkedHashMap<>();
-    body.put("errorCode", ErrorCode.WKS_LIC_003.wire());
+    body.put("code", ErrorCode.WKS_LIC_003.wire());
     body.put("message", "SSO/SAML is not available on the current license.");
+    body.put("field", null);
     objectMapper.writeValue(response.getWriter(), body);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
+++ b/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -43,8 +45,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class SamlGatingFilter extends OncePerRequestFilter {
 
   private static final Logger LOG = LoggerFactory.getLogger(SamlGatingFilter.class);
-  private static final String SAML_PATH_PREFIX = "/api/auth/saml/";
-  private static final String SAML_PATH_EXACT = "/api/auth/saml";
+  // Ant matcher (case-insensitive, path-normalised) — covers /api/auth/saml and
+  // /api/auth/saml/** in one rule, defeats trivial casing/encoding bypasses
+  // (e.g. /API/AUTH/SAML/metadata, //api/auth/saml///init).
+  private static final RequestMatcher SAML_MATCHER =
+      new AntPathRequestMatcher("/api/auth/saml/**", null, /* caseSensitive */ false);
 
   private final LicenseService licenseService;
   private final ObjectMapper objectMapper;
@@ -59,7 +64,7 @@ public class SamlGatingFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, FilterChain chain)
       throws ServletException, IOException {
     String path = request.getRequestURI();
-    if (!isSamlPath(path)) {
+    if (!SAML_MATCHER.matches(request)) {
       chain.doFilter(request, response);
       return;
     }
@@ -75,10 +80,6 @@ public class SamlGatingFilter extends OncePerRequestFilter {
         licenseService.getTier(),
         ErrorCode.WKS_LIC_003.wire());
     rejectWithNotFound(response, path);
-  }
-
-  private static boolean isSamlPath(String path) {
-    return path != null && (path.equals(SAML_PATH_EXACT) || path.startsWith(SAML_PATH_PREFIX));
   }
 
   private void rejectWithNotFound(HttpServletResponse response, String path) throws IOException {

--- a/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
+++ b/backend/src/main/java/com/wkspower/platform/security/SamlGatingFilter.java
@@ -39,6 +39,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * result internally — Story 7.1/7.2 design); no bean-construction-time snapshot is taken,
  * satisfying AC3 (hot-reload without restart).
  *
+ * <p><b>Fail-closed policy.</b> If {@code LicenseService.isFeatureEnabled} throws (e.g. the
+ * service is mid-reload, dependency-injected stub mis-wired, or any unexpected runtime fault),
+ * the filter treats SSO as <em>unavailable</em> and emits 404 + {@code WKS-LIC-004}. This is
+ * deliberately the same HTTP shape as the "feature off" response so a degraded license layer
+ * cannot accidentally open the SAML surface to an unauthenticated caller. The underlying
+ * exception is logged at WARN for operators.
+ *
  * <p>Story 7.5 AC1 / AC2 / AC3.
  */
 @Component
@@ -74,7 +81,23 @@ public class SamlGatingFilter extends OncePerRequestFilter {
       chain.doFilter(request, response);
       return;
     }
-    if (licenseService.isFeatureEnabled(WksFeature.AUTH_SSO)) {
+    boolean ssoEnabled;
+    try {
+      ssoEnabled = licenseService.isFeatureEnabled(WksFeature.AUTH_SSO);
+    } catch (Exception e) {
+      // Fail CLOSED — see class Javadoc. Treat unknown-availability as unavailable so a
+      // degraded license layer cannot open the SAML surface.
+      LOG.warn(
+          "event=saml.gate.licenseService.error path={} errorCode={} cause={}",
+          path,
+          ErrorCode.WKS_LIC_004.wire(),
+          e.toString(),
+          e);
+      rejectWithNotFound(
+          response, path, ErrorCode.WKS_LIC_004.wire(), "SSO availability check unavailable");
+      return;
+    }
+    if (ssoEnabled) {
       // Feature is licensed — pass through; Story 10.4 will add the actual SAML provider.
       chain.doFilter(request, response);
       return;
@@ -83,19 +106,33 @@ public class SamlGatingFilter extends OncePerRequestFilter {
     LOG.debug(
         "event=saml.gate.blocked path={} licenseTier={} errorCode={}",
         path,
-        licenseService.getTier(),
+        safeTier(),
         ErrorCode.WKS_LIC_003.wire());
-    rejectWithNotFound(response, path);
+    rejectWithNotFound(
+        response,
+        path,
+        ErrorCode.WKS_LIC_003.wire(),
+        "SSO/SAML is not available on the current license.");
   }
 
-  private void rejectWithNotFound(HttpServletResponse response, String path) throws IOException {
+  /** Best-effort tier lookup for the debug log line — never throws. */
+  private String safeTier() {
+    try {
+      return licenseService.getTier();
+    } catch (Exception e) {
+      return "unknown";
+    }
+  }
+
+  private void rejectWithNotFound(
+      HttpServletResponse response, String path, String code, String message) throws IOException {
     response.setStatus(HttpServletResponse.SC_NOT_FOUND);
     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
     Map<String, Object> body = new LinkedHashMap<>();
-    body.put("code", ErrorCode.WKS_LIC_003.wire());
-    body.put("message", "SSO/SAML is not available on the current license.");
+    body.put("code", code);
+    body.put("message", message);
     body.put("field", null);
     objectMapper.writeValue(response.getWriter(), body);
   }

--- a/backend/src/main/java/com/wkspower/platform/security/SecurityConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/security/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
   public SecurityFilterChain securityFilterChain(
       HttpSecurity http,
       JwtAuthenticationFilter jwtAuthenticationFilter,
+      SamlGatingFilter samlGatingFilter,
       CorsConfigurationSource corsConfigurationSource,
       WksAuthenticationEntryPoint authenticationEntryPoint,
       Environment environment,
@@ -104,6 +105,10 @@ public class SecurityConfig {
               }
               auth.requestMatchers("/api/**").authenticated().anyRequest().permitAll();
             })
+        // samlGatingFilter is registered first, so it runs before jwtAuthenticationFilter in the
+        // chain — both are positioned just before UsernamePasswordAuthenticationFilter, and Spring
+        // Security preserves registration order within the same slot.
+        .addFilterBefore(samlGatingFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }

--- a/backend/src/main/resources/application-production.yml
+++ b/backend/src/main/resources/application-production.yml
@@ -73,15 +73,10 @@ wks:
   documents:
     max-size-mb: 25
     bucket: ${WKS_STORAGE_BUCKET:wks-documents}
-  # Keycloak/SSO is a forward-compatible seam (Story 14.1 AC5). The compose
-  # `production-sso` profile provisions the container; this property gates the
-  # log surface that announces the seam. Auth-provider integration is gated on
-  # Story 10.4 (SSO/SAML via Keycloak) and Story 7.3 (Feature Flag Registry,
-  # which will subsume this property under feature.sso with license-tier
-  # gating). Until then the operator's direct toggle is `WKS_KEYCLOAK_ENABLED`.
-  # NOTE: this code path MUST NOT depend on LicenseService — Epic 7 has not shipped.
-  keycloak:
-    enabled: ${WKS_KEYCLOAK_ENABLED:false}
+  # Keycloak/SSO seam announcer (Story 14.1 AC5) is gated by LicenseService
+  # (auth.sso feature flag) since Story 7-5. The compose `production-sso`
+  # profile provisions the Keycloak container — orthogonal to the license
+  # gate. SAML provider activation lands in Story 10.4.
   case-types:
     # Operators typically set WKS_CASE_TYPES_DIR to a mounted path in container.
     dir: ${WKS_CASE_TYPES_DIR:./case-types/}

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerTest.java
@@ -23,9 +23,11 @@ import com.wkspower.platform.domain.config.model.WorkflowRef;
 import com.wkspower.platform.domain.exception.ErrorDetail;
 import com.wkspower.platform.domain.port.UserRepository;
 import com.wkspower.platform.domain.service.ConfigService;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.domain.workflow.DeploymentResult;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import java.time.Instant;
 import java.util.List;
@@ -45,7 +47,12 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
  * path, validation aggregate, and the multipart 413 mapping.
  */
 @WebMvcTest(AdminController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@Import({
+  SecurityConfig.class,
+  GlobalExceptionHandler.class,
+  JwtAuthenticationFilter.class,
+  SamlGatingFilter.class
+})
 @ActiveProfiles("dev")
 class AdminControllerTest {
 
@@ -53,6 +60,7 @@ class AdminControllerTest {
   @MockitoBean private ConfigService configService;
   @MockitoBean private JwtTokenProvider jwtTokenProvider;
   @MockitoBean private UserRepository userRepository;
+  @MockitoBean private LicenseService licenseService;
 
   // ---- happy path --------------------------------------------------------
 

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AdminMappingInspectorControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AdminMappingInspectorControllerTest.java
@@ -18,10 +18,12 @@ import com.wkspower.platform.domain.port.CaseTypeRef;
 import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
 import com.wkspower.platform.domain.port.ExecutionSignalKind;
 import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.domain.service.MappingRegistry;
 import com.wkspower.platform.domain.service.SignalAuditRingBuffer;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import java.time.Instant;
 import java.util.List;
@@ -41,7 +43,12 @@ import org.springframework.test.web.servlet.MockMvc;
  * plus the {@code @PreAuthorize("hasRole('ADMIN')")} gate.
  */
 @WebMvcTest(AdminMappingInspectorController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@Import({
+  SecurityConfig.class,
+  GlobalExceptionHandler.class,
+  JwtAuthenticationFilter.class,
+  SamlGatingFilter.class
+})
 @ActiveProfiles("dev")
 class AdminMappingInspectorControllerTest {
 
@@ -51,6 +58,7 @@ class AdminMappingInspectorControllerTest {
   @MockitoBean private SignalAuditRingBuffer ringBuffer;
   @MockitoBean private JwtTokenProvider jwtTokenProvider;
   @MockitoBean private UserRepository userRepository;
+  @MockitoBean private LicenseService licenseService;
 
   // -- AC1 happy path ------------------------------------------------------
 

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AuthControllerTest.java
@@ -15,9 +15,11 @@ import com.wkspower.platform.api.GlobalExceptionHandler;
 import com.wkspower.platform.api.dto.request.LoginRequest;
 import com.wkspower.platform.domain.model.User;
 import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.security.AuthenticatedUser;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import com.wkspower.platform.security.SecurityConfig.ProductionProfile;
 import com.wkspower.platform.security.WksUserPrincipal;
@@ -50,7 +52,12 @@ import org.springframework.test.web.servlet.MvcResult;
  * WKS error envelopes instead of Spring's default 403 HTML.
  */
 @WebMvcTest(AuthController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@Import({
+  SecurityConfig.class,
+  GlobalExceptionHandler.class,
+  JwtAuthenticationFilter.class,
+  SamlGatingFilter.class
+})
 class AuthControllerTest {
 
   @Autowired private MockMvc mockMvc;
@@ -58,6 +65,7 @@ class AuthControllerTest {
 
   @MockitoBean private JwtTokenProvider jwtTokenProvider;
   @MockitoBean private UserRepository userRepository;
+  @MockitoBean private LicenseService licenseService;
   @MockitoBean private AuthenticationManager authenticationManager;
   @MockitoBean private ProductionProfile productionProfile;
 

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
@@ -32,10 +32,12 @@ import com.wkspower.platform.domain.page.Page;
 import com.wkspower.platform.domain.page.PageRequest;
 import com.wkspower.platform.domain.port.UserRepository;
 import com.wkspower.platform.domain.service.CaseService;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.security.AuthenticatedUser;
 import com.wkspower.platform.security.CaseTypePermissionEvaluator;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import com.wkspower.platform.security.WksUserPrincipal;
 import java.time.Instant;
@@ -56,7 +58,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 /** Slice test for {@link CaseController}. Covers the four endpoints + the SpEL permission gate. */
 @WebMvcTest(CaseController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@Import({
+  SecurityConfig.class,
+  GlobalExceptionHandler.class,
+  JwtAuthenticationFilter.class,
+  SamlGatingFilter.class
+})
 @ActiveProfiles("dev")
 class CaseControllerTest {
 
@@ -82,6 +89,7 @@ class CaseControllerTest {
 
   @MockitoBean JwtTokenProvider jwtTokenProvider;
   @MockitoBean UserRepository userRepository;
+  @MockitoBean LicenseService licenseService;
 
   // ---- POST /api/cases ---------------------------------------------------
 

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
@@ -23,10 +23,12 @@ import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.port.UserRepository;
 import com.wkspower.platform.domain.service.CaseService;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.security.AuthenticatedUser;
 import com.wkspower.platform.security.CaseTypePermissionEvaluator;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import com.wkspower.platform.security.WksUserPrincipal;
 import java.time.Instant;
@@ -47,7 +49,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 /** Slice test for {@link CaseController#transition}. Covers Story 2.4 AC1 contract. */
 @WebMvcTest(CaseController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@Import({
+  SecurityConfig.class,
+  GlobalExceptionHandler.class,
+  JwtAuthenticationFilter.class,
+  SamlGatingFilter.class
+})
 @ActiveProfiles("dev")
 class CaseTransitionControllerTest {
 
@@ -72,6 +79,7 @@ class CaseTransitionControllerTest {
 
   @MockitoBean JwtTokenProvider jwtTokenProvider;
   @MockitoBean UserRepository userRepository;
+  @MockitoBean LicenseService licenseService;
 
   @Test
   void transitionReturns200WithUpdatedCase() throws Exception {

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseTypeControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseTypeControllerTest.java
@@ -19,10 +19,12 @@ import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.domain.config.model.WorkflowRef;
 import com.wkspower.platform.domain.port.CaseTypeReader;
 import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.security.AuthenticatedUser;
 import com.wkspower.platform.security.CaseTypePermissionEvaluator;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import com.wkspower.platform.security.WksUserPrincipal;
 import java.util.List;
@@ -42,7 +44,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 /** Slice test for {@link CaseTypeController} (Story 2.5 AC9). */
 @WebMvcTest(CaseTypeController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@Import({
+  SecurityConfig.class,
+  GlobalExceptionHandler.class,
+  JwtAuthenticationFilter.class,
+  SamlGatingFilter.class
+})
 @ActiveProfiles("dev")
 class CaseTypeControllerTest {
 
@@ -57,6 +64,7 @@ class CaseTypeControllerTest {
 
   @MockitoBean JwtTokenProvider jwtTokenProvider;
   @MockitoBean UserRepository userRepository;
+  @MockitoBean LicenseService licenseService;
 
   // ---- GET /api/case-types (list) ---------------------------------------
 

--- a/backend/src/test/java/com/wkspower/platform/api/controller/HealthControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/HealthControllerTest.java
@@ -5,8 +5,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,13 +24,14 @@ import org.springframework.test.web.servlet.MockMvc;
  * not prove what it claims.
  */
 @WebMvcTest(HealthController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, SamlGatingFilter.class})
 class HealthControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
   @MockitoBean private JwtTokenProvider jwtTokenProvider;
   @MockitoBean private UserRepository userRepository;
+  @MockitoBean private LicenseService licenseService;
 
   @Test
   void healthReturnsEnvelopeWithVersionAndUptime() throws Exception {

--- a/backend/src/test/java/com/wkspower/platform/api/controller/LicenseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/LicenseControllerTest.java
@@ -17,6 +17,7 @@ import com.wkspower.platform.domain.service.WksFeature;
 import com.wkspower.platform.security.AuthenticatedUser;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import com.wkspower.platform.security.WksUserPrincipal;
 import java.time.Instant;
@@ -40,7 +41,7 @@ import org.springframework.test.web.servlet.MockMvc;
  * each {@link LicenseState} variant and that unauthenticated requests are rejected with 401.
  */
 @WebMvcTest(LicenseController.class)
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, SamlGatingFilter.class})
 class LicenseControllerTest {
 
   @Autowired MockMvc mockMvc;

--- a/backend/src/test/java/com/wkspower/platform/api/controller/TaskControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/TaskControllerTest.java
@@ -15,11 +15,13 @@ import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.model.Task;
 import com.wkspower.platform.domain.port.Clock;
 import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.domain.service.TaskService;
 import com.wkspower.platform.security.AuthenticatedUser;
 import com.wkspower.platform.security.CaseTypePermissionEvaluator;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import com.wkspower.platform.security.WksUserPrincipal;
 import java.time.Instant;
@@ -41,7 +43,12 @@ import org.springframework.test.web.servlet.MockMvc;
  * Slice test for {@link TaskController}. Covers complete + claim contract incl. all error codes.
  */
 @WebMvcTest(TaskController.class)
-@Import({SecurityConfig.class, GlobalExceptionHandler.class, JwtAuthenticationFilter.class})
+@Import({
+  SecurityConfig.class,
+  GlobalExceptionHandler.class,
+  JwtAuthenticationFilter.class,
+  SamlGatingFilter.class
+})
 @ActiveProfiles("dev")
 class TaskControllerTest {
 
@@ -61,6 +68,7 @@ class TaskControllerTest {
 
   @MockitoBean JwtTokenProvider jwtTokenProvider;
   @MockitoBean UserRepository userRepository;
+  @MockitoBean LicenseService licenseService;
 
   // ---- POST /api/tasks/{id}/complete -------------------------------------
 

--- a/backend/src/test/java/com/wkspower/platform/api/controller/ThemeControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/ThemeControllerTest.java
@@ -6,8 +6,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
+import com.wkspower.platform.security.SamlGatingFilter;
 import com.wkspower.platform.security.SecurityConfig;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -46,7 +48,7 @@ class ThemeControllerTest {
   // ---------------------------------------------------------------------------
 
   @WebMvcTest(ThemeController.class)
-  @Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+  @Import({SecurityConfig.class, JwtAuthenticationFilter.class, SamlGatingFilter.class})
   @TestPropertySource(properties = "wks.theme.css-path=")
   static class WhenNoCssPathConfigured {
 
@@ -54,6 +56,7 @@ class ThemeControllerTest {
 
     @MockitoBean private JwtTokenProvider jwtTokenProvider;
     @MockitoBean private UserRepository userRepository;
+    @MockitoBean private LicenseService licenseService;
 
     @Test
     void returns204WhenNoThemeConfigured() throws Exception {
@@ -76,7 +79,7 @@ class ThemeControllerTest {
   // ---------------------------------------------------------------------------
 
   @WebMvcTest(ThemeController.class)
-  @Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+  @Import({SecurityConfig.class, JwtAuthenticationFilter.class, SamlGatingFilter.class})
   @TestPropertySource(properties = "wks.theme.css-path=/tmp/nonexistent-99999.css")
   static class WhenFileIsMissing {
 
@@ -84,6 +87,7 @@ class ThemeControllerTest {
 
     @MockitoBean private JwtTokenProvider jwtTokenProvider;
     @MockitoBean private UserRepository userRepository;
+    @MockitoBean private LicenseService licenseService;
 
     @Test
     void returns204WhenFileIsMissing() throws Exception {
@@ -126,7 +130,7 @@ class ThemeControllerTest {
   }
 
   @WebMvcTest(ThemeController.class)
-  @Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+  @Import({SecurityConfig.class, JwtAuthenticationFilter.class, SamlGatingFilter.class})
   @ContextConfiguration(initializers = TestThemePathInitializer.class)
   static class WhenCssFileConfigured {
 
@@ -134,6 +138,7 @@ class ThemeControllerTest {
 
     @MockitoBean private JwtTokenProvider jwtTokenProvider;
     @MockitoBean private UserRepository userRepository;
+    @MockitoBean private LicenseService licenseService;
 
     @Test
     void returnsCssContentWhenThemeFileConfigured() throws Exception {

--- a/backend/src/test/java/com/wkspower/platform/api/error/ConfigProbeWebMvcTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/error/ConfigProbeWebMvcTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.wkspower.platform.api.GlobalExceptionHandler;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
+import com.wkspower.platform.security.SamlGatingFilter;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -26,7 +27,9 @@ import org.springframework.test.web.servlet.MockMvc;
     controllers = ConfigProbeController.class,
     excludeAutoConfiguration = {SecurityAutoConfiguration.class},
     excludeFilters =
-        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class))
+        @Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = {JwtAuthenticationFilter.class, SamlGatingFilter.class}))
 @Import(GlobalExceptionHandler.class)
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")

--- a/backend/src/test/java/com/wkspower/platform/api/pagination/PagingProbeWebMvcTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/pagination/PagingProbeWebMvcTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.wkspower.platform.api.GlobalExceptionHandler;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
+import com.wkspower.platform.security.SamlGatingFilter;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -30,7 +31,9 @@ import org.springframework.test.web.servlet.MockMvc;
     controllers = PagingProbeController.class,
     excludeAutoConfiguration = {SecurityAutoConfiguration.class},
     excludeFilters =
-        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class))
+        @Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = {JwtAuthenticationFilter.class, SamlGatingFilter.class}))
 @Import(GlobalExceptionHandler.class)
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/KeycloakSeamAnnouncerLicenseGateTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/KeycloakSeamAnnouncerLicenseGateTest.java
@@ -1,0 +1,75 @@
+package com.wkspower.platform.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.WksFeature;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Story 7-5 AC5 — verifies the announcer reads the gate from {@link LicenseService} (not the
+ * removed {@code wks.keycloak.enabled} env property) and emits the documented log lines for each
+ * branch. The WARN wire string {@code WKS-AUTH-001} is asserted verbatim because operators grep for
+ * it (Story 14.1.1 finding C4).
+ */
+class KeycloakSeamAnnouncerLicenseGateTest {
+
+  private ListAppender<ILoggingEvent> appender;
+  private Logger logger;
+
+  @BeforeEach
+  void attachAppender() {
+    logger = (Logger) LoggerFactory.getLogger(KeycloakSeamAnnouncer.class);
+    appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+  }
+
+  @AfterEach
+  void detachAppender() {
+    logger.detachAppender(appender);
+  }
+
+  @Test
+  void disabledFeatureEmitsInfoLine() {
+    LicenseService service = Mockito.mock(LicenseService.class);
+    when(service.isFeatureEnabled(WksFeature.AUTH_SSO)).thenReturn(false);
+
+    new KeycloakSeamAnnouncer(service).announce();
+
+    assertThat(appender.list).hasSize(1);
+    ILoggingEvent event = appender.list.get(0);
+    assertThat(event.getLevel()).isEqualTo(Level.INFO);
+    assertThat(event.getFormattedMessage())
+        .isEqualTo(
+            "WKS auth: built-in cookie-JWT (auth.sso disabled by license — Enterprise tier"
+                + " unlocks SSO; Story 10.4 will deliver the SAML provider).");
+  }
+
+  @Test
+  void enabledFeatureEmitsWarnWireString() {
+    LicenseService service = Mockito.mock(LicenseService.class);
+    when(service.isFeatureEnabled(WksFeature.AUTH_SSO)).thenReturn(true);
+
+    new KeycloakSeamAnnouncer(service).announce();
+
+    assertThat(appender.list).hasSize(1);
+    ILoggingEvent event = appender.list.get(0);
+    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+    // WKS-AUTH-001 wire string preserved verbatim — Story 14.1.1 AC3 finding C4.
+    assertThat(event.getFormattedMessage())
+        .isEqualTo(
+            "WKS-AUTH-001: Keycloak seam is currently INERT — built-in cookie-JWT remains the"
+                + " sole auth gate. SSO enforcement requires Story 10.4 (SAML via Keycloak realm)"
+                + " to land. To enforce auth posture, do NOT rely on this flag.");
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/security/SecurityConfigSamlGatingTest.java
+++ b/backend/src/test/java/com/wkspower/platform/security/SecurityConfigSamlGatingTest.java
@@ -1,0 +1,116 @@
+package com.wkspower.platform.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.domain.service.LicenseService;
+import com.wkspower.platform.domain.service.WksFeature;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Story 7-5 AC1 / AC2 / AC3 — verifies the SAML-path gate.
+ *
+ * <ul>
+ *   <li>AC1: feature off → 404 + {@code code=WKS-LIC-003}
+ *   <li>AC2: feature on → 401 fallthrough via {@link WksAuthenticationEntryPoint}
+ *   <li>AC3: hot-reload — flipping the mock between calls in the same Spring context changes the
+ *       gate state without {@code @DirtiesContext}
+ * </ul>
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:samlgating;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=",
+      "wks.bootstrap.production-validation.enabled=false"
+    })
+class SecurityConfigSamlGatingTest {
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private ObjectMapper json;
+  @MockBean private LicenseService licenseService;
+
+  @Test
+  void disabledFeatureReturnsNotFoundWithWksLic003() throws Exception {
+    when(licenseService.isFeatureEnabled(WksFeature.AUTH_SSO)).thenReturn(false);
+    when(licenseService.getTier()).thenReturn("oss");
+
+    ResponseEntity<String> response = rest.getForEntity("/api/auth/saml/metadata", String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    JsonNode body = json.readTree(response.getBody());
+    assertThat(body.path("code").asText()).isEqualTo("WKS-LIC-003");
+    assertThat(body.path("message").asText())
+        .isEqualTo("SSO/SAML is not available on the current license.");
+    assertThat(body.has("field")).isTrue();
+    assertThat(body.path("field").isNull()).isTrue();
+  }
+
+  @Test
+  void enabledFeatureFallsThroughToUnauthorized() {
+    when(licenseService.isFeatureEnabled(WksFeature.AUTH_SSO)).thenReturn(true);
+    when(licenseService.getTier()).thenReturn("enterprise");
+
+    ResponseEntity<String> response = rest.getForEntity("/api/auth/saml/metadata", String.class);
+
+    // No SAML provider on classpath yet (Story 10.4) — chain reaches FilterSecurityInterceptor
+    // which sees /api/**.authenticated() and the EntryPoint returns 401.
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  void hotReloadFlipsGateWithoutContextRebuild() throws Exception {
+    when(licenseService.isFeatureEnabled(WksFeature.AUTH_SSO)).thenReturn(false);
+    when(licenseService.getTier()).thenReturn("oss");
+
+    ResponseEntity<String> first = rest.getForEntity("/api/auth/saml/metadata", String.class);
+    assertThat(first.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(json.readTree(first.getBody()).path("code").asText()).isEqualTo("WKS-LIC-003");
+
+    // Simulate license hot-reload — same Spring context, same SecurityFilterChain bean.
+    when(licenseService.isFeatureEnabled(WksFeature.AUTH_SSO)).thenReturn(true);
+    when(licenseService.getTier()).thenReturn("enterprise");
+
+    ResponseEntity<String> second = rest.getForEntity("/api/auth/saml/metadata", String.class);
+    assertThat(second.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  void subPathsAreAlsoGated() {
+    when(licenseService.isFeatureEnabled(WksFeature.AUTH_SSO)).thenReturn(false);
+    when(licenseService.getTier()).thenReturn("oss");
+
+    for (String path :
+        new String[] {
+          "/api/auth/saml/metadata",
+          "/api/auth/saml/init",
+          "/api/auth/saml/acs",
+          "/api/auth/saml/logout"
+        }) {
+      ResponseEntity<String> r = rest.getForEntity(path, String.class);
+      assertThat(r.getStatusCode()).as("path=%s", path).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+  }
+
+  @Test
+  void nonSamlPathsAreUnaffected() {
+    when(licenseService.isFeatureEnabled(WksFeature.AUTH_SSO)).thenReturn(false);
+
+    // /api/cases is /api/** but not /api/auth/saml/** — must still 401 via the normal entry
+    // point, not 404 from the gate.
+    ResponseEntity<String> response = rest.getForEntity("/api/cases", String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/security/SecurityConfigSamlGatingTest.java
+++ b/backend/src/test/java/com/wkspower/platform/security/SecurityConfigSamlGatingTest.java
@@ -1,6 +1,8 @@
 package com.wkspower.platform.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -13,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -40,6 +43,7 @@ class SecurityConfigSamlGatingTest {
 
   @Autowired private TestRestTemplate rest;
   @Autowired private ObjectMapper json;
+  @Autowired private ApplicationContext ctx;
   @MockBean private LicenseService licenseService;
 
   @Test
@@ -72,6 +76,9 @@ class SecurityConfigSamlGatingTest {
 
   @Test
   void hotReloadFlipsGateWithoutContextRebuild() throws Exception {
+    // Capture the SamlGatingFilter bean identity BEFORE the first hit.
+    SamlGatingFilter filterBefore = ctx.getBean(SamlGatingFilter.class);
+
     when(licenseService.isFeatureEnabled(WksFeature.AUTH_SSO)).thenReturn(false);
     when(licenseService.getTier()).thenReturn("oss");
 
@@ -85,6 +92,16 @@ class SecurityConfigSamlGatingTest {
 
     ResponseEntity<String> second = rest.getForEntity("/api/auth/saml/metadata", String.class);
     assertThat(second.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+    // The exact same SamlGatingFilter bean instance handled both requests — no context rebuild,
+    // no proxy swap, no bean re-creation between the OSS hit and the Enterprise hit.
+    SamlGatingFilter filterAfter = ctx.getBean(SamlGatingFilter.class);
+    assertThat(filterAfter).isSameAs(filterBefore);
+
+    // Per-request consultation: the filter must call LicenseService.isFeatureEnabled(AUTH_SSO)
+    // exactly once per SAML-path request — never cached on the filter side. Two SAML hits ⇒
+    // two consultations.
+    verify(licenseService, times(2)).isFeatureEnabled(WksFeature.AUTH_SSO);
   }
 
   @Test

--- a/docker/.env.production.example
+++ b/docker/.env.production.example
@@ -66,11 +66,11 @@ WKS_OPENAPI_ENABLED=false
 # by the frontend at startup. Unset (default) → no override; defaults apply.
 WKS_THEME_CSS_PATH=
 
-# Keycloak/SSO seam — RESERVED forward-compat seam for Story 10.4. Setting
-# this to `true` today logs a WARN at boot (WKS-AUTH-001) and changes NOTHING
-# about auth enforcement. Built-in cookie-JWT (Story 1.2) is the sole auth
-# gate until Story 10.4 ships. (Story 14.1.1 AC4 wording.)
-WKS_KEYCLOAK_ENABLED=false
+# Keycloak/SSO seam — gated by the auth.sso license feature flag since Story
+# 7-5. Operators no longer toggle this directly; the announcer reads
+# LicenseService.isFeatureEnabled(AUTH_SSO). Enterprise / Demo licenses unlock
+# the surface; Story 10.4 will deliver the SAML provider. Stacking
+# docker-compose.sso.yml still provisions a Keycloak container ahead of 10.4.
 
 # ----- Compose-only keys (provision the bundled containers) -----
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -36,9 +36,9 @@ The `docker/.env` file is gitignored (Story 14.1.1 fix-up — no longer tracked)
 docker compose -f docker/docker-compose.prod.yml -f docker/docker-compose.sso.yml up
 ```
 
-`WKS_KEYCLOAK_ENABLED` is **RESERVED — forward-compat seam for Story 10.4. Setting this to `true` today logs a WARN at boot and changes NOTHING about auth enforcement. Built-in cookie-JWT is the sole auth gate until Story 10.4 ships.** (Story 14.1.1 AC4, finding C4.) Stacking `docker-compose.sso.yml` provisions a Keycloak container so realms can be pre-baked ahead of 10.4, but no WKS code path consumes the container until 10.4 wires the SAML adapter. Realms / clients are NOT pre-configured — Story 10.4 owns that.
+The Keycloak/SSO seam is **gated by the `auth.sso` license feature flag since Story 7-5.** Operators no longer toggle it directly — the announcer reads `LicenseService.isFeatureEnabled(AUTH_SSO)` at startup and per request. Enterprise / Demo licenses unlock the surface (the seam announces and `/api/auth/saml/**` paths fall through to the security chain, currently returning 401 until Story 10.4); OSS / Team / Expired / Degraded licenses 404 the SAML paths with `WKS-LIC-003`. Stacking `docker-compose.sso.yml` provisions a Keycloak container so realms can be pre-baked ahead of Story 10.4, but no WKS code path consumes the container until 10.4 wires the SAML adapter. Realms / clients are NOT pre-configured — Story 10.4 owns that.
 
-When `WKS_KEYCLOAK_ENABLED=true` the application emits `WKS-AUTH-001` at WARN explicitly stating the seam is INERT.
+When the license unlocks SSO, the application emits `WKS-AUTH-001` at WARN explicitly stating the seam is INERT (Story 14.1.1 AC4 wire string preserved — only the trigger source changed in Story 7-5).
 
 ## Production rotation guidance (Story 14.1.1 AC7)
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -51,7 +51,6 @@ services:
       WKS_CORS_ORIGINS: ${WKS_CORS_ORIGINS:-}
       WKS_JWT_SECRET: ${WKS_JWT_SECRET}
       WKS_OPENAPI_ENABLED: ${WKS_OPENAPI_ENABLED:-false}
-      WKS_KEYCLOAK_ENABLED: ${WKS_KEYCLOAK_ENABLED:-false}
       # Consumed by ProductionBootstrapValidator AC7 for boot-time secret-rotation;
       # app does not use these at runtime; minio container is the actual consumer.
       WKS_MINIO_ROOT_USER: ${WKS_MINIO_ROOT_USER}


### PR DESCRIPTION
## Summary

Story 7-5 — gates the `/api/auth/saml/**` surface behind the `auth.sso` license feature flag and rewires `KeycloakSeamAnnouncer` off the operator-direct `WKS_KEYCLOAK_ENABLED` env property onto `LicenseService`. First feature-flag wiring on the auth surface; handoff seam for Story 10.4 SAML provider.

## ACs

- [x] **AC1** — `SamlGatingFilter` returns 404 + `WKS-LIC-003` on `/api/auth/saml/**` when `AUTH_SSO` disabled. Envelope shape matches `WksAuthenticationEntryPoint` (`code`/`message`/`field`) per Task 1; story literal text said `errorCode` but Task 1 explicitly binds to the existing envelope — deviation documented.
- [x] **AC2** — `AUTH_SSO` licensed → gate is no-op, chain falls through, 401 via existing `WksAuthenticationEntryPoint`. Handoff for Story 10.4.
- [x] **AC3** — Per-request consultation, no bean rebuild. IT flips `@MockBean LicenseService` across calls in same Spring context (no `@DirtiesContext`); review remediation strengthens this assertion with bean-identity capture + `Mockito.verify(times(2))`.
- [ ] **AC4 — N/A — no existing audit emitter to enrich; story assumption incorrect on tip `323860c7e`.** Neither `AuthController.login()` nor `JwtAuthenticationFilter` emits an audit line today, and AC text explicitly says "do NOT introduce a new audit emitter." Carried forward to the future login-audit story.
- [x] **AC5** — `KeycloakSeamAnnouncer` constructor-injects `LicenseService`. `WKS-AUTH-001` WARN wire string preserved verbatim (operators grep it — Story 14.1.1 finding C4). `wks.keycloak.enabled` / `WKS_KEYCLOAK_ENABLED` removed from `application-production.yml`, `docker-compose.prod.yml`, `ci.yml`, `docker/.env.production.example`, `docker/README.md`. `--profile production-sso` compose flag preserved (orthogonal to the license gate).

## Postgres-IT parity

**Declared: N/A.** No DB code paths. Test-double `LicenseService` via `@MockBean` / `Mockito.mock` is H2-sufficient.

`find . -name "*PostgresIT.java" -path "*saml*"` returns nothing — confirmed.

## Flyway

**None.** No schema changes. Slot pre-assignment (sprint-status.yaml line 482) confirmed unused.

## New error codes

- `WKS-LIC-003` — SSO unavailable on current license tier (404). Next-free slot at story-implementation time in the `WKS-LIC-001..099` band (001 + 002 allocated in 7.1). Verified against `ErrorCode.java` lines 472–488 on tip `323860c7e`.
- `WKS-LIC-004` — *(review remediation)* SSO availability could not be determined because `LicenseService` threw mid-consultation. Filter fails CLOSED (404, same shape as 003) and logs the cause at WARN. Next-free slot after 003.

## Compat-ctor grep

**N/A.** Surface lists none of `CaseTypeConfig.java`, `FormDefinition.java`, `StageDefinition.java`, `RawFormDefinition.java`, `RawCaseTypeConfig.java`.

## Filter ordering

`SamlGatingFilter` is registered before `UsernamePasswordAuthenticationFilter` (the Spring-registered marker class), NOT before `JwtAuthenticationFilter`. Reason: `JwtAuthenticationFilter` has no Spring-registered order so `addFilterBefore(filter, JwtAuthenticationFilter.class)` fails with `"The Filter class JwtAuthenticationFilter does not have a registered order"`. Insertion order within the same Spring filter slot preserves the intended runtime sequence: SAML gate runs before JWT auth.

## Deviations from story spec

1. **Envelope shape on AC1.** Story AC1 literal says `{"errorCode": ..., "message": ...}`. Task 1 says "Reuse the existing `WksAuthenticationEntryPoint` JSON envelope shape... Confirm the field names by reading `WksAuthenticationEntryPoint.commence()` before writing the filter." Followed Task 1. Envelope is `{"code": "WKS-LIC-003", "message": "...", "field": null}` — consistent with the rest of the WKS error surface.

2. **AC4 marked N/A.** No existing login audit emitter to enrich. AC text explicitly says "do NOT introduce a new audit emitter." Story creator's assumption that `AuthController.login()` or `JwtAuthenticationFilter` already emits an audit line is incorrect on tip `323860c7e`.

3. **Filter ordering** as documented above.

## Deferred from review

The following review observations are deliberately deferred (not blocking) — captured here so they don't get lost:

- **Filter ordering pinned only by comment, not `@Order`.** Today the SAML gate runs before JWT auth purely by Spring Security's preservation of `addFilterBefore` registration order within the same slot. Annotate `SamlGatingFilter` and `JwtAuthenticationFilter` with explicit `@Order` values when Story 10.4 lands.
- **`licenseService.getTier()` in the DEBUG log line.** Low-risk tier-name fingerprint exposure (debug-level only, never on the wire). Revisit when the license-audit story lands.
- **Story 10.4 follow-up — permitAll matchers.** This filter only gates *availability*; it does not grant access. When Story 10.4 wires the real SAML provider it must add `/api/auth/saml/**` to `SecurityConfig.authorizeHttpRequests(...).permitAll()` (or equivalent), otherwise the `auth.sso`-on path will still 401 instead of reaching the SAML controller. Carry-forward into 10.4 dev notes.

## CI gauntlet — local results

Every `ci.yml` step run verbatim before push (per `feedback_match_ci_locally`):

| Step | Result |
|---|---|
| `mvn -B verify` (backend) | 570 unit + 162 IT, 0 failures, 1 pre-existing skip — GREEN |
| `check-tenant-invariant.sh` | OK |
| `shellcheck deploy/wks-deploy.sh + check-runtime-no-tenant-id.sh` | OK |
| Frontend `npm ci && npm run lint && npm run format:check && npm test && npm run build` | 348 tests pass, 4 woff2, build OK |
| Docker buildx | **CI-only** (no Dockerfile change in this story) |
| Production-profile-smoke | **CI-only** (no production-stack change — only removes a no-op env var inject) |

Re-run after review remediation commits — see CI status on this PR.

## Test plan

- [ ] CI green on PR (post-remediation)
- [ ] Reviewer confirms WKS-LIC-004 fail-closed semantics
- [ ] Reviewer confirms envelope-shape deviation (`code` vs `errorCode`)
- [ ] Spot-check filter ordering rationale
- [ ] Confirm WKS-LIC-003/004 still free at merge time (Sprint 10 parallel stories may shift adjacent bands)

## Cross-story collision verification (Sprint 10)

- 3-9: AdminController + ConfigService migrate — **no overlap**
- 5-5: FormController + FormDefinition record — **no overlap**
- 6-2: ExecutionSignalRouter + frontend task dialog — **no overlap**

7-5 owns `SecurityConfig.securityFilterChain` bean + `KeycloakSeamAnnouncer` + 13 controller-slice tests (additive). Last-merger rebases are mechanical.

## Recovery note

This PR was implemented in foreground by the orchestrator after the assigned background dev agent terminated mid-implementation (content-filter block, ~40% through). WIP `SamlGatingFilter` + `ErrorCode.WKS_LIC_003` were preserved at snapshot commit `b854012cb`; this PR completes AC1/AC2/AC3/AC5 and marks AC4 N/A per the deviation rationale above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
