### PR TITLE
feat(5-5): frozen-on-version form binding (D20) + Postgres-IT parity + compat-ctor cleanup

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
@@ -220,9 +220,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
    * the most actionable signal for SI operators.
    *
    * <p>Story 5.5 AC-4 — {@code WKS-VER-002} (case pinned to unknown CaseTypeVersion) maps to HTTP
-   * 422 Unprocessable Entity instead: the request is structurally invalid (the case's pinned version
-   * is not in the registry — a data-integrity condition, not a transient service error). 503 +
-   * Retry-After would be misleading for this sub-code.
+   * 422 Unprocessable Entity instead: the request is structurally invalid (the case's pinned
+   * version is not in the registry — a data-integrity condition, not a transient service error).
+   * 503 + Retry-After would be misleading for this sub-code.
    */
   @ExceptionHandler(com.wkspower.platform.domain.exception.WksVersionException.class)
   public ResponseEntity<ApiResponse<Void>> handleVersion(

--- a/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
@@ -215,9 +215,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   /**
    * Story 3.4 / Decision 20 — CaseType version-registry exceptions. Story 3.4.1 AC4 (finding I6)
    * flips the HTTP semantic from {@code 409 Conflict} (misleading — it is not a client conflict) to
-   * {@code 503 Service Unavailable} with a {@code Retry-After: 5} header: the registry-not- primed
+   * {@code 503 Service Unavailable} with a {@code Retry-After: 5} header: the registry-not-primed
    * condition is recoverable (startup race, polling redeploy window) and "transient, retry safe" is
    * the most actionable signal for SI operators.
+   *
+   * <p>Story 5.5 AC-4 — {@code WKS-VER-002} (case pinned to unknown CaseTypeVersion) maps to HTTP
+   * 422 Unprocessable Entity instead: the request is structurally invalid (the case's pinned version
+   * is not in the registry — a data-integrity condition, not a transient service error). 503 +
+   * Retry-After would be misleading for this sub-code.
    */
   @ExceptionHandler(com.wkspower.platform.domain.exception.WksVersionException.class)
   public ResponseEntity<ApiResponse<Void>> handleVersion(
@@ -225,6 +230,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     MDC.put(MDC_KEY, ex.getCode());
     try {
       log.warn("CaseType version-registry error: {}", ex.getCode());
+      if (ErrorCode.WKS_VER_002.wire().equals(ex.getCode())) {
+        // Story 5.5 AC-4 — pinned-version not in registry: data-integrity error, not transient.
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .body(ApiResponse.error(ErrorPayload.of(ex.getCode(), ex.getMessage())));
+      }
+      // WKS-VER-001 (and any future VER codes) — transient, retry-safe.
       return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
           .header(HttpHeaders.RETRY_AFTER, "5")
           .body(ApiResponse.error(ErrorPayload.of(ex.getCode(), ex.getMessage())));

--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
@@ -76,6 +76,7 @@ public class CaseController {
   private final CaseTypePermissionEvaluator evaluator;
   private final WksStageAdvancer stageAdvancer;
   private final StageRepository stageRepository;
+
   /**
    * Story 5.5 AC-4 — used to resolve the pinned CaseTypeConfig for the case-detail response. The
    * response must embed the pinned CaseType (not the latest deployed) so the frontend form renderer

--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
@@ -28,6 +28,7 @@ import com.wkspower.platform.domain.model.StageState;
 import com.wkspower.platform.domain.page.Page;
 import com.wkspower.platform.domain.page.PageRequest;
 import com.wkspower.platform.domain.page.SortOrder;
+import com.wkspower.platform.domain.port.CaseTypeReader;
 import com.wkspower.platform.domain.port.StageRepository;
 import com.wkspower.platform.domain.service.CaseService;
 import com.wkspower.platform.domain.service.TaskService;
@@ -75,18 +76,26 @@ public class CaseController {
   private final CaseTypePermissionEvaluator evaluator;
   private final WksStageAdvancer stageAdvancer;
   private final StageRepository stageRepository;
+  /**
+   * Story 5.5 AC-4 — used to resolve the pinned CaseTypeConfig for the case-detail response. The
+   * response must embed the pinned CaseType (not the latest deployed) so the frontend form renderer
+   * shows the form the case was bound to (Decision D20 frozen-on-version).
+   */
+  private final CaseTypeReader caseTypeReader;
 
   public CaseController(
       CaseService caseService,
       TaskService taskService,
       CaseTypePermissionEvaluator evaluator,
       WksStageAdvancer stageAdvancer,
-      StageRepository stageRepository) {
+      StageRepository stageRepository,
+      CaseTypeReader caseTypeReader) {
     this.caseService = caseService;
     this.taskService = taskService;
     this.evaluator = evaluator;
     this.stageAdvancer = stageAdvancer;
     this.stageRepository = stageRepository;
+    this.caseTypeReader = caseTypeReader;
   }
 
   /**
@@ -121,7 +130,13 @@ public class CaseController {
       @PathVariable("id") UUID id, @AuthenticationPrincipal WksUserPrincipal actor) {
     Case found = caseService.findById(id);
     requireVerb(actor, found.caseTypeId(), "view");
-    CaseTypeConfig caseType = caseService.requireCaseType(found.caseTypeId());
+    // Story 5.5 AC-4 — embed PINNED CaseType in the response (Decision D20). Frontend FormPage
+    // reads caseDto.caseType.forms to render the form; it must see the v-pinned form definition,
+    // not the latest deployed version. Falls back to latest on registry miss (defensive guard).
+    CaseTypeConfig caseType =
+        caseTypeReader
+            .findVersion(found.caseTypeId(), found.caseTypeVersion())
+            .orElseGet(() -> caseService.requireCaseType(found.caseTypeId()));
     List<Stage> history = stageRepository.loadHistory(id);
     return ApiResponse.success(CaseDtoMapper.toDto(found, caseType, history));
   }
@@ -195,7 +210,11 @@ public class CaseController {
     Case found = caseService.findById(id);
     requireVerb(actor, found.caseTypeId(), "edit");
     Case updated = caseService.update(id, request.data(), request.version(), actor.id());
-    CaseTypeConfig caseType = caseService.requireCaseType(updated.caseTypeId());
+    // Story 5.5 AC-4 — embed pinned CaseType for D20 consistency; falls back to latest.
+    CaseTypeConfig caseType =
+        caseTypeReader
+            .findVersion(updated.caseTypeId(), updated.caseTypeVersion())
+            .orElseGet(() -> caseService.requireCaseType(updated.caseTypeId()));
     return ApiResponse.success(CaseDtoMapper.toDto(updated, caseType));
   }
 
@@ -221,7 +240,11 @@ public class CaseController {
     Case found = caseService.findById(id);
     requireVerb(actor, found.caseTypeId(), "transition");
     Case updated = caseService.transition(id, request.action(), request.variables(), actor.id());
-    CaseTypeConfig caseType = caseService.requireCaseType(updated.caseTypeId());
+    // Story 5.5 AC-4 — embed pinned CaseType for D20 consistency; falls back to latest.
+    CaseTypeConfig caseType =
+        caseTypeReader
+            .findVersion(updated.caseTypeId(), updated.caseTypeVersion())
+            .orElseGet(() -> caseService.requireCaseType(updated.caseTypeId()));
     return ApiResponse.success(CaseDtoMapper.toDto(updated, caseType));
   }
 

--- a/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
@@ -47,6 +47,7 @@ public class FormController {
   private final CaseService caseService;
   private final StageRepository stageRepository;
   private final FormDraftService formDraftService;
+
   /**
    * Story 5.5 AC-4 — used to resolve the pinned CaseTypeConfig for the DTO response. The response
    * must embed the pinned CaseType (not the latest deployed) so the frontend renders the form the

--- a/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/FormController.java
@@ -7,6 +7,7 @@ import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.WksValidationException;
 import com.wkspower.platform.domain.model.Case;
+import com.wkspower.platform.domain.port.CaseTypeReader;
 import com.wkspower.platform.domain.port.StageRepository;
 import com.wkspower.platform.domain.service.CaseService;
 import com.wkspower.platform.domain.service.FormDraftService;
@@ -46,12 +47,22 @@ public class FormController {
   private final CaseService caseService;
   private final StageRepository stageRepository;
   private final FormDraftService formDraftService;
+  /**
+   * Story 5.5 AC-4 — used to resolve the pinned CaseTypeConfig for the DTO response. The response
+   * must embed the pinned CaseType (not the latest deployed) so the frontend renders the form the
+   * case is bound to (Decision D20 frozen-on-version).
+   */
+  private final CaseTypeReader caseTypeReader;
 
   public FormController(
-      CaseService caseService, StageRepository stageRepository, FormDraftService formDraftService) {
+      CaseService caseService,
+      StageRepository stageRepository,
+      FormDraftService formDraftService,
+      CaseTypeReader caseTypeReader) {
     this.caseService = caseService;
     this.stageRepository = stageRepository;
     this.formDraftService = formDraftService;
+    this.caseTypeReader = caseTypeReader;
   }
 
   /**
@@ -100,7 +111,15 @@ public class FormController {
     // post-submit failure rolls back the deletion (preserving the draft) per AC6.
     formDraftService.deleteDraft(caseId, formId, actor.id());
 
-    CaseTypeConfig caseType = caseService.requireCaseType(updated.caseTypeId());
+    // Story 5.5 AC-4 — embed the PINNED CaseType in the response DTO (Decision D20). The
+    // frontend FormPage reads caseDto.caseType.forms to render the form definition; it must see
+    // the v-pinned form, not the latest deployed CaseType. Falls back to latest if pinned version
+    // is not in registry (defensive — should not occur after resolveFormDefinitionForCase succeeded
+    // above, but guards against race conditions on the read-only response path).
+    CaseTypeConfig caseType =
+        caseTypeReader
+            .findVersion(updated.caseTypeId(), updated.caseTypeVersion())
+            .orElseGet(() -> caseService.requireCaseType(updated.caseTypeId()));
     List<com.wkspower.platform.domain.model.Stage> history = stageRepository.loadHistory(caseId);
 
     CaseDto dto = CaseDtoMapper.toDto(updated, caseType, history);

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
@@ -49,30 +49,4 @@ public record FormDefinition(
     sections = sections == null ? List.of() : List.copyOf(sections);
   }
 
-  /**
-   * Backward-compat constructor for callers that pre-date Story 5.3's {@code sections} slot.
-   * Defaults {@code sections} and {@code archetype} to their null/empty defaults.
-   */
-  public FormDefinition(
-      String id,
-      String topology,
-      String dataModel,
-      String rendering,
-      List<FieldDefinition> fields) {
-    this(id, topology, dataModel, rendering, fields, List.of(), null);
-  }
-
-  /**
-   * Backward-compat constructor for callers that pre-date Story 6.1's {@code archetype} slot.
-   * Defaults {@code archetype} to {@code null}.
-   */
-  public FormDefinition(
-      String id,
-      String topology,
-      String dataModel,
-      String rendering,
-      List<FieldDefinition> fields,
-      List<FormSection> sections) {
-    this(id, topology, dataModel, rendering, fields, sections, null);
-  }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/model/FormDefinition.java
@@ -48,5 +48,4 @@ public record FormDefinition(
     fields = fields == null ? List.of() : List.copyOf(fields);
     sections = sections == null ? List.of() : List.copyOf(sections);
   }
-
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/event/FormSubmitted.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/FormSubmitted.java
@@ -37,11 +37,7 @@ public record FormSubmitted(
    * production paths must always supply the version.
    */
   public static FormSubmitted of(
-      UUID caseId,
-      String formId,
-      UUID actorId,
-      Instant submittedAt,
-      Set<String> updatedFieldIds) {
+      UUID caseId, String formId, UUID actorId, Instant submittedAt, Set<String> updatedFieldIds) {
     return new FormSubmitted(caseId, formId, actorId, submittedAt, updatedFieldIds, 0);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/event/FormSubmitted.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/FormSubmitted.java
@@ -16,6 +16,32 @@ import java.util.UUID;
  * subscribers never observe state that the underlying transaction subsequently rolls back.
  *
  * <p>Story 5.2 — Phase 0. No persistence; in-memory routing via Spring ApplicationEventPublisher.
+ *
+ * <p>Story 5.5 AC-7 — {@code caseTypeVersion} records the pinned CaseTypeVersion the form was
+ * resolved against (Decision D20 frozen-on-version). This is the version the case was bound to at
+ * create time, NOT the latest deployed CaseType version. The audit row consumer MUST use this field
+ * to surface "caseTypeVersion" in the audit payload JSON — never re-read the live registry.
  */
 public record FormSubmitted(
-    UUID caseId, String formId, UUID actorId, Instant submittedAt, Set<String> updatedFieldIds) {}
+    UUID caseId,
+    String formId,
+    UUID actorId,
+    Instant submittedAt,
+    Set<String> updatedFieldIds,
+    /** Story 5.5 AC-7 — the pinned CaseTypeVersion the form was resolved against (D20). */
+    int caseTypeVersion) {
+
+  /**
+   * Backward-compat factory for callers (e.g. test helpers) that pre-date Story 5.5's {@code
+   * caseTypeVersion} slot. Defaults {@code caseTypeVersion} to {@code 0} as a sentinel — real
+   * production paths must always supply the version.
+   */
+  public static FormSubmitted of(
+      UUID caseId,
+      String formId,
+      UUID actorId,
+      Instant submittedAt,
+      Set<String> updatedFieldIds) {
+    return new FormSubmitted(caseId, formId, actorId, submittedAt, updatedFieldIds, 0);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -376,6 +376,15 @@ public enum ErrorCode {
    * bootstrap migration closes the gap for pre-3.4 CaseTypes by materialising v1 rows.
    */
   WKS_VER_001("WKS-VER-001"),
+  /**
+   * Story 5.5 AC-4 — {@code CaseService.resolveFormDefinitionForCase} called for a Case whose
+   * {@code caseTypeVersion} has no matching row in {@code case_type_versions} registry (defensive
+   * guard — should never fire on a healthy system; discovered cases must not 500). HTTP 422.
+   *
+   * <p>Wire string is stable — SI devs grep this against audit logs per {@code
+   * feedback_error_codes_are_wire_contract.md}. Do NOT reuse for a different meaning.
+   */
+  WKS_VER_002("WKS-VER-002"),
 
   // 422 — Form Definition Schema validation (Story 5.1). Band: WKS-FORM-001..099.
   // Codes 002+ are RESERVED for Stories 5.2–5.8 — do NOT mint speculatively.

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -790,8 +790,8 @@ public class CaseService {
    *   <li>Finds the {@link FormDefinition} by {@code formId} on the pinned CaseTypeConfig.
    * </ol>
    *
-   * @throws WksVersionException ({@code WKS-VER-002}, HTTP 422) when the case's
-   *     {@code caseTypeVersion} is not in the {@code case_type_versions} registry — defensive guard,
+   * @throws WksVersionException ({@code WKS-VER-002}, HTTP 422) when the case's {@code
+   *     caseTypeVersion} is not in the {@code case_type_versions} registry — defensive guard,
    *     should not fire on a healthy system, but discovered cases must not 500.
    * @throws WksNotFoundException ({@code WKS-API-404}, HTTP 404) when the {@code formId} is not
    *     declared on the pinned CaseTypeConfig (invalid request — form removed post-deploy).

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -216,7 +216,15 @@ public class CaseService {
           "Case " + caseId + " was modified by another transaction; reload and retry");
     }
 
-    CaseTypeConfig caseType = requireCaseType(existing.caseTypeId());
+    // Story 5.5 AC-4 — Decision D20 frozen-on-version: validate updated case data against the
+    // CaseType the case is PINNED to, not the latest deployed version. This ensures a v1-pinned
+    // case can still pass update validation after a v2 (with additional required fields) is
+    // deployed. Falls back to latest if the pinned version is not in the registry (defensive — the
+    // normal path always has the pinned version cached since register() now populates byVersion).
+    CaseTypeConfig caseType =
+        caseTypeReader
+            .findVersion(existing.caseTypeId(), existing.caseTypeVersion())
+            .orElseGet(() -> requireCaseType(existing.caseTypeId()));
     Map<String, Object> safeData = newData == null ? Map.of() : Map.copyOf(newData);
 
     List<ErrorDetail> violations = caseDataValidator.validate(caseType, safeData);

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -420,21 +420,19 @@ public class CaseService {
             .findById(caseId)
             .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
 
-    CaseTypeConfig caseType = requireCaseType(existing.caseTypeId());
+    // Story 5.5 AC-4 — Decision D20 frozen-on-version: resolve the form definition from the
+    // CaseTypeVersion the case is pinned to, NOT the latest deployed version. Server-side binding
+    // from case.caseTypeVersion — clients NEVER supply formVersion. WKS-VER-002 on registry miss.
+    FormDefinition form = resolveFormDefinitionForCase(existing, formId);
 
-    // Resolve the form definition by id — 404 if not declared on this case type.
-    FormDefinition form =
-        caseType.forms().stream()
-            .filter(f -> f.id().equals(formId))
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new WksNotFoundException(
-                        "Form '"
-                            + formId
-                            + "' not found on case type '"
-                            + existing.caseTypeId()
-                            + "'"));
+    // Story 5.6 AC2 — field-level edit-permission check requires the pinned CaseTypeConfig (which
+    // carries editableBy declarations). Use findVersion so the permission check respects the same
+    // version the form was resolved against. Fallback to latest on registry miss (should not occur
+    // since resolveFormDefinitionForCase above already threw WKS-VER-002 on that path).
+    CaseTypeConfig caseType =
+        caseTypeReader
+            .findVersion(existing.caseTypeId(), existing.caseTypeVersion())
+            .orElseGet(() -> requireCaseType(existing.caseTypeId()));
 
     // Validate submitted field values against the form's field definitions.
     // Collections.unmodifiableMap(new HashMap<>(...)) is used instead of Map.copyOf() because
@@ -450,7 +448,7 @@ public class CaseService {
 
     // Story 5.6 AC2 — field-level edit-permission check on the diff of changed fields only. An
     // unchanged value passing through the form does NOT trigger rejection (round-tripped immutable
-    // display fields are common). The check operates against the case-type's full field set
+    // display fields are common). The check operates against the pinned case-type's full field set
     // (caseType.fields()) because field permissions live on the case-type, not the form view.
     Set<String> changedFieldIds = diffFieldIds(existing.data(), safeData);
     List<ErrorDetail> permViolations =
@@ -513,8 +511,10 @@ public class CaseService {
     Set<String> updatedFieldIds = diffFieldIds(existing.data(), safeData);
 
     // Publish FormSubmitted after commit so the audit listener never observes rolled-back state.
+    // Story 5.5 AC-7 — include caseTypeVersion in the audit payload (pinned version, not latest).
     eventPublisher.publishAfterCommit(
-        new FormSubmitted(caseId, formId, actorId, clock.now(), updatedFieldIds));
+        new FormSubmitted(
+            caseId, formId, actorId, clock.now(), updatedFieldIds, existing.caseTypeVersion()));
 
     return updated;
   }
@@ -768,6 +768,53 @@ public class CaseService {
         .findById(caseId)
         .orElseThrow(() -> new WksNotFoundException("Case " + caseId + " not found"));
     // Phase-0: no additional access check beyond authentication. Hook for Phase-1 RBAC.
+  }
+
+  /**
+   * Story 5.5 AC-4 — Decision D20 frozen-on-version invariant. Single source of truth for "what
+   * form does this case see right now." Controllers MUST consume this method — do NOT inline the
+   * lookup (memory {@code feedback_consolidate_property_readers.md} analog applies).
+   *
+   * <ol>
+   *   <li>Reads {@code case.caseTypeVersion()} (existing field on the Case record).
+   *   <li>Looks up the CaseTypeConfig snapshot from the {@code case_type_versions} registry via
+   *       {@link com.wkspower.platform.domain.port.CaseTypeReader#findVersion}.
+   *   <li>Finds the {@link FormDefinition} by {@code formId} on the pinned CaseTypeConfig.
+   * </ol>
+   *
+   * @throws WksVersionException ({@code WKS-VER-002}, HTTP 422) when the case's
+   *     {@code caseTypeVersion} is not in the {@code case_type_versions} registry — defensive guard,
+   *     should not fire on a healthy system, but discovered cases must not 500.
+   * @throws WksNotFoundException ({@code WKS-API-404}, HTTP 404) when the {@code formId} is not
+   *     declared on the pinned CaseTypeConfig (invalid request — form removed post-deploy).
+   */
+  public FormDefinition resolveFormDefinitionForCase(Case c, String formId) {
+    Objects.requireNonNull(c, "case");
+    Objects.requireNonNull(formId, "formId");
+    CaseTypeConfig pinnedCaseType =
+        caseTypeReader
+            .findVersion(c.caseTypeId(), c.caseTypeVersion())
+            .orElseThrow(
+                () ->
+                    new WksVersionException(
+                        ErrorCode.WKS_VER_002,
+                        "Case "
+                            + c.id()
+                            + " is pinned to CaseTypeVersion "
+                            + c.caseTypeVersion()
+                            + " which is not in the registry"));
+    return pinnedCaseType.forms().stream()
+        .filter(f -> f.id().equals(formId))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new WksNotFoundException(
+                    "Form '"
+                        + formId
+                        + "' not found on case type '"
+                        + c.caseTypeId()
+                        + "' at version "
+                        + c.caseTypeVersion()));
   }
 
   /**

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeRegistry.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/CaseTypeRegistry.java
@@ -137,6 +137,12 @@ public class CaseTypeRegistry implements CaseTypeReader, CaseTypeRegistrar {
               });
     }
     Registered incoming = new Registered(config, schemaGenerator.generate(config));
+    // Story 5.5 AC-4 — populate byVersion cache eagerly on register so that findVersion(id,
+    // version) never falls back to parsing the stub YAML written by the test-bypass path. The
+    // production path (ConfigService.applyVersionRegistry) writes full YAML before register; the
+    // test-bypass path writes a stub. Either way, the in-memory CaseTypeConfig is authoritative and
+    // is cached here, making the parse-validate round-trip unnecessary for same-version lookups.
+    byVersion.putIfAbsent(new VersionKey(config.id(), config.version()), config);
     AtomicReference<RegistrationResult> outcome = new AtomicReference<>();
 
     byId.compute(

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
@@ -38,6 +38,4 @@ public record RawFormDefinition(
      * submit_for_processing}, {@code business_final}). Validated by {@link ConfigValidator} which
      * emits {@code WKS-ARCH-001} for unknown values.
      */
-    @JsonProperty("archetype") String archetype) {
-
-}
+    @JsonProperty("archetype") String archetype) {}

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/RawFormDefinition.java
@@ -40,30 +40,4 @@ public record RawFormDefinition(
      */
     @JsonProperty("archetype") String archetype) {
 
-  /**
-   * Backward-compat constructor for callers (mostly tests) that pre-date Story 5.3's {@code
-   * sections} slot. Defaults {@code sections} and {@code archetype} to {@code null}.
-   */
-  public RawFormDefinition(
-      String id,
-      String topology,
-      String dataModel,
-      String rendering,
-      List<Map<String, Object>> fields) {
-    this(id, topology, dataModel, rendering, fields, null, null);
-  }
-
-  /**
-   * Backward-compat constructor for callers that pre-date Story 6.1's {@code archetype} slot.
-   * Defaults {@code archetype} to {@code null}.
-   */
-  public RawFormDefinition(
-      String id,
-      String topology,
-      String dataModel,
-      String rendering,
-      List<Map<String, Object>> fields,
-      List<RawFormSection> sections) {
-    this(id, topology, dataModel, rendering, fields, sections, null);
-  }
 }

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
@@ -76,6 +76,7 @@ class CaseControllerTest {
   com.wkspower.platform.domain.service.WksStageAdvancer stageAdvancer;
 
   @MockitoBean com.wkspower.platform.domain.port.StageRepository stageRepository;
+
   /** Story 5.5 AC-4 — CaseController now injects CaseTypeReader for pinned-version DTO build. */
   @MockitoBean com.wkspower.platform.domain.port.CaseTypeReader caseTypeReader;
 

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseControllerTest.java
@@ -76,6 +76,8 @@ class CaseControllerTest {
   com.wkspower.platform.domain.service.WksStageAdvancer stageAdvancer;
 
   @MockitoBean com.wkspower.platform.domain.port.StageRepository stageRepository;
+  /** Story 5.5 AC-4 — CaseController now injects CaseTypeReader for pinned-version DTO build. */
+  @MockitoBean com.wkspower.platform.domain.port.CaseTypeReader caseTypeReader;
 
   @MockitoBean(name = "caseTypePermissionEvaluator")
   CaseTypePermissionEvaluator caseTypePermissionEvaluator;

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
@@ -66,6 +66,7 @@ class CaseTransitionControllerTest {
   com.wkspower.platform.domain.service.WksStageAdvancer stageAdvancer;
 
   @MockitoBean com.wkspower.platform.domain.port.StageRepository stageRepository;
+
   /** Story 5.5 AC-4 — CaseController now injects CaseTypeReader for pinned-version DTO build. */
   @MockitoBean com.wkspower.platform.domain.port.CaseTypeReader caseTypeReader;
 

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseTransitionControllerTest.java
@@ -66,6 +66,8 @@ class CaseTransitionControllerTest {
   com.wkspower.platform.domain.service.WksStageAdvancer stageAdvancer;
 
   @MockitoBean com.wkspower.platform.domain.port.StageRepository stageRepository;
+  /** Story 5.5 AC-4 — CaseController now injects CaseTypeReader for pinned-version DTO build. */
+  @MockitoBean com.wkspower.platform.domain.port.CaseTypeReader caseTypeReader;
 
   @MockitoBean(name = "caseTypePermissionEvaluator")
   CaseTypePermissionEvaluator evaluator;

--- a/backend/src/test/java/com/wkspower/platform/domain/config/diff/CaseTypeDiffTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/config/diff/CaseTypeDiffTest.java
@@ -600,7 +600,7 @@ class CaseTypeDiffTest {
             List.of(),
             List.of(
                 new FormDefinition(
-                    "intake-form", "single", "monolithic", "single-page", List.of())));
+                    "intake-form", "single", "monolithic", "single-page", List.of(), List.of(), null)));
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());

--- a/backend/src/test/java/com/wkspower/platform/domain/config/diff/CaseTypeDiffTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/config/diff/CaseTypeDiffTest.java
@@ -600,7 +600,13 @@ class CaseTypeDiffTest {
             List.of(),
             List.of(
                 new FormDefinition(
-                    "intake-form", "single", "monolithic", "single-page", List.of(), List.of(), null)));
+                    "intake-form",
+                    "single",
+                    "monolithic",
+                    "single-page",
+                    List.of(),
+                    List.of(),
+                    null)));
 
     BlastRadiusReport report =
         CaseTypeDiff.classify(prev, next, MappingDefinition.empty(), MappingDefinition.empty());

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
@@ -36,6 +36,7 @@ class FormDefinitionMapperTest {
                     true,
                     "order",
                     0)),
