### PR TITLE
[docs] DOCS-4: deploy-to-production + env-vars reference

### DIFF
--- a/docs/PLAN-modernization.md
+++ b/docs/PLAN-modernization.md
@@ -1,0 +1,136 @@
+# wks-docs modernization plan
+
+Outside sprint/epic tracking. Five independent tracks, each one PR off `v2-develop`.
+
+**Stack:** fumadocs 15 / Next.js 15 / Tailwind. Source: `content/docs/**/*.mdx`. Nav: `meta.json` per folder.
+
+**Strategic role:** activation funnel between wks-website (conversion) and a running local instance. Optimizes for SI-dev evaluation and SI-architect "coming from Camunda."
+
+## Conventions
+
+- Branch per track: `docs/<N>-<slug>` off `v2-develop`.
+- Worktree per track: `../wks-platform-docs-<N>-<slug>/`.
+- PR title prefix: `[docs]` — keeps these visually distinct from Sprint PRs.
+- No Flyway, no ErrorCode, no backend, no sprint-status entry, no epic linkage.
+- All paths below are relative to `wks-platform/docs/`.
+
+---
+
+## DOCS-1 — Brand bridge
+
+**Goal:** visual continuity with `wks-website`. After this, every doc page inherits the right tokens for free.
+
+**Surface:**
+- `app/layout.tsx` — wrap `RootProvider` with CSS-vars override mirroring `wks-website/src/styles/global.css` (`--color-primary`, `--color-brand-navy`, `--color-brand-cyan`, Poppins/Rubik/JetBrains Mono).
+- `public/fonts/` — port the four woff2 files from `wks-website/public/fonts/`.
+- `app/docs/layout.tsx` — replace `nav={{ title: 'WKS Platform' }}` with a custom navbar component mirroring `wks-website` `StageNav` links (Overview / Demo / Proof / Product / Pricing) targeting `https://wkspower.com/*`, plus GitHub.
+- `components/DocsFooter.tsx` (new) — React port of `wks-website/src/components/AuditStrip.astro`.
+
+**ACs:**
+1. Theme tokens visible: primary buttons/links render `#3B5BDB`; headings use Poppins.
+2. Navbar shows StageNav links pointing to product site; GitHub link present.
+3. Footer renders on every docs page.
+4. Lighthouse a11y score ≥ 95 (the product site's bar).
+5. No content changes — only chrome.
+
+**Est:** ~150 LOC, one session.
+
+---
+
+## DOCS-2 — Cases-first concept page
+
+**Goal:** unblock the mental-model entry point. This is the principle inversion (locked 2026-04-27) and the single most strategically important concept page.
+
+**Surface:**
+- `content/docs/concepts/cases-first-processes-optional.mdx` — replace stub with full page.
+
+**Source:** `wks-platform2/_bmad-output/planning-artifacts/CONCEPTS.md §principle inversion`. Voice-rules pass only — content already comprehensive.
+
+**ACs:**
+1. Page opens with the inversion stated in one sentence.
+2. Side-by-side diagram or table: "Camunda mental model" vs "WKS mental model."
+3. Concrete walk-through: zero-stage case → add stages → attach BPMN — each step framed as additive.
+4. Closes with link to `/docs/start/your-first-case-type` and `/docs/concepts/coming-from-camunda`.
+
+**Est:** content-only, one session.
+
+---
+
+## DOCS-3 — YAML schema reference
+
+**Goal:** SIs cannot evaluate without a complete reference page. Handwritten now; auto-generation later.
+
+**Surface:**
+- `content/docs/reference/yaml-schema.mdx` — replace stub.
+
+**ACs:**
+1. Every top-level YAML key documented: `id`, `displayName`, `version`, `description`, `roles`, `stages`, `forms`, `statuses`, `workflows`, `attachments`, `mapping`.
+2. For each key: type, required/optional, default, validator citation (file:line in `wks-platform`), and a minimal example.
+3. One complete example case-type YAML at the bottom exercising every key.
+4. Cross-links to validator error codes in `reference/error-codes.mdx`.
+
+**Est:** content-only, one session. Citations require grep against `wks-platform/backend/` validators.
+
+---
+
+## DOCS-4 — Deploy-to-production ops page
+
+**Goal:** turn "I demoed it" into "I shipped it for a client." Required for the Managed Hosting tier to be credible.
+
+**Surface:**
+- `content/docs/operations/deploy-to-production.mdx` — replace stub.
+- `content/docs/reference/environment-variables.mdx` — populate (currently stub).
+
+**ACs:**
+1. docker-compose example with Postgres + MinIO + production profile.
+2. Required env vars table — sourced from `wks-platform/backend/src/main/resources/application-production.yml` and Spring `@ConfigurationProperties` classes.
+3. `wks.bootstrap.production-validation.enabled` switch documented (per memory `project_postgres_it_parity_gap.md` family).
+4. Smoke check: `curl /api/health` + Postgres migration count assertion.
+5. Two-switch Keycloak seam (`WKS_KEYCLOAK_ENABLED` + `--profile production-sso`) documented per Story 14.1 milestone.
+
+**Est:** content-only, one session.
+
+---
+
+## DOCS-5 — IA cleanup + landing page
+
+**Goal:** fix navigation defects + replace the bare redirect with a persona router.
+
+**Surface:**
+- `content/docs/start/meta.json` — drop `demo-to-a-client`, add `coming-from-camunda` (move file from `concepts/`).
+- `content/docs/concepts/meta.json` — remove `coming-from-camunda`.
+- `content/docs/meta.json` — reorder to `start, concepts, guides, operations, reference`.
+- `content/docs/guides/meta.json` — add `demo-to-a-client` here.
+- `app/page.tsx` — replace `redirect('/docs')` with a real landing page using DOCS-1 design tokens.
+- New: `app/components/PersonaCard.tsx`.
+
+**Landing page personas (four cards):**
+- "New to WKS" → `/docs/start/run-wks-in-5-minutes`
+- "Coming from Camunda" → `/docs/start/coming-from-camunda`
+- "Going to production" → `/docs/operations/deploy-to-production`
+- "API & schema reference" → `/docs/reference/yaml-schema`
+
+**ACs:**
+1. `/` renders persona-router, not a redirect.
+2. All internal links resolve (no 404s after `meta.json` moves).
+3. Visual identity matches DOCS-1.
+4. Mobile-responsive (test ≤ 640px).
+
+**Depends on:** DOCS-1 merged (uses its tokens). Ideally DOCS-2/3/4 merged too so the landing's "Going to production" and "API reference" links don't land on stubs — but not strictly required.
+
+**Est:** ~200 LOC, one session.
+
+---
+
+## Suggested order
+
+1. **DOCS-1** first — unlocks visual identity for everything else.
+2. **DOCS-2 / DOCS-3 / DOCS-4** in any order (or parallel worktrees if desired) — pure content, no shared files.
+3. **DOCS-5** last — wants the design tokens and ideally the populated reference pages.
+
+## What's intentionally deferred
+
+- Filling the other 18 stub pages — fold into next-touching backend story per existing memory rule.
+- Search config / "edit on GitHub" / feedback widget.
+- Error-code auto-generation (spec exists at `wks-platform2/docs/error-codes-automation-spec.md` — defer).
+- Versioned docs (per-release branches) — not needed before public launch.

--- a/docs/content/docs/operations/deploy-to-production.mdx
+++ b/docs/content/docs/operations/deploy-to-production.mdx
@@ -2,11 +2,238 @@
 title: Deploy to production
 description: One-command per-client deployment — from zero to a running WKS instance in under 2 hours.
 gate: "3"
-status: stub
-source: docs/ops/per-client-deploy-runbook.md (Story 14-7)
 ---
 
-{/* Source material is complete. Needs voice-rules pass and removal of internal references. */}
-{/* Owner: Victor (with Claude) */}
+A local demo proves the concept. A production deployment proves it to your client. WKS is designed for isolated per-client instances: one Postgres database, one MinIO object-store, one URL, one license — no shared infrastructure, no `tenant_id`, no row-level gymnastics. Each deployment is a three-container stack you bring up with a single `docker compose` command.
 
-TODO: content — migrate and polish from docs/ops/per-client-deploy-runbook.md
+## Quick start
+
+Copy the example env file, rotate every sentinel, then start the stack:
+
+```bash
+cp docker/.env.production.example docker/.env
+# Generate secrets — examples below.
+# Replace every <MUST-BE-ROTATED> value before the next step.
+docker compose -f docker/docker-compose.prod.yml up -d
+```
+
+Generate secrets with:
+
+```bash
+openssl rand -base64 32   # use for passwords and storage keys
+openssl rand -base64 48   # use for WKS_JWT_SECRET (needs ≥32 bytes after decode)
+```
+
+## docker-compose example
+
+The compose file at `docker/docker-compose.prod.yml` is the authoritative single-tenant production surface. It brings up three services:
+
+```yaml
+services:
+  wks-platform-prod:
+    image: wkspower/wks-platform:2.0.0-prod
+    container_name: wks-platform-prod
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    ports:
+      - "${WKS_HOST_PORT:-8080}:8080"
+    environment:
+      TZ: UTC
+      SPRING_PROFILES_ACTIVE: production
+      WKS_DB_URL: ${WKS_DB_URL}
+      WKS_DB_USER: ${WKS_DB_USER}
+      WKS_DB_PASSWORD: ${WKS_DB_PASSWORD}
+      WKS_STORAGE_ENDPOINT: ${WKS_STORAGE_ENDPOINT}
+      WKS_STORAGE_KEY: ${WKS_STORAGE_KEY}
+      WKS_ADMIN_EMAIL: ${WKS_ADMIN_EMAIL}
+      WKS_ADMIN_PASSWORD: ${WKS_ADMIN_PASSWORD}
+      WKS_JWT_SECRET: ${WKS_JWT_SECRET}
+      WKS_MINIO_ROOT_USER: ${WKS_MINIO_ROOT_USER}
+      WKS_MINIO_ROOT_PASSWORD: ${WKS_MINIO_ROOT_PASSWORD}
+      WKS_LOCALE: ${WKS_LOCALE:-en-IN}
+      WKS_CORS_ORIGINS: ${WKS_CORS_ORIGINS:-}
+      WKS_KEYCLOAK_ENABLED: ${WKS_KEYCLOAK_ENABLED:-false}
+      WKS_OPENAPI_ENABLED: ${WKS_OPENAPI_ENABLED:-false}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/api/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 30s
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: wks-postgres
+    environment:
+      POSTGRES_DB: wks
+      POSTGRES_USER: ${WKS_DB_USER}
+      POSTGRES_PASSWORD: ${WKS_DB_PASSWORD}
+    volumes:
+      - wks-pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${WKS_DB_USER} -d wks"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: wks-minio
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: ${WKS_MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${WKS_MINIO_ROOT_PASSWORD}
+    volumes:
+      - wks-miniodata:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/ready || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+
+volumes:
+  wks-pgdata:
+    driver: local
+  wks-miniodata:
+    driver: local
+```
+
+The application waits for Postgres and MinIO healthchecks before starting. Flyway runs its migrations on boot; `ddl-auto: validate` confirms schema parity after each migration run.
+
+**Running multiple instances on the same host:** set `COMPOSE_PROJECT_NAME` per deploy to scope named volumes and container names:
+
+```bash
+COMPOSE_PROJECT_NAME=wks-clientA docker compose -f docker/docker-compose.prod.yml up -d
+COMPOSE_PROJECT_NAME=wks-clientB docker compose -f docker/docker-compose.prod.yml up -d
+```
+
+## Required environment variables
+
+These vars have no defaults and cause a hard startup failure if unset. The bootstrap validator (`WKS-API-055`) enforces rotation — any var still holding its `<MUST-BE-ROTATED>` sentinel from `.env.production.example` aborts startup.
+
+| Variable | Description | Generate with |
+|----------|-------------|---------------|
+| `WKS_DB_URL` | JDBC connection string — must be `jdbc:postgresql://...` | Postgres host + credentials |
+| `WKS_DB_USER` | Postgres role name | operator-chosen |
+| `WKS_DB_PASSWORD` | Postgres role password | `openssl rand -base64 32` |
+| `WKS_STORAGE_ENDPOINT` | MinIO URL (`http://minio:9000`) | MinIO host |
+| `WKS_STORAGE_KEY` | MinIO secret key | `openssl rand -base64 32` |
+| `WKS_ADMIN_EMAIL` | First-boot admin login email | operator-chosen |
+| `WKS_ADMIN_PASSWORD` | First-boot admin login password | `openssl rand -base64 24` |
+| `WKS_JWT_SECRET` | Base64-encoded HMAC key (≥32 bytes after decode) | `openssl rand -base64 48` |
+| `WKS_MINIO_ROOT_USER` | MinIO root user identifier | operator-chosen |
+| `WKS_MINIO_ROOT_PASSWORD` | MinIO root password | `openssl rand -base64 32` |
+
+For the full variable reference — including optional vars, defaults, and which Spring property each maps to — see [Environment variables](/docs/reference/environment-variables).
+
+## Bootstrap validation
+
+WKS runs two fail-closed validators at startup when `SPRING_PROFILES_ACTIVE=production`:
+
+**WKS-API-053 — datasource must be Postgres.** The production profile hard-overrides the datasource driver to `org.postgresql.Driver`. At boot, the validator opens a test connection and reads the database product name; if it resolves to H2, startup is aborted. This catches misconfigured `WKS_DB_URL` values before any traffic is served.
+
+**WKS-API-055 — required env vars must be rotated.** The validator reads every required env var directly from the OS environment (not from Spring's property resolution — YAML defaults cannot satisfy this check). Any var that is unset or still equals `<MUST-BE-ROTATED>` causes a startup failure listing every offending var by name.
+
+Both validators activate by default (`matchIfMissing = true`). The switch to disable them is:
+
+```
+WKS_BOOTSTRAP_PRODUCTION_VALIDATION_ENABLED=false
+```
+
+**When to disable:** only in integration tests that activate the production profile against an H2 datasource or with incomplete env-var fixtures. Never disable in a live deployment.
+
+Source: `backend/src/main/java/com/wkspower/platform/infrastructure/config/ProductionBootstrapValidator.java`
+
+## SSO seam (Keycloak)
+
+WKS has a forward-compatible SSO seam with two independent switches. The switches are orthogonal — enabling one without the other is intentional in certain stages.
+
+**Switch 1 — provision the Keycloak container:**
+
+```bash
+docker compose \
+  -f docker/docker-compose.prod.yml \
+  -f docker/docker-compose.sso.yml \
+  up -d
+```
+
+`docker-compose.sso.yml` adds a `keycloak` service (image `quay.io/keycloak/keycloak:26.0.5`) on port `${WKS_KEYCLOAK_PORT:-8081}`. This allows operators to pre-bake Keycloak realms ahead of the SSO integration landing.
+
+**Switch 2 — tell the WKS app Keycloak is provisioned:**
+
+```bash
+WKS_KEYCLOAK_ENABLED=true
+```
+
+Maps to `wks.keycloak.enabled` in `application-production.yml`. Default: `false`.
+
+**Important:** `WKS_KEYCLOAK_ENABLED=true` is currently a **forward-compat seam only**. It logs a `WKS-AUTH-001 WARN` at boot explicitly stating the seam is inert. Built-in cookie-JWT (`WKS_JWT_SECRET`) remains the sole auth gate until Story 10.4 (SAML via Keycloak) ships. Setting this flag does not enforce SSO; it signals to the `KeycloakSeamAnnouncer` that a Keycloak container is reachable.
+
+Summary:
+
+| State | Effect |
+|-------|--------|
+| Neither switch set | Built-in cookie-JWT auth active; no Keycloak container |
+| `docker-compose.sso.yml` stacked, `WKS_KEYCLOAK_ENABLED=false` | Keycloak container running; WKS logs INFO that SSO is disabled |
+| `docker-compose.sso.yml` stacked, `WKS_KEYCLOAK_ENABLED=true` | Keycloak container running; WKS emits `WKS-AUTH-001 WARN` — seam is inert, cookie-JWT still active |
+| SSO enforcement | Requires Story 10.4 to land (not yet available) |
+
+Source: `backend/src/main/java/com/wkspower/platform/infrastructure/config/KeycloakSeamAnnouncer.java`
+
+## Smoke check
+
+Run these after `docker compose up` reports all containers healthy.
+
+**1. Application health:**
+
+```bash
+curl -s http://localhost:8080/api/health | jq .
+```
+
+Expected response:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "version": "2.0.0",
+    "uptime": "PT12.345S"
+  }
+}
+```
+
+HTTP 200 confirms the application started and Flyway migrations completed. A non-200 or connection refused means the `start_period` has not elapsed — wait 30 seconds and retry.
+
+**2. Postgres migration count:**
+
+Connect to the Postgres container and verify Flyway applied its full migration set:
+
+```bash
+docker exec -it wks-postgres \
+  psql -U "${WKS_DB_USER}" -d wks \
+  -c "SELECT count(*) FROM flyway_schema_history WHERE success = true;"
+```
+
+Expected output: a count greater than 10. The exact number grows with each release. A count of 0 means Flyway did not run (check startup logs). A `relation "flyway_schema_history" does not exist` error means the schema was not created — verify `WKS_DB_URL` and that the Postgres container is the one WKS connected to.
+
+**3. Rollback (data-preserving):**
+
+```bash
+docker compose -f docker/docker-compose.prod.yml down
+# Volumes are retained. Restart later with `up`.
+```
+
+**4. Full teardown (irreversible):**
+
+```bash
+docker compose -f docker/docker-compose.prod.yml down -v
+# Removes wks-pgdata and wks-miniodata. This is the GDPR-delete path.
+```

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -2,12 +2,152 @@
 title: Environment variables
 description: All WKS_* environment variables — what they control, their defaults, and whether they are required.
 gate: "3"
-status: needs-writing
-source: architecture AR-18
 ---
 
-{/* AR-18 list: WKS_DB_URL, WKS_DB_USER, WKS_DB_PASSWORD, WKS_STORAGE_ENDPOINT, */}
-{/* WKS_STORAGE_KEY, WKS_CORS_ORIGINS, WKS_LOCALE */}
-{/* Owner: Victor (with Claude) */}
+All configuration in the WKS production profile is delivered through environment variables. No secrets are baked into the image; the image itself has no production defaults. The sections below map each `WKS_*` variable to its Spring property, document its type and default, and cite the source file where the binding is declared.
 
-TODO: content
+Variables marked **required** have no default and cause a hard startup failure if unset. Variables marked **required (rotated)** additionally fail startup if they still equal the `<MUST-BE-ROTATED>` sentinel from `docker/.env.production.example` — enforced by `ProductionBootstrapValidator` (`WKS-API-055`).
+
+---
+
+## Datasource (`spring.datasource`)
+
+Binding: `DataSourceConfig.java` (`@ConfigurationProperties("spring.datasource")`) and `application-production.yml` lines 22–28.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `WKS_DB_URL` | String | — | **required** | JDBC connection string. Must be `jdbc:postgresql://host:5432/dbname`. Any `jdbc:h2:` value aborts startup with `WKS-API-053`. |
+| `WKS_DB_USER` | String | — | **required** | Postgres role name used by the connection pool. |
+| `WKS_DB_PASSWORD` | String | — | **required (rotated)** | Postgres role password. `ProductionBootstrapValidator` (`WKS-API-055`) aborts startup if unrotated. |
+
+The production profile hard-overrides `spring.datasource.driver-class-name` to `org.postgresql.Driver` and excludes H2 autoconfig entirely (`spring.autoconfigure.exclude`). These overrides live in `application-production.yml` and are not operator-configurable.
+
+---
+
+## Security / JWT (`wks.admin`, `wks.jwt`)
+
+Binding: `application.yml` lines 72–77.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `WKS_ADMIN_EMAIL` | String | — | **required (rotated)** | Email address used to create the first-boot admin account. |
+| `WKS_ADMIN_PASSWORD` | String | — | **required (rotated)** | Password for the first-boot admin account. |
+| `WKS_JWT_SECRET` | String | — | **required (rotated)** | Base64-encoded HMAC key used to sign session JWTs. Must decode to ≥ 32 bytes. Generate with `openssl rand -base64 48`. |
+| `WKS_JWT_TTL_HOURS` | Integer | `8` | optional | Session token lifetime in hours. Default 8 hours. Maps to `wks.jwt.ttl-hours`. |
+
+---
+
+## CORS (`wks.cors`)
+
+Binding: `application.yml` line 79; production override `application-production.yml` line 68.
+
+| Variable | Type | Default (production) | Required | Description |
+|----------|------|----------------------|----------|-------------|
+| `WKS_CORS_ORIGINS` | String (comma-separated) | `""` (empty) | optional | Allowed CORS origins for the REST API. Set to your frontend domain in production (e.g. `https://app.example.com`). Empty string disables cross-origin access. |
+
+---
+
+## Storage / MinIO (`wks.storage`, `wks.documents`)
+
+Binding: `application-production.yml` lines 69–75.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `WKS_STORAGE_ENDPOINT` | String | `""` | **required** | MinIO server URL including scheme and port (e.g. `http://minio:9000`). Empty string falls back to `LocalDocumentStore` (dev mode only). |
+| `WKS_STORAGE_KEY` | String | `""` | **required (rotated)** | MinIO secret key for the WKS service account. The matching access key is `WKS_MINIO_ROOT_USER`. |
+| `WKS_STORAGE_BUCKET` | String | `wks-documents` | optional | S3/MinIO bucket name for document storage. Maps to `wks.documents.bucket`. |
+| `WKS_MINIO_ROOT_USER` | String | — | **required (rotated)** | MinIO root user identifier. Used by `ProductionBootstrapValidator` (`WKS-API-055`) to verify rotation; the WKS app does not consume this at runtime — it is the MinIO container's admin login. |
+| `WKS_MINIO_ROOT_PASSWORD` | String | — | **required (rotated)** | MinIO root password. Same rotation requirement as `WKS_MINIO_ROOT_USER`. |
+
+---
+
+## Keycloak / SSO (`wks.keycloak`)
+
+Binding: `application-production.yml` lines 83–84. See also `KeycloakSeamAnnouncer.java`.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `WKS_KEYCLOAK_ENABLED` | Boolean | `false` | optional | Forward-compat seam flag. When `true`, the app emits `WKS-AUTH-001 WARN` at boot stating the seam is currently inert. Built-in cookie-JWT remains the sole auth gate until Story 10.4 ships. Does not enforce SSO. |
+
+---
+
+## Bootstrap validation (`wks.bootstrap`)
+
+Binding: `application-production.yml` lines 63–65. Controlled by `ProductionBootstrapValidator.java`.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `WKS_BOOTSTRAP_PRODUCTION_VALIDATION_ENABLED` | Boolean | `true` | optional | When `true` (default), activates two fail-closed boot validators: `WKS-API-053` (datasource must be Postgres) and `WKS-API-055` (required env vars must be rotated). Set to `false` only in integration tests that activate the production profile against H2 or with incomplete env-var fixtures. Never disable in a live deployment. |
+
+---
+
+## Case types (`wks.case-types`)
+
+Binding: `application.yml` lines 83–86; production override `application-production.yml` lines 86–88.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `WKS_CASE_TYPES_DIR` | String | `./case-types/` | optional | Directory the backend scans at startup for case-type YAML files. In containers, mount your YAML files and point this to the mount path (e.g. `/app/case-types`). |
+| `WKS_CASE_TYPES_FAIL_ON_INVALID` | Boolean | `false` | optional | When `true`, any invalid case-type YAML aborts startup. Default `false` logs a WARN and skips the invalid file. Set to `true` for strict production rollouts. |
+
+---
+
+## License (`wks.license`)
+
+Binding: `application.yml` lines 88–91.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `WKS_LICENSE_FILE` | String | `""` | optional | Path to the Ed25519-signed license JWT file. Empty string activates OSS mode (no EE features). |
+| `WKS_LICENSE_POLL_INTERVAL` | Integer | `30` | optional | Hot-reload polling interval in seconds. The license file is reloaded when its `lastModified` timestamp changes. |
+
+---
+
+## Form drafts (`wks.form.draft`)
+
+Binding: `application.yml` lines 95–97.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `WKS_FORM_DRAFT_TTL_DAYS` | Integer | `30` | optional | Number of days before an inactive form draft is expired by the scheduled cleanup job. |
+| `WKS_FORM_DRAFT_EXPIRATION_CRON` | String | `0 0 3 * * *` | optional | Spring cron expression for the draft expiration job. Default runs at 03:00 UTC daily. |
+
+---
+
+## Theme (`wks.theme`)
+
+Binding: `application.yml` line 101.
+
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `WKS_THEME_CSS_PATH` | String | `""` | optional | Path to a CSS file served at `GET /api/theme.css`. When empty, the endpoint returns HTTP 204 and the browser ignores the empty link. Used for per-client brand overrides without rebuilding the image. |
+
+---
+
+## OpenAPI / Swagger UI (`springdoc`)
+
+Binding: `application-production.yml` lines 93–97.
+
+| Variable | Type | Default (production) | Required | Description |
+|----------|------|----------------------|----------|-------------|
+| `WKS_OPENAPI_ENABLED` | Boolean | `false` | optional | Enables `GET /v3/api-docs` and the Swagger UI. Disabled by default in production — unauthenticated `/v3/api-docs` is a recurring CVE vector. Enable only for internal tooling deployments. |
+
+---
+
+## Localisation (`wks.locale`)
+
+Binding: `application-production.yml` line 66.
+
+| Variable | Type | Default (production) | Required | Description |
+|----------|------|----------------------|----------|-------------|
+| `WKS_LOCALE` | String | `en-IN` | optional | BCP 47 locale tag used for date formatting and number display in UI-facing fields. |
+
+---
+
+## Host port (compose-level only)
+
+This variable is consumed by `docker-compose.prod.yml` only — not read by the Spring application.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `WKS_HOST_PORT` | Integer | `8080` | Host port mapped to the WKS container's `8080`. Change to avoid conflicts when running multiple instances on the same host. |