+            null,
             null);
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
 
@@ -92,7 +93,7 @@ class FormDefinitionMapperTest {
             new RawFormSection("employment", "Employment Details", employmentFields));
 
     var raw =
-        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, sections);
+        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, sections, null);
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
 
     assertThat(result.sections()).hasSize(2);
@@ -117,7 +118,7 @@ class FormDefinitionMapperTest {
     var section = new RawFormSection("personal", null, List.of());
     var raw =
         new RawFormDefinition(
-            "bank-form", "single", "sectioned", "multi-section", null, List.of(section));
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(section), null);
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
 
     // label defaults to id when absent
@@ -131,7 +132,7 @@ class FormDefinitionMapperTest {
     var valid = new RawFormSection("employment", "Employment", List.of());
     var raw =
         new RawFormDefinition(
-            "bank-form", "single", "sectioned", "multi-section", null, List.of(blankId, valid));
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(blankId, valid), null);
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
 
     // blank-id section is skipped; valid section remains
@@ -145,7 +146,7 @@ class FormDefinitionMapperTest {
     sections.add(null);
     sections.add(new RawFormSection("employment", "Employment", List.of()));
     var raw =
-        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, sections);
+        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, sections, null);
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
 
     assertThat(result.sections()).hasSize(1);
@@ -199,7 +200,9 @@ class FormDefinitionMapperTest {
                     "required",
                     false,
                     "order",
-                    0)));
+                    0)),
+            null,
+            null);
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
     assertThat(result.archetype()).isNull();
   }

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormDefinitionMapperTest.java
@@ -93,7 +93,8 @@ class FormDefinitionMapperTest {
             new RawFormSection("employment", "Employment Details", employmentFields));
 
     var raw =
-        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, sections, null);
+        new RawFormDefinition(
+            "bank-form", "single", "sectioned", "multi-section", null, sections, null);
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
 
     assertThat(result.sections()).hasSize(2);
@@ -132,7 +133,13 @@ class FormDefinitionMapperTest {
     var valid = new RawFormSection("employment", "Employment", List.of());
     var raw =
         new RawFormDefinition(
-            "bank-form", "single", "sectioned", "multi-section", null, List.of(blankId, valid), null);
+            "bank-form",
+            "single",
+            "sectioned",
+            "multi-section",
+            null,
+            List.of(blankId, valid),
+            null);
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
 
     // blank-id section is skipped; valid section remains
@@ -146,7 +153,8 @@ class FormDefinitionMapperTest {
     sections.add(null);
     sections.add(new RawFormSection("employment", "Employment", List.of()));
     var raw =
-        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, sections, null);
+        new RawFormDefinition(
+            "bank-form", "single", "sectioned", "multi-section", null, sections, null);
     FormDefinition result = FormDefinitionMapper.toDomain(raw);
 
     assertThat(result.sections()).hasSize(1);

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormValidatorTest.java
@@ -39,7 +39,8 @@ class FormValidatorTest {
   @Test
   void validTriplet_singleMonolithicSinglePage_noErrors() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null, null);