### PR DESCRIPTION
## Summary

- Replaces `content/docs/operations/deploy-to-production.mdx` stub with full sourced content: three-container docker-compose example (backend + Postgres + MinIO), required env vars table, bootstrap validation switch, two-switch SSO seam, and smoke-check section.
- Replaces `content/docs/reference/environment-variables.mdx` stub with a complete reference page grouping all `WKS_*` variables by `@ConfigurationProperties` prefix, with type, default, required/optional status, and source file citations.

## ACs satisfied

1. docker-compose example sourced from `docker/docker-compose.prod.yml` — syntactically valid YAML, real image names/pins.
2. Required env vars table sourced from `application-production.yml` + `ProductionBootstrapValidator.java` sentinel list.
3. `WKS_BOOTSTRAP_PRODUCTION_VALIDATION_ENABLED` documented with both validators it guards (WKS-API-053, WKS-API-055), default `true`, opt-out rationale.
4. Smoke check: `curl http://localhost:8080/api/health` (sourced from `HealthController.java`) + Postgres `SELECT count(*) FROM flyway_schema_history` assertion.
5. Two-switch Keycloak seam documented: compose stacking (`docker-compose.sso.yml`) vs `WKS_KEYCLOAK_ENABLED`; orthogonality table; current-inert warning (WKS-AUTH-001).