+    var def =
+        new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
     assertThat(errors).isEmpty();
   }
@@ -62,7 +63,8 @@ class FormValidatorTest {
   void parallelTopology_rejected_withWksForm001() {
     List<ErrorDetail> errors = new ArrayList<>();
     var def =
-        new RawFormDefinition("parallel-form", "parallel", "sectioned", "multi-section", null, null, null);
+        new RawFormDefinition(
+            "parallel-form", "parallel", "sectioned", "multi-section", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors).isNotEmpty();
@@ -89,7 +91,8 @@ class FormValidatorTest {
   @Test
   void unknownTopology_rejected_withWksForm001() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("x", "distributed", "monolithic", "single-page", null, null, null);
+    var def =
+        new RawFormDefinition("x", "distributed", "monolithic", "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -191,8 +194,10 @@ class FormValidatorTest {
   @Test
   void multipleDefinitions_validThenInvalid_errorsOnlyForInvalid() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var valid = new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null, null);
-    var invalid = new RawFormDefinition("bad", "parallel", "sectioned", "multi-section", null, null, null);
+    var valid =
+        new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null, null);
+    var invalid =
+        new RawFormDefinition("bad", "parallel", "sectioned", "multi-section", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(valid, invalid)), errors);
 
     // Only the second definition should produce errors
@@ -207,7 +212,8 @@ class FormValidatorTest {
     List<ErrorDetail> errors = new ArrayList<>();
     // No sections provided — should require at least one
     var def =
-        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, null, null);
+        new RawFormDefinition(
+            "bank-form", "single", "sectioned", "multi-section", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -223,7 +229,8 @@ class FormValidatorTest {
   void sectioned_withEmptySectionsList_emitsWksCfg001() {
     List<ErrorDetail> errors = new ArrayList<>();
     var def =
-        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, List.of(), null);
+        new RawFormDefinition(
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(), null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -284,7 +291,8 @@ class FormValidatorTest {
   void monolithic_withoutSections_noSectionErrors() {
     List<ErrorDetail> errors = new ArrayList<>();
     // monolithic forms do not need sections — no section errors expected
-    var def = new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null, null);
+    var def =
+        new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors).isEmpty();

--- a/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormValidatorTest.java
+++ b/backend/src/test/java/com/wkspower/platform/infrastructure/config/FormValidatorTest.java
@@ -39,7 +39,7 @@ class FormValidatorTest {
   @Test
   void validTriplet_singleMonolithicSinglePage_noErrors() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("intake", "single", "monolithic", "single-page", null);
+    var def = new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
     assertThat(errors).isEmpty();
   }
@@ -51,7 +51,7 @@ class FormValidatorTest {
     var section = new RawFormSection("personal", "Personal Information", List.of());
     var def =
         new RawFormDefinition(
-            "onboarding", "single", "sectioned", "multi-section", null, List.of(section));
+            "onboarding", "single", "sectioned", "multi-section", null, List.of(section), null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
     assertThat(errors).isEmpty();
   }
@@ -62,7 +62,7 @@ class FormValidatorTest {
   void parallelTopology_rejected_withWksForm001() {
     List<ErrorDetail> errors = new ArrayList<>();
     var def =
-        new RawFormDefinition("parallel-form", "parallel", "sectioned", "multi-section", null);
+        new RawFormDefinition("parallel-form", "parallel", "sectioned", "multi-section", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors).isNotEmpty();
@@ -78,7 +78,7 @@ class FormValidatorTest {
   @Test
   void parallelTopology_message_containsUseTopologySingle() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("x", "parallel", "monolithic", "single-page", null);
+    var def = new RawFormDefinition("x", "parallel", "monolithic", "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors).anySatisfy(e -> assertThat(e.message()).contains("use topology: single"));
@@ -89,7 +89,7 @@ class FormValidatorTest {
   @Test
   void unknownTopology_rejected_withWksForm001() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("x", "distributed", "monolithic", "single-page", null);
+    var def = new RawFormDefinition("x", "distributed", "monolithic", "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -103,7 +103,7 @@ class FormValidatorTest {
   @Test
   void invalidDataModel_rejected() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("x", "single", "flat", "single-page", null);
+    var def = new RawFormDefinition("x", "single", "flat", "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -118,7 +118,7 @@ class FormValidatorTest {
   @Test
   void invalidRendering_rejected() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("x", "single", "monolithic", "full-page", null);
+    var def = new RawFormDefinition("x", "single", "monolithic", "full-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -135,7 +135,7 @@ class FormValidatorTest {
   @Test
   void missingTopology_reportsWksCfg001() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("x", null, "monolithic", "single-page", null);
+    var def = new RawFormDefinition("x", null, "monolithic", "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -149,7 +149,7 @@ class FormValidatorTest {
   @Test
   void missingDataModel_reportsWksCfg001() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("x", "single", null, "single-page", null);
+    var def = new RawFormDefinition("x", "single", null, "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -163,7 +163,7 @@ class FormValidatorTest {
   @Test
   void missingRendering_reportsWksCfg001() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("x", "single", "monolithic", null, null);
+    var def = new RawFormDefinition("x", "single", "monolithic", null, null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -179,7 +179,7 @@ class FormValidatorTest {
   @Test
   void allAxesMissing_collectsThreeErrors() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var def = new RawFormDefinition("x", null, null, null, null);
+    var def = new RawFormDefinition("x", null, null, null, null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors).hasSize(3);
@@ -191,8 +191,8 @@ class FormValidatorTest {
   @Test
   void multipleDefinitions_validThenInvalid_errorsOnlyForInvalid() {
     List<ErrorDetail> errors = new ArrayList<>();
-    var valid = new RawFormDefinition("intake", "single", "monolithic", "single-page", null);
-    var invalid = new RawFormDefinition("bad", "parallel", "sectioned", "multi-section", null);
+    var valid = new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null, null);
+    var invalid = new RawFormDefinition("bad", "parallel", "sectioned", "multi-section", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(valid, invalid)), errors);
 
     // Only the second definition should produce errors
@@ -207,7 +207,7 @@ class FormValidatorTest {
     List<ErrorDetail> errors = new ArrayList<>();
     // No sections provided — should require at least one
     var def =
-        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, null);
+        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -223,7 +223,7 @@ class FormValidatorTest {
   void sectioned_withEmptySectionsList_emitsWksCfg001() {
     List<ErrorDetail> errors = new ArrayList<>();
     var def =
-        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, List.of());
+        new RawFormDefinition("bank-form", "single", "sectioned", "multi-section", null, List.of(), null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -240,7 +240,7 @@ class FormValidatorTest {
     var section = new RawFormSection("personal", "Personal Information", List.of());
     var def =
         new RawFormDefinition(
-            "bank-form", "single", "sectioned", "multi-section", null, List.of(section));
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(section), null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors).isEmpty();
@@ -252,7 +252,7 @@ class FormValidatorTest {
     var section = new RawFormSection("personal", null, List.of());
     var def =
         new RawFormDefinition(
-            "bank-form", "single", "sectioned", "multi-section", null, List.of(section));
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(section), null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -269,7 +269,7 @@ class FormValidatorTest {
     var section = new RawFormSection(null, "Personal Information", List.of());
     var def =
         new RawFormDefinition(
-            "bank-form", "single", "sectioned", "multi-section", null, List.of(section));
+            "bank-form", "single", "sectioned", "multi-section", null, List.of(section), null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors)
@@ -284,7 +284,7 @@ class FormValidatorTest {
   void monolithic_withoutSections_noSectionErrors() {
     List<ErrorDetail> errors = new ArrayList<>();
     // monolithic forms do not need sections — no section errors expected
-    var def = new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null);
+    var def = new RawFormDefinition("intake", "single", "monolithic", "single-page", null, null, null);
     validator.validate(RawFormConfig.fromList(List.of(def)), errors);
 
     assertThat(errors).isEmpty();

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinIT.java
@@ -1,0 +1,267 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Story 5.5 AC-5 — Decision D20 frozen-on-version: in-flight case isolation.
+ *
+ * <p>Proves that a case created under CaseType v1 continues to see the v1 form definition after
+ * CaseType v2 (with a different form topology) is deployed. The response DTO embeds the
+ * <em>pinned</em> CaseTypeConfig, not the latest registered version.
+ *
+ * <p>AC-5 scenario: create a case (v1 pinned), register v2 with a renamed field, GET the case
+ * and submit the form — both must use v1's field set.
+ *
+ * <p>AC-7 scenario: the FormSubmitted event (inspected via the updated CaseDto response) carries the
+ * caseTypeVersion at the time of submission — which must be 1, the pinned version, even though v2
+ * is live.
+ *
+ * <p>Uses H2 in-memory DB; companion Postgres-IT is {@code FormBindingVersionPinPostgresIT}.
+ *
+ * <p>Memory {@code feedback_production_validator_opt_out.md}: production-validation disabled — no
+ * production-profile boot here.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:formbindingversionpin;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=",
+      "wks.bootstrap.production-validation.enabled=false"
+    })
+class FormBindingVersionPinIT {
+
+  private static final String EMAIL = "formbind-pin-it@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String CASE_TYPE_ID = "formbind-pin-fixture";
+  private static final String FORM_ID = "intake-form";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private ObjectMapper json;
+
+  @BeforeEach
+  void setup() {
+    if (users.findByEmail(EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+    // Register v1 — two fields: applicant (required) + amount (optional)
+    registry.register(caseTypeV1());
+  }
+
+  /**
+   * AC-5 — In-flight case isolation.
+   *
+   * <p>Steps:
+   * <ol>
+   *   <li>Create a case while v1 is the only deployed version → case.caseTypeVersion = 1.
+   *   <li>Register v2 (adds a new required field "email", renames nothing but changes the form).
+   *   <li>GET the case — response DTO must embed v1's form (2 fields, no "email").
+   *   <li>Submit the v1 form — must succeed (v1's required fields satisfied).
+   * </ol>
+   */
+  @Test
+  void inFlightCaseSeesV1FormAfterV2Deploy() throws Exception {
+    String cookie = login();
+    // Step 1: create case while v1 is live
+    String caseId = createCase(cookie);
+
+    // Step 2: register v2 with an extra required field "email"
+    registry.register(caseTypeV2());
+
+    // Step 3: GET the case — embedded CaseType must be v1 (no "email" field in forms)
+    ResponseEntity<String> getResp =
+        exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
+    assertThat(getResp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode caseBody = json.readTree(getResp.getBody());
+    JsonNode caseTypeNode = caseBody.path("data").path("caseType");
+    assertThat(caseTypeNode.path("version").asInt())
+        .as("GET response must embed pinned v1")
+        .isEqualTo(1);
+    // v1 form has exactly 2 fields; v2 form has 3
+    JsonNode formFields =
+        caseTypeNode
+            .path("forms")
+            .elements()
+            .next() // first (only) form
+            .path("fields");
+    assertThat(formFields.size()).as("pinned v1 form must have 2 fields, not 3").isEqualTo(2);
+
+    // Step 4: submit the v1 form — required "applicant" satisfied; "email" not required at v1
+    ResponseEntity<String> submitResp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\",\"amount\":9000}");
+    assertThat(submitResp.getStatusCode())
+        .as("submit with v1 payload must succeed even though v2 is live")
+        .isEqualTo(HttpStatus.OK);
+    JsonNode submitBody = json.readTree(submitResp.getBody());
+    // Embedded CaseType in submit response must still be v1
+    assertThat(submitBody.path("data").path("caseType").path("version").asInt())
+        .as("submit response must embed pinned v1")
+        .isEqualTo(1);
+  }
+
+  /**
+   * AC-7 — submit response caseTypeVersion reflects pinned version.
+   *
+   * <p>The FormController embeds the pinned CaseType in the response DTO. After submitting,
+   * caseDto.caseTypeVersion must equal the pinned version (1), not the latest (2).
+   */
+  @Test
+  void submitResponseEmbedsPinnedCaseTypeVersion() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    // Deploy v2 before submit — should have no effect on the pinned case
+    registry.register(caseTypeV2());
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Bob\",\"amount\":42}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode body = json.readTree(resp.getBody());
+    // caseDto.caseTypeVersion is the case's pinned version (not caseType.version which is also 1
+    // because we embed pinned — both must be 1)
+    assertThat(body.path("data").path("caseTypeVersion").asInt())
+        .as("caseDto.caseTypeVersion must be pinned v1")
+        .isEqualTo(1);
+    assertThat(body.path("data").path("caseType").path("version").asInt())
+        .as("embedded caseType.version must be pinned v1")
+        .isEqualTo(1);
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(EMAIL, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", EMAIL).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).isNotNull();
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private String createCase(String cookie) throws Exception {
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"applicant\":\"Initial\"}}");
+    assertThat(resp.getStatusCode()).as("create case").isEqualTo(HttpStatus.CREATED);
+    return json.readTree(resp.getBody()).path("data").path("id").asText();
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  // ---- CaseType fixtures -----------------------------------------------------
+
+  /**
+   * v1: "applicant" (required text) + "amount" (optional number).
+   * Form has 2 fields. Version = 1.
+   */
+  private static CaseTypeConfig caseTypeV1() {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
+
+    FormDefinition form =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "FormBind Pin Fixture",
+        1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(form));
+  }
+
+  /**
+   * v2: adds a third required field "email". A case pinned to v1 must NOT be required to supply
+   * "email" when submitting the intake-form.
+   */
+  private static CaseTypeConfig caseTypeV2() {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null),
+            new FieldDefinition("email", "Email", FieldType.TEXT, true, 2, List.of(), null));
+
+    FormDefinition form =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "FormBind Pin Fixture",
+        2,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(form));
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinIT.java
@@ -47,10 +47,10 @@ import org.springframework.test.context.TestPropertySource;
  * <p>AC-7 scenario: the submit response DTO carries {@code caseTypeVersion = 1} (pinned), even
  * though v2 is live.
  *
- * <p>Each test uses a unique case-type ID to avoid cross-test registry pollution: the
- * {@link CaseTypeRegistry} is a shared singleton (Spring context reuse) and once v2 is registered
- * for an ID, v1 cannot be re-registered (older-version guard). Per-test IDs isolate the version
- * lifecycle entirely.
+ * <p>Each test uses a unique case-type ID to avoid cross-test registry pollution: the {@link
+ * CaseTypeRegistry} is a shared singleton (Spring context reuse) and once v2 is registered for an
+ * ID, v1 cannot be re-registered (older-version guard). Per-test IDs isolate the version lifecycle
+ * entirely.
  *
  * <p>Uses H2 in-memory DB; companion Postgres-IT is {@code FormBindingVersionPinPostgresIT}.
  *
@@ -93,6 +93,7 @@ class FormBindingVersionPinIT {
    * independent of other tests sharing the same Spring context.
    *
    * <p>Steps:
+   *
    * <ol>
    *   <li>Register v1 and create a case → case.caseTypeVersion = 1.
    *   <li>Register v2 (adds a new required field "email").
@@ -114,8 +115,7 @@ class FormBindingVersionPinIT {
     registry.register(caseTypeV2(caseTypeId));
 
     // Step 3: GET the case — embedded CaseType must be v1 (no "email" field in forms)
-    ResponseEntity<String> getResp =
-        exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
+    ResponseEntity<String> getResp = exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
     assertThat(getResp.getStatusCode()).isEqualTo(HttpStatus.OK);
     JsonNode caseBody = json.readTree(getResp.getBody());
     JsonNode caseTypeNode = caseBody.path("data").path("caseType");
@@ -218,8 +218,7 @@ class FormBindingVersionPinIT {
   // ---- CaseType fixtures -----------------------------------------------------
 
   /**
-   * v1: "applicant" (required text) + "amount" (optional number).
-   * Form has 2 fields. Version = 1.
+   * v1: "applicant" (required text) + "amount" (optional number). Form has 2 fields. Version = 1.
    */
   private static CaseTypeConfig caseTypeV1(String caseTypeId) {
     List<FieldDefinition> fields =

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinIT.java
@@ -41,12 +41,16 @@ import org.springframework.test.context.TestPropertySource;
  * CaseType v2 (with a different form topology) is deployed. The response DTO embeds the
  * <em>pinned</em> CaseTypeConfig, not the latest registered version.
  *
- * <p>AC-5 scenario: create a case (v1 pinned), register v2 with a renamed field, GET the case
- * and submit the form — both must use v1's field set.
+ * <p>AC-5 scenario: create a case (v1 pinned), register v2 with an extra required field, GET the
+ * case and submit the form — both must use v1's field set.
  *
- * <p>AC-7 scenario: the FormSubmitted event (inspected via the updated CaseDto response) carries the
- * caseTypeVersion at the time of submission — which must be 1, the pinned version, even though v2
- * is live.
+ * <p>AC-7 scenario: the submit response DTO carries {@code caseTypeVersion = 1} (pinned), even
+ * though v2 is live.
+ *
+ * <p>Each test uses a unique case-type ID to avoid cross-test registry pollution: the
+ * {@link CaseTypeRegistry} is a shared singleton (Spring context reuse) and once v2 is registered
+ * for an ID, v1 cannot be re-registered (older-version guard). Per-test IDs isolate the version
+ * lifecycle entirely.
  *
  * <p>Uses H2 in-memory DB; companion Postgres-IT is {@code FormBindingVersionPinPostgresIT}.
  *
@@ -66,7 +70,6 @@ class FormBindingVersionPinIT {
 
   private static final String EMAIL = "formbind-pin-it@wkspower.local";
   private static final String PASSWORD = "admin";
-  private static final String CASE_TYPE_ID = "formbind-pin-fixture";
   private static final String FORM_ID = "intake-form";
 
   @Autowired private TestRestTemplate rest;
@@ -81,29 +84,34 @@ class FormBindingVersionPinIT {
       users.save(
           new User(UUID.randomUUID(), EMAIL, Set.of("admin"), true), encoder.encode(PASSWORD));
     }
-    // Register v1 — two fields: applicant (required) + amount (optional)
-    registry.register(caseTypeV1());
   }
 
   /**
    * AC-5 — In-flight case isolation.
    *
+   * <p>Uses a unique case-type ID ({@code "fvp-t1-" + suffix}) so this test's v1/v2 lifecycle is
+   * independent of other tests sharing the same Spring context.
+   *
    * <p>Steps:
    * <ol>
-   *   <li>Create a case while v1 is the only deployed version → case.caseTypeVersion = 1.
-   *   <li>Register v2 (adds a new required field "email", renames nothing but changes the form).
+   *   <li>Register v1 and create a case → case.caseTypeVersion = 1.
+   *   <li>Register v2 (adds a new required field "email").
    *   <li>GET the case — response DTO must embed v1's form (2 fields, no "email").
    *   <li>Submit the v1 form — must succeed (v1's required fields satisfied).
    * </ol>
    */
   @Test
   void inFlightCaseSeesV1FormAfterV2Deploy() throws Exception {
+    // Per-test unique ID avoids registry older-version rejection across tests
+    String caseTypeId = "fvp-t1-" + UUID.randomUUID().toString().substring(0, 8);
+    registry.register(caseTypeV1(caseTypeId));
+
     String cookie = login();
     // Step 1: create case while v1 is live
-    String caseId = createCase(cookie);
+    String caseId = createCase(cookie, caseTypeId);
 
     // Step 2: register v2 with an extra required field "email"
-    registry.register(caseTypeV2());
+    registry.register(caseTypeV2(caseTypeId));
 
     // Step 3: GET the case — embedded CaseType must be v1 (no "email" field in forms)
     ResponseEntity<String> getResp =
@@ -148,11 +156,14 @@ class FormBindingVersionPinIT {
    */
   @Test
   void submitResponseEmbedsPinnedCaseTypeVersion() throws Exception {
+    String caseTypeId = "fvp-t2-" + UUID.randomUUID().toString().substring(0, 8);
+    registry.register(caseTypeV1(caseTypeId));
+
     String cookie = login();
-    String caseId = createCase(cookie);
+    String caseId = createCase(cookie, caseTypeId);
 
     // Deploy v2 before submit — should have no effect on the pinned case
-    registry.register(caseTypeV2());
+    registry.register(caseTypeV2(caseTypeId));
 
     ResponseEntity<String> resp =
         exchange(
@@ -185,13 +196,13 @@ class FormBindingVersionPinIT {
     return semi > 0 ? setCookie.substring(0, semi) : setCookie;
   }
 
-  private String createCase(String cookie) throws Exception {
+  private String createCase(String cookie, String caseTypeId) throws Exception {
     ResponseEntity<String> resp =
         exchange(
             "/api/cases",
             HttpMethod.POST,
             cookie,
-            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"applicant\":\"Initial\"}}");
+            "{\"caseTypeId\":\"" + caseTypeId + "\",\"data\":{\"applicant\":\"Initial\"}}");
     assertThat(resp.getStatusCode()).as("create case").isEqualTo(HttpStatus.CREATED);
     return json.readTree(resp.getBody()).path("data").path("id").asText();
   }
@@ -210,7 +221,7 @@ class FormBindingVersionPinIT {
    * v1: "applicant" (required text) + "amount" (optional number).
    * Form has 2 fields. Version = 1.
    */
-  private static CaseTypeConfig caseTypeV1() {
+  private static CaseTypeConfig caseTypeV1(String caseTypeId) {
     List<FieldDefinition> fields =
         List.of(
             new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
@@ -220,7 +231,7 @@ class FormBindingVersionPinIT {
         new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
 
     return new CaseTypeConfig(
-        CASE_TYPE_ID,
+        caseTypeId,
         "FormBind Pin Fixture",
         1,
         null,
@@ -239,7 +250,7 @@ class FormBindingVersionPinIT {
    * v2: adds a third required field "email". A case pinned to v1 must NOT be required to supply
    * "email" when submitting the intake-form.
    */
-  private static CaseTypeConfig caseTypeV2() {
+  private static CaseTypeConfig caseTypeV2(String caseTypeId) {
     List<FieldDefinition> fields =
         List.of(
             new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
@@ -250,7 +261,7 @@ class FormBindingVersionPinIT {
         new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
 
     return new CaseTypeConfig(
-        CASE_TYPE_ID,
+        caseTypeId,
         "FormBind Pin Fixture",
         2,
         null,

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinPostgresIT.java
@@ -37,9 +37,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 /**
  * Story 5.5 AC-3 + AC-5 — Postgres-IT parity for {@link FormBindingVersionPinIT}.
  *
- * <p>Proves the frozen-on-version guarantee on a real Postgres (JSONB semantics differ from H2
- * for the {@code cases.data} column). The {@code case_type_versions} registry persistence and
- * {@code CaseTypeRegistry.findVersion} cache-miss path are both exercised on real Postgres.
+ * <p>Proves the frozen-on-version guarantee on a real Postgres (JSONB semantics differ from H2 for
+ * the {@code cases.data} column). The {@code case_type_versions} registry persistence and {@code
+ * CaseTypeRegistry.findVersion} cache-miss path are both exercised on real Postgres.
  *
  * <p>Skipped automatically when Docker is unavailable.
  *
@@ -75,8 +75,7 @@ class FormBindingVersionPinPostgresIT {
     reg.add("WKS_ADMIN_PASSWORD", () -> PASSWORD);
     reg.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
     reg.add("WKS_CORS_ORIGINS", () -> "http://localhost:5173");
-    reg.add(
-        "camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+    reg.add("camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
     reg.add("wks.case-types.dir", () -> "");
   }
 
@@ -105,20 +104,14 @@ class FormBindingVersionPinPostgresIT {
     registry.register(caseTypeV2());
 
     // GET the case — embedded CaseType must be v1
-    ResponseEntity<String> getResp =
-        exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
+    ResponseEntity<String> getResp = exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
     assertThat(getResp.getStatusCode()).isEqualTo(HttpStatus.OK);
     JsonNode caseBody = json.readTree(getResp.getBody());
     JsonNode caseTypeNode = caseBody.path("data").path("caseType");
     assertThat(caseTypeNode.path("version").asInt())
         .as("GET response must embed pinned v1 on Postgres")
         .isEqualTo(1);
-    JsonNode formFields =
-        caseTypeNode
-            .path("forms")
-            .elements()
-            .next()
-            .path("fields");
+    JsonNode formFields = caseTypeNode.path("forms").elements().next().path("fields");
     assertThat(formFields.size()).as("pinned v1 form must have 2 fields on Postgres").isEqualTo(2);
 
     // Submit with v1 payload — must succeed (no "email" required at v1)
@@ -131,8 +124,12 @@ class FormBindingVersionPinPostgresIT {
     assertThat(submitResp.getStatusCode())
         .as("v1 submit must succeed on Postgres even though v2 is live")
         .isEqualTo(HttpStatus.OK);
-    assertThat(json.readTree(submitResp.getBody())
-            .path("data").path("caseType").path("version").asInt())
+    assertThat(
+            json.readTree(submitResp.getBody())
+                .path("data")
+                .path("caseType")
+                .path("version")
+                .asInt())
         .as("submit response embeds pinned v1 on Postgres")
         .isEqualTo(1);
   }

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinPostgresIT.java
@@ -1,0 +1,219 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Story 5.5 AC-3 + AC-5 — Postgres-IT parity for {@link FormBindingVersionPinIT}.
+ *
+ * <p>Proves the frozen-on-version guarantee on a real Postgres (JSONB semantics differ from H2
+ * for the {@code cases.data} column). The {@code case_type_versions} registry persistence and
+ * {@code CaseTypeRegistry.findVersion} cache-miss path are both exercised on real Postgres.
+ *
+ * <p>Skipped automatically when Docker is unavailable.
+ *
+ * <p>Memory {@code feedback_production_validator_opt_out.md}: production-validation disabled.
+ */
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = "wks.bootstrap.production-validation.enabled=false")
+@ActiveProfiles("production")
+@Testcontainers(disabledWithoutDocker = true)
+class FormBindingVersionPinPostgresIT {
+
+  private static final String EMAIL = "formbind-pin-pg-it@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String CASE_TYPE_ID = "formbind-pin-pg-fixture";
+  private static final String FORM_ID = "intake-form";
+
+  @Container
+  @SuppressWarnings("resource")
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("wks")
+          .withUsername("wks")
+          .withPassword("wks");
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry reg) {
+    reg.add("WKS_DB_URL", POSTGRES::getJdbcUrl);
+    reg.add("WKS_DB_USER", POSTGRES::getUsername);
+    reg.add("WKS_DB_PASSWORD", POSTGRES::getPassword);
+    reg.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    reg.add("WKS_ADMIN_EMAIL", () -> EMAIL);
+    reg.add("WKS_ADMIN_PASSWORD", () -> PASSWORD);
+    reg.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+    reg.add("WKS_CORS_ORIGINS", () -> "http://localhost:5173");
+    reg.add(
+        "camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+    reg.add("wks.case-types.dir", () -> "");
+  }
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private ObjectMapper json;
+
+  @BeforeEach
+  void setup() {
+    registry.register(caseTypeV1());
+  }
+
+  /**
+   * AC-5 on Postgres — In-flight case isolation with real JSONB column.
+   *
+   * <p>Verifies that a case created while v1 is current sees v1's form (2 fields) after v2 (3
+   * fields, adds required "email") is deployed. The {@code case_type_versions} table on Postgres
+   * must persist both versions and {@code CaseTypeRegistry.findVersion(id, 1)} must resolve v1.
+   */
+  @Test
+  void inFlightCaseSeesV1FormAfterV2DeployOnPostgres() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    // Deploy v2 with extra required field
+    registry.register(caseTypeV2());
+
+    // GET the case — embedded CaseType must be v1
+    ResponseEntity<String> getResp =
+        exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
+    assertThat(getResp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode caseBody = json.readTree(getResp.getBody());
+    JsonNode caseTypeNode = caseBody.path("data").path("caseType");
+    assertThat(caseTypeNode.path("version").asInt())
+        .as("GET response must embed pinned v1 on Postgres")
+        .isEqualTo(1);
+    JsonNode formFields =
+        caseTypeNode
+            .path("forms")
+            .elements()
+            .next()
+            .path("fields");
+    assertThat(formFields.size()).as("pinned v1 form must have 2 fields on Postgres").isEqualTo(2);
+
+    // Submit with v1 payload — must succeed (no "email" required at v1)
+    ResponseEntity<String> submitResp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\",\"amount\":9000}");
+    assertThat(submitResp.getStatusCode())
+        .as("v1 submit must succeed on Postgres even though v2 is live")
+        .isEqualTo(HttpStatus.OK);
+    assertThat(json.readTree(submitResp.getBody())
+            .path("data").path("caseType").path("version").asInt())
+        .as("submit response embeds pinned v1 on Postgres")
+        .isEqualTo(1);
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(EMAIL, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", EMAIL).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).isNotNull();
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private String createCase(String cookie) throws Exception {
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"applicant\":\"Initial\"}}");
+    assertThat(resp.getStatusCode()).as("create case").isEqualTo(HttpStatus.CREATED);
+    return json.readTree(resp.getBody()).path("data").path("id").asText();
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  // ---- CaseType fixtures -----------------------------------------------------
+
+  private static CaseTypeConfig caseTypeV1() {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
+    FormDefinition form =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "FormBind Pin PG Fixture",
+        1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(form));
+  }
+
+  private static CaseTypeConfig caseTypeV2() {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null),
+            new FieldDefinition("email", "Email", FieldType.TEXT, true, 2, List.of(), null));
+    FormDefinition form =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "FormBind Pin PG Fixture",
+        2,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(form));
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/FormDraftIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormDraftIT.java
@@ -308,7 +308,7 @@ class FormDraftIT {
             new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
             new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
     FormDefinition intakeForm =
-        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
     return new CaseTypeConfig(
         CASE_TYPE_ID,
         "Form Draft Fixture",

--- a/backend/src/test/java/com/wkspower/platform/integration/FormSubmitIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormSubmitIT.java
@@ -186,7 +186,7 @@ class FormSubmitIT {
             new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
 
     FormDefinition intakeForm =
-        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
 
     return new CaseTypeConfig(
         CASE_TYPE_ID,

--- a/backend/src/test/java/com/wkspower/platform/integration/FormSubmitPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormSubmitPostgresIT.java
@@ -1,0 +1,214 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Story 5.5 AC-3 — Postgres-IT parity for {@link FormSubmitIT}.
+ *
+ * <p>CF#2 from Sprint 9 retro: the H2 FormSubmitIT siblings must be re-verified on a real Postgres
+ * at PR-open to guard against schema drift (H2 and Postgres differ on JSONB semantics for the
+ * {@code cases.data} column). This IT mirrors the four key scenarios from {@link FormSubmitIT}
+ * against a real Postgres instance provided by Testcontainers.
+ *
+ * <p>Skipped automatically when Docker is unavailable.
+ *
+ * <p>Memory {@code feedback_production_validator_opt_out.md}: production-validation disabled — only
+ * exercises the form-submit surface, not the boot-invariant.
+ */
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = "wks.bootstrap.production-validation.enabled=false")
+@ActiveProfiles("production")
+@Testcontainers(disabledWithoutDocker = true)
+class FormSubmitPostgresIT {
+
+  private static final String EMAIL = "form-submit-pg-it@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String CASE_TYPE_ID = "form-submit-pg-fixture";
+  private static final String FORM_ID = "intake-form";
+
+  @Container
+  @SuppressWarnings("resource")
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("wks")
+          .withUsername("wks")
+          .withPassword("wks");
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry reg) {
+    reg.add("WKS_DB_URL", POSTGRES::getJdbcUrl);
+    reg.add("WKS_DB_USER", POSTGRES::getUsername);
+    reg.add("WKS_DB_PASSWORD", POSTGRES::getPassword);
+    reg.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    reg.add("WKS_ADMIN_EMAIL", () -> EMAIL);
+    reg.add("WKS_ADMIN_PASSWORD", () -> PASSWORD);
+    reg.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+    reg.add("WKS_CORS_ORIGINS", () -> "http://localhost:5173");
+    reg.add(
+        "camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+    reg.add("wks.case-types.dir", () -> "");
+  }
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private ObjectMapper json;
+
+  @BeforeEach
+  void setup() {
+    registry.register(caseTypeWithForm());
+  }
+
+  @Test
+  void happyPathReturns200WithUpdatedCaseDataOnPostgres() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\",\"amount\":5000}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    JsonNode body = json.readTree(resp.getBody());
+    assertThat(body.path("data").path("data").path("applicant").asText()).isEqualTo("Alice");
+  }
+
+  @Test
+  void unknownFormIdReturns404OnPostgres() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/nonexistent-form/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\"}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(resp.getBody()).contains("WKS-API-404");
+  }
+
+  @Test
+  void missingRequiredFieldReturns422OnPostgres() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"amount\":100}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(resp.getBody()).contains("WKS-FORM-002");
+  }
+
+  @Test
+  void emptyBodyReturns400OnPostgres() throws Exception {
+    String cookie = login();
+    String caseId = createCase(cookie);
+
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{}");
+
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(resp.getBody()).contains("WKS-FORM-003");
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(EMAIL, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", EMAIL).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).isNotNull();
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private String createCase(String cookie) throws Exception {
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"applicant\":\"Initial\"}}");
+    assertThat(resp.getStatusCode()).as("create case").isEqualTo(HttpStatus.CREATED);
+    return json.readTree(resp.getBody()).path("data").path("id").asText();
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  private static CaseTypeConfig caseTypeWithForm() {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
+
+    FormDefinition intakeForm =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Form Submit PG Fixture",
+        1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(intakeForm));
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/FormSubmitPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormSubmitPostgresIT.java
@@ -77,8 +77,7 @@ class FormSubmitPostgresIT {
     reg.add("WKS_ADMIN_PASSWORD", () -> PASSWORD);
     reg.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
     reg.add("WKS_CORS_ORIGINS", () -> "http://localhost:5173");
-    reg.add(
-        "camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+    reg.add("camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
     reg.add("wks.case-types.dir", () -> "");
   }
 

--- a/backend/src/test/java/com/wkspower/platform/integration/PerFieldEditPermissionIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/PerFieldEditPermissionIT.java
@@ -239,7 +239,7 @@ class PerFieldEditPermissionIT {
                 null,
                 List.of("role:underwriter")));
     FormDefinition intakeForm =
-        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
     return new CaseTypeConfig(
         CASE_TYPE_ID,
         "Per-Field Permission Fixture",
@@ -276,7 +276,7 @@ class PerFieldEditPermissionIT {
             new FieldDefinition(
                 "amount", "Amount", FieldType.NUMBER, false, false, 1, List.of(), null, List.of()));
     FormDefinition intakeForm =
-        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
     return new CaseTypeConfig(
         LOCKED_CASE_TYPE_ID,
         "Locked Default Fixture",

--- a/backend/src/test/java/com/wkspower/platform/integration/RequireCaseAccessConsolidationIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/RequireCaseAccessConsolidationIT.java
@@ -139,7 +139,7 @@ class RequireCaseAccessConsolidationIT {
             new FieldDefinition(
                 "applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null));
     FormDefinition intakeForm =
-        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields);
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
     return new CaseTypeConfig(
         CASE_TYPE_ID,
         "Require Access Fixture",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -284,5 +284,6 @@
   "form.draft.versionChanged.title": "This form has changed since your draft was saved",
   "form.draft.versionChanged.body": "The case-type version was bumped while you were away. Your draft cannot be applied to the new form. Discard the draft to continue with the current form, or cancel to come back later.",
   "form.draft.versionChanged.discardAndUseCurrent": "Discard draft and use current form",
-  "form.draft.versionChanged.cancel": "Cancel"
+  "form.draft.versionChanged.cancel": "Cancel",
+  "form.pinnedVersion": "Form pinned to CaseType v{version}"
 }

--- a/frontend/src/pages/FormPage.tsx
+++ b/frontend/src/pages/FormPage.tsx
@@ -128,7 +128,17 @@ export function FormPage() {
 
   return (
     <div className="mx-auto max-w-2xl p-6">
-      <h1 className="mb-6 text-xl font-semibold">{formDef.id}</h1>
+      <div className="mb-6 flex items-center gap-3">
+        <h1 className="text-xl font-semibold">{formDef.id}</h1>
+        {/* Story 5.5 AC-4 — version-pin chip. caseDto.caseTypeVersion is the pinned version
+            (server now returns pinned CaseType, not latest — Decision D20). */}
+        <span
+          className="rounded-full bg-[var(--muted)] px-2 py-0.5 text-xs text-[var(--muted-foreground)]"
+          aria-label={t('form.pinnedVersion', { version: String(caseDto.caseTypeVersion) })}
+        >
+          {t('form.pinnedVersion', { version: String(caseDto.caseTypeVersion) })}
+        </span>
+      </div>
       {draft.draft ? (
         <div
           role="status"


### PR DESCRIPTION
## Summary

Story 5-5 — Frozen-on-version form binding per D20. Form submission and rendering now resolve `FormDefinition` against the **pinned** `CaseType` carried on the `Case` (not the latest deployed version), so a v1-pinned case sees v1 forms even after v2 deploys with breaking changes.

Also hosts two Sprint 9 carry-forwards: CF#2 (Postgres-IT parity for `FormSubmitIT` family, parity drift = defect per hardened rule) and CF#3 (remove `FormDefinition` + `RawFormDefinition` compat ctors introduced by 6-1).

## ACs

- [x] **AC-1** Remove `FormDefinition` 2 compat ctors (5-arg pre-5.3, 6-arg pre-6.1) → migrate all callers to 7-arg canonical
- [x] **AC-2** Remove `RawFormDefinition` 2 compat ctors → migrate all callers to 7-arg canonical
- [x] **AC-3** Postgres-IT parity (CF#2): `FormSubmitPostgresIT` + `FormBindingVersionPinPostgresIT` ship in same PR as H2 siblings — verified at PR-open time
- [x] **AC-4** `CaseService.resolveFormDefinitionForCase` as single source of truth for pinned-version form lookup; `FormController` + `CaseController` embed pinned `CaseType` (not latest); mint `WKS-VER-002` defensive code; FormPage shows "Form pinned to CaseType v{N}" chip
- [x] **AC-5** `FormBindingVersionPinIT` proves in-flight isolation — v1-pinned case sees v1 form after v2 deploys
- [x] **AC-6** `CaseService.update()` validates against pinned CaseType (not latest)
- [x] **AC-7** `FormSubmitted` event carries `caseTypeVersion` (pinned, not latest)
- [x] **AC-8** Gap-4 fold: `seed.sh --j11-v2` flag + `form-single-page-v2.yaml` fixture + JOURNEYS.md version-bumped-resume walk

## Postgres-IT parity

YES — `FormSubmitPostgresIT.java` + `FormBindingVersionPinPostgresIT.java` both present (verified at PR-open).

## Wire-contract / migrations

- Flyway: no new migration (per-Case pinning uses existing `cases.case_type_version` + `form_drafts.case_type_version_at_save` columns; placeholder slot V202605120002 dropped at story creation)
- Error codes: mints `WKS-VER-002` ("case pinned to unknown CaseTypeVersion") — next-free in WKS-VER band

## Compat-ctor debt

This story removes the last two known compat-ctor accretions in the form record family. `StageDefinition` retains 2 compat ctors (lines 72, 80) — flagged for next stage-touching story per `project_raw_casetype_config_constructor_debt` memory.

## Test plan

- [x] `mvn -B verify` green from clean working tree (Postgres ITs included)
- [x] Tenant-invariant lint clean
- [x] Spotless applied
- [x] Pre-push CI mirror passed
- [x] Manual UI walkthrough: v1-pinned chip + version-bumped resume per JOURNEYS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)