## @ConfigurationProperties prefixes documented

- `spring.datasource` — `DataSourceConfig.java` + `application-production.yml`
- `wks.admin` — `application.yml`
- `wks.jwt` — `application.yml`
- `wks.cors` — `application.yml` / `application-production.yml`
- `wks.storage` / `wks.documents` — `application-production.yml`
- `wks.keycloak` — `application-production.yml` / `KeycloakSeamAnnouncer.java`
- `wks.bootstrap` — `application-production.yml` / `ProductionBootstrapValidator.java`
- `wks.case-types` — `application.yml` / `application-production.yml`
- `wks.license` — `application.yml`
- `wks.form.draft` — `application.yml`
- `wks.theme` — `application.yml`
- `springdoc` (WKS_OPENAPI_ENABLED) — `application-production.yml`
- `wks.locale` — `application-production.yml`
- Compose-level only: `WKS_HOST_PORT`

## Build

`npm run build` green (33/33 static pages, exit 0).

## Test plan

- [ ] Navigate to `/docs/operations/deploy-to-production` — page renders without errors
- [ ] Navigate to `/docs/reference/environment-variables` — all sections render
- [ ] Verify docker-compose YAML block is syntactically valid (paste into validator)
- [ ] Follow cross-link from deploy page to env-vars reference — resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)