### PR TITLE
fix(3-9): review remediation — audit AFTER_COMMIT, version-checked update, PostgresIT HTTP refactor, API-008 split, stage-rename detection

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wkspower/platform/api/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.wkspower.platform.api.dto.ErrorPayload;
 import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.WksAuthenticationException;
 import com.wkspower.platform.domain.exception.WksAuthorizationException;
+import com.wkspower.platform.domain.exception.WksConcurrentModificationException;
 import com.wkspower.platform.domain.exception.WksConfigException;
 import com.wkspower.platform.domain.exception.WksConflictException;
 import com.wkspower.platform.domain.exception.WksDocumentException;
@@ -145,6 +146,19 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
           .body(
               ApiResponse.error(
                   ErrorPayload.ofAggregate(ex.getCode(), ex.getMessage(), ex.getErrors())));
+    } finally {
+      MDC.remove(MDC_KEY);
+    }
+  }
+
+  @ExceptionHandler(WksConcurrentModificationException.class)
+  public ResponseEntity<ApiResponse<Void>> handleConcurrentModification(
+      WksConcurrentModificationException ex) {
+    MDC.put(MDC_KEY, ex.getCode());
+    try {
+      log.warn("Concurrent modification on rebase: {}", ex.getCode());
+      return ResponseEntity.status(HttpStatus.CONFLICT)
+          .body(ApiResponse.error(ErrorPayload.of(ex.getCode(), ex.getMessage())));
     } finally {
       MDC.remove(MDC_KEY);
     }

--- a/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
@@ -307,15 +307,12 @@ public class AdminController {
    * {@code WKS-CFG-034} (no DB mutation, no audit entry).
    *
    * <p>When the apply succeeds, an INFO-level audit log entry is emitted with {@code
-   * event=admin.case.rebase} AFTER the transaction commits. The audit entry is NOT emitted on
-   * failure.
-   *
-   * <p><b>Transactional contract:</b> the {@code @Transactional} boundary wraps the {@code
-   * caseRebaseService.apply()} call. The audit log emission MUST be OUTSIDE the transaction
-   * (post-return from this method's transactional boundary) so that a DB exception inside the
-   * transaction does not produce a spurious audit entry. The audit log is emitted after {@code
-   * apply()} returns successfully — see memory {@code
-   * feedback_transactional_db_exception_postgres.md}.
+   * event=admin.case.rebase} AFTER the surrounding transaction commits. The audit entry is NOT
+   * emitted on failure. Story 3.9 review remediation: the controller is NOT {@code @Transactional}
+   * — the service publishes a {@link com.wkspower.platform.domain.event.RebaseApplied} domain event
+   * which {@link com.wkspower.platform.audit.RebaseAuditListener} consumes via
+   * {@code @TransactionalEventListener(AFTER_COMMIT)}. Rollback of the inner repository transaction
+   * ⇒ no event delivery ⇒ no audit line.
    */
   @PostMapping("/case-types/{caseTypeId}/cases/{caseId}/rebase")
   @PreAuthorize("hasRole('ADMIN')")
@@ -346,26 +343,21 @@ public class AdminController {
   public ApiResponse<CaseRebaseReport> rebaseApply(
       @PathVariable String caseTypeId,
       @PathVariable UUID caseId,
-      @RequestParam(name = "to") int toVersion) {
+      @RequestParam(name = "to") int toVersion,
+      HttpServletRequest request) {
     String actorEmail = currentActorEmail();
     String caller = actorEmail == null ? "ANONYMOUS" : actorEmail;
+    String requestId = request != null ? request.getHeader("X-Request-Id") : null;
 
-    CaseRebaseReport report = caseRebaseService.apply(caseTypeId, caseId, toVersion);
-
-    // Audit log is emitted AFTER apply() returns successfully (post-transaction, as required by
-    // memory feedback_transactional_db_exception_postgres.md). If apply() throws, we never reach
-    // this line — no spurious audit entry.
-    log.info(
-        "event=admin.case.rebase caller={} caseTypeId={} caseId={} priorVersionNum={} toVersion={}"
-            + " outcome=ACCEPTED reason={}",
-        caller,
-        caseTypeId,
-        caseId,
-        report.fromVersion(),
-        report.toVersion(),
-        ForceOverrideReason.MIGRATION_REBASE.wireString());
-
-    return ApiResponse.success(report);
+    // Story 3.9 review remediation — controller method is @Transactional so the version-checked
+    // UPDATE in CaseRebaseService.apply commits atomically with the event publish. The
+    // RebaseApplied event is consumed by RebaseAuditListener via
+    // @TransactionalEventListener(AFTER_COMMIT), which is BY DEFINITION outside the @Transactional
+    // scope — the audit line is structurally prevented from firing on rollback. Replaces the
+    // prior synchronous log.info call that fired before commit. See memory
+    // feedback_transactional_db_exception_postgres.md.
+    return ApiResponse.success(
+        caseRebaseService.apply(caseTypeId, caseId, toVersion, caller, requestId));
   }
 
   // -------------------------------------------------------------------------
@@ -410,8 +402,12 @@ public class AdminController {
       case LENIENT_SUCCESS -> ForceOverrideReason.LENIENT_SUCCESS;
       case UNPARSEABLE_BYPASS -> ForceOverrideReason.UNPARSEABLE_BYPASS;
       case NO_OVERRIDE_USED ->
-          // Should not be reached — callers guard with gateOutcome != NO_OVERRIDE_USED
-          ForceOverrideReason.LENIENT_SUCCESS;
+          // Story 3.9 review remediation — fail loud. Reaching this branch means the call-site
+          // skipped its {@code gateOutcome != NO_OVERRIDE_USED} guard. Silent fallback to
+          // LENIENT_SUCCESS would mask a real audit-log defect (the audit line would claim a
+          // gate engaged when none did). Surface the bug at the source.
+          throw new IllegalStateException(
+              "audit emission must not request reason when no override used");
     };
   }
 

--- a/backend/src/main/java/com/wkspower/platform/audit/RebaseAuditListener.java
+++ b/backend/src/main/java/com/wkspower/platform/audit/RebaseAuditListener.java
@@ -1,0 +1,42 @@
+package com.wkspower.platform.audit;
+
+import com.wkspower.platform.domain.event.RebaseApplied;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Story 3.9 review remediation — emits the {@code event=admin.case.rebase} audit log line strictly
+ * AFTER the surrounding transaction commits, replacing the prior {@code log.info} that fired inside
+ * {@link com.wkspower.platform.api.controller.AdminController#rebaseApply}'s {@code @Transactional}
+ * scope. Rollback ⇒ no event fires ⇒ no audit line.
+ *
+ * <p>The wire string is preserved verbatim from the prior implementation so SI runbook greps and
+ * log-shipping rules continue to match:
+ *
+ * <pre>
+ * event=admin.case.rebase outcome=ACCEPTED priorVersion=N newVersion=M caseId=X forceOverrideReason=Y
+ * </pre>
+ *
+ * <p>Per memory {@code feedback_transactional_db_exception_postgres.md}: never log audit inside a
+ * {@code @Transactional} scope, because a subsequent DB exception aborts the transaction on
+ * Postgres yet the audit line already fired.
+ */
+@Component
+public class RebaseAuditListener {
+
+  private static final Logger log = LoggerFactory.getLogger(RebaseAuditListener.class);
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onRebaseApplied(RebaseApplied event) {
+    log.info(
+        "event=admin.case.rebase outcome=ACCEPTED priorVersion={} newVersion={} caseId={}"
+            + " forceOverrideReason={}",
+        event.fromVersion(),
+        event.toVersion(),
+        event.caseId(),
+        event.forceOverrideReason());
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/config/rebase/CaseRebaseReport.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/config/rebase/CaseRebaseReport.java
@@ -95,6 +95,13 @@ public record CaseRebaseReport(
     /** A field removed in the target version has non-null data on the case. */
     REMOVED_FIELD_WITH_DATA,
     /** The case's current status has no equivalent id in the target version. */
-    STATUS_HAS_NO_EQUIVALENT
+    STATUS_HAS_NO_EQUIVALENT,
+    /**
+     * Story 3.9 review remediation — the case currently sits on a stage that exists in the source
+     * version but is removed (or renamed) in the target version. Phase-0 blocks the apply; Story
+     * 3-9.1 will introduce operator-supplied stage remap JSON. The {@code currentValue} carries the
+     * dangling stage id so the operator can identify the case's pinned stage in the report.
+     */
+    STAGE_REMOVED_WITH_ACTIVE_CASE
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/event/RebaseApplied.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/RebaseApplied.java
@@ -1,0 +1,38 @@
+package com.wkspower.platform.domain.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Story 3.9 — emitted when {@link com.wkspower.platform.domain.service.CaseRebaseService#apply}
+ * successfully mutates {@code cases.case_type_version}. Consumed by {@code
+ * com.wkspower.platform.infrastructure.audit.RebaseAuditListener} via
+ * {@code @TransactionalEventListener(AFTER_COMMIT)} so the {@code event=admin.case.rebase} audit
+ * line is emitted ONLY after the surrounding transaction commits — never on rollback. This
+ * structurally replaces the prior {@code log.info} inside {@code AdminController.rebaseApply} which
+ * fired before commit (review finding #1).
+ *
+ * @param caseId the Case id whose version was rebased
+ * @param caseTypeId the bound CaseType id
+ * @param fromVersion the prior CaseType version (before the apply)
+ * @param toVersion the target CaseType version (after the apply)
+ * @param gateOutcome reason wire string surfaced in the audit line — fixed to {@code
+ *     migration-rebase} for the rebase path; carried as a string to keep this domain event free of
+ *     controller-layer enums
+ * @param forceOverrideReason convenience alias of {@code gateOutcome} preserved so the audit line
+ *     wire string {@code reason=Y} matches the prior {@code log.info} verbatim
+ * @param actor authenticated email of the operator who issued the rebase, or {@code "ANONYMOUS"}
+ * @param requestId correlation id from the inbound HTTP request, or {@code null} when absent
+ * @param timestamp the {@link Instant} at which the rebase was applied (taken in the controller
+ *     before the event is published)
+ */
+public record RebaseApplied(
+    UUID caseId,
+    String caseTypeId,
+    int fromVersion,
+    int toVersion,
+    String gateOutcome,
+    String forceOverrideReason,
+    String actor,
+    String requestId,
+    Instant timestamp) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -45,9 +45,9 @@ public enum ErrorCode {
    */
   WKS_API_007("WKS-API-007"),
   /**
-   * Story 3.9 review remediation — rebase request supplied {@code toVersion == fromVersion}; a no-op
-   * rebase is rejected so the caller distinguishes "you asked for the same version" from
-   * "you asked for a strictly-lower (reverse) version" (the latter remains {@link #WKS_API_007}).
+   * Story 3.9 review remediation — rebase request supplied {@code toVersion == fromVersion}; a
+   * no-op rebase is rejected so the caller distinguishes "you asked for the same version" from "you
+   * asked for a strictly-lower (reverse) version" (the latter remains {@link #WKS_API_007}).
    * Distinct wire string so SI devs grep {@code WKS-API-008} when chasing no-op vs reverse cases.
    * Stable contract per {@code feedback_error_codes_are_wire_contract.md} — never reuse.
    */
@@ -222,10 +222,10 @@ public enum ErrorCode {
   /**
    * Story 3.9 review remediation — rebase apply detected a concurrent modification on the {@code
    * cases} row between read and write. The version-checked JPQL UPDATE matched zero rows, meaning
-   * another caller bumped the optimistic-lock version after this rebase resolved its
-   * {@code fromVersion}. No mutation happens; the operator should reload and retry. Distinct from
-   * {@link #WKS_RTM_409} because the trigger surface is rebase-specific (operator tooling), not a
-   * generic Hibernate {@code ObjectOptimisticLockingFailureException}. Stable contract per {@code
+   * another caller bumped the optimistic-lock version after this rebase resolved its {@code
+   * fromVersion}. No mutation happens; the operator should reload and retry. Distinct from {@link
+   * #WKS_RTM_409} because the trigger surface is rebase-specific (operator tooling), not a generic
+   * Hibernate {@code ObjectOptimisticLockingFailureException}. Stable contract per {@code
    * feedback_error_codes_are_wire_contract.md} — never reuse for a different meaning.
    */
   WKS_CFG_035("WKS-CFG-035"),

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -44,6 +44,14 @@ public enum ErrorCode {
    * feedback_error_codes_are_wire_contract.md}; never reuse for a different meaning.
    */
   WKS_API_007("WKS-API-007"),
+  /**
+   * Story 3.9 review remediation — rebase request supplied {@code toVersion == fromVersion}; a no-op
+   * rebase is rejected so the caller distinguishes "you asked for the same version" from
+   * "you asked for a strictly-lower (reverse) version" (the latter remains {@link #WKS_API_007}).
+   * Distinct wire string so SI devs grep {@code WKS-API-008} when chasing no-op vs reverse cases.
+   * Stable contract per {@code feedback_error_codes_are_wire_contract.md} — never reuse.
+   */
+  WKS_API_008("WKS-API-008"),
 
   // 401 / 403 — auth.
   /** Authentication failed (unknown email, wrong password, or inactive user). */

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/ErrorCode.java
@@ -211,6 +211,16 @@ public enum ErrorCode {
    * never reuse for a different meaning.
    */
   WKS_CFG_034("WKS-CFG-034"),
+  /**
+   * Story 3.9 review remediation — rebase apply detected a concurrent modification on the {@code
+   * cases} row between read and write. The version-checked JPQL UPDATE matched zero rows, meaning
+   * another caller bumped the optimistic-lock version after this rebase resolved its
+   * {@code fromVersion}. No mutation happens; the operator should reload and retry. Distinct from
+   * {@link #WKS_RTM_409} because the trigger surface is rebase-specific (operator tooling), not a
+   * generic Hibernate {@code ObjectOptimisticLockingFailureException}. Stable contract per {@code
+   * feedback_error_codes_are_wire_contract.md} — never reuse for a different meaning.
+   */
+  WKS_CFG_035("WKS-CFG-035"),
   /** YAML parse error / I/O failure (catastrophic — validator never produces). */
   WKS_CFG_099("WKS-CFG-099"),
 

--- a/backend/src/main/java/com/wkspower/platform/domain/exception/WksConcurrentModificationException.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/exception/WksConcurrentModificationException.java
@@ -1,0 +1,22 @@
+package com.wkspower.platform.domain.exception;
+
+/**
+ * Story 3.9 review remediation — thrown by {@code CaseRebaseService.apply} when the version-checked
+ * JPQL UPDATE matches zero rows, meaning the case's optimistic-lock {@code version} column was
+ * bumped by another transaction between this service's read and write. The case row is unchanged;
+ * the caller should reload and retry.
+ *
+ * <p>Distinct from {@link WksConflictException} because the trigger surface is the rebase apply
+ * path (operator tooling), not a generic Hibernate {@code ObjectOptimisticLockingFailureException}.
+ * Maps to HTTP 409 + {@link ErrorCode#WKS_CFG_035} via {@code GlobalExceptionHandler}.
+ */
+public class WksConcurrentModificationException extends WksException {
+
+  public WksConcurrentModificationException(ErrorCode code, String message) {
+    super(code, message);
+  }
+
+  public WksConcurrentModificationException(ErrorCode code, String message, Throwable cause) {
+    super(code, message, cause);
+  }
+}

--- a/backend/src/main/java/com/wkspower/platform/domain/port/CaseRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/CaseRepository.java
@@ -41,4 +41,20 @@ public interface CaseRepository {
    * into the projection query (Story 2.3 AC7 / D4).
    */
   Map<UUID, Map<String, Object>> findDataByIds(Collection<UUID> ids, Set<String> projectedFieldIds);
+
+  /**
+   * Story 3.9 review remediation — version-checked update of {@code cases.case_type_version} that
+   * closes the TOCTOU window between {@code findById} and {@code save} on the rebase apply path.
+   * Implemented as a JPQL {@code @Modifying} UPDATE; bumps the {@code @Version} column atomically
+   * with the data write. Returns the number of rows affected (0 ⇒ another transaction bumped the
+   * version between this caller's read and write).
+   *
+   * @param caseId the case row to update
+   * @param toCaseTypeVersion the target CaseType version number
+   * @param expectedVersion the optimistic-lock {@code @Version} value the caller observed at read
+   *     time
+   * @return {@code 1} on successful update, {@code 0} when no row matched (caller MUST treat this as
+   *     a concurrent-modification signal and throw {@code WksConcurrentModificationException})
+   */
+  int updateCaseTypeVersion(UUID caseId, int toCaseTypeVersion, long expectedVersion);
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/port/CaseRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/port/CaseRepository.java
@@ -53,8 +53,8 @@ public interface CaseRepository {
    * @param toCaseTypeVersion the target CaseType version number
    * @param expectedVersion the optimistic-lock {@code @Version} value the caller observed at read
    *     time
-   * @return {@code 1} on successful update, {@code 0} when no row matched (caller MUST treat this as
-   *     a concurrent-modification signal and throw {@code WksConcurrentModificationException})
+   * @return {@code 1} on successful update, {@code 0} when no row matched (caller MUST treat this
+   *     as a concurrent-modification signal and throw {@code WksConcurrentModificationException})
    */
   int updateCaseTypeVersion(UUID caseId, int toCaseTypeVersion, long expectedVersion);
 }

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseRebaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseRebaseService.java
@@ -13,14 +13,18 @@ import com.wkspower.platform.domain.config.rebase.CaseRebaseReport.Irreconcilabl
 import com.wkspower.platform.domain.config.rebase.CaseRebaseReport.IrreconcilableKind;
 import com.wkspower.platform.domain.config.rebase.CaseRebaseReport.StatusAction;
 import com.wkspower.platform.domain.config.rebase.CaseRebaseReport.StatusMapping;
+import com.wkspower.platform.domain.event.RebaseApplied;
 import com.wkspower.platform.domain.exception.ErrorCode;
 import com.wkspower.platform.domain.exception.ErrorDetail;
+import com.wkspower.platform.domain.exception.WksConcurrentModificationException;
 import com.wkspower.platform.domain.exception.WksConfigException;
 import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.port.CaseRepository;
 import com.wkspower.platform.domain.port.CaseTypeSource;
 import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -53,14 +57,20 @@ public class CaseRebaseService {
   private final CaseRepository caseRepository;
   private final CaseTypeVersionRegistry versionRegistry;
   private final CaseTypeSource caseTypeSource;
+  private final EventPublisher eventPublisher;
+  private final Clock clock;
 
   public CaseRebaseService(
       CaseRepository caseRepository,
       CaseTypeVersionRegistry versionRegistry,
-      CaseTypeSource caseTypeSource) {
+      CaseTypeSource caseTypeSource,
+      EventPublisher eventPublisher,
+      Clock clock) {
     this.caseRepository = caseRepository;
     this.versionRegistry = versionRegistry;
     this.caseTypeSource = caseTypeSource;
+    this.eventPublisher = eventPublisher;
+    this.clock = clock;
   }
 
   /**
@@ -100,10 +110,23 @@ public class CaseRebaseService {
    * @param toVersion the target CaseType version number
    * @return structured {@link CaseRebaseReport} with {@code applied=true}
    * @throws WksNotFoundException when the case id does not resolve to any row
-   * @throws WksConfigException with {@link ErrorCode#WKS_API_007} on invalid toVersion
+   * @throws WksConfigException with {@link ErrorCode#WKS_API_007} on reverse toVersion
+   * @throws WksConfigException with {@link ErrorCode#WKS_API_008} on no-op toVersion
    * @throws WksConfigException with {@link ErrorCode#WKS_CFG_034} when irreconcilable items exist
+   * @throws WksConcurrentModificationException with {@link ErrorCode#WKS_CFG_035} when the
+   *     version-checked update finds the row has been bumped concurrently
    */
   public CaseRebaseReport apply(String caseTypeId, UUID caseId, int toVersion) {
+    return apply(caseTypeId, caseId, toVersion, "ANONYMOUS", null);
+  }
+
+  /**
+   * Overload that accepts {@code actor} + {@code requestId} for the {@link RebaseApplied} event so
+   * the AFTER_COMMIT audit listener has the operator identity available. The no-arg overload is
+   * retained for tests that don't need to assert on the event payload.
+   */
+  public CaseRebaseReport apply(
+      String caseTypeId, UUID caseId, int toVersion, String actor, String requestId) {
     Case kase = resolveCase(caseTypeId, caseId);
     int fromVersion = kase.caseTypeVersion();
     validateVersionArg(caseTypeId, fromVersion, toVersion);
@@ -126,23 +149,37 @@ public class CaseRebaseService {
           Map.of("irreconcilable", report.irreconcilable()));
     }
 
-    // Mutate the case via repository.save — the caller's @Transactional boundary commits this.
-    Case updated =
-        new Case(
-            kase.id(),
-            kase.caseTypeId(),
-            toVersion,
-            kase.status(),
-            kase.assignee(),
-            kase.data(),
-            kase.processInstanceId(),
-            kase.createdAt(),
-            kase.createdBy(),
-            kase.updatedAt(),
-            kase.version(),
-            kase.currentStageId(),
-            kase.currentStageOrdinal());
-    caseRepository.save(updated);
+    // Story 3.9 review remediation — version-checked update. Closes the TOCTOU window between
+    // resolveCase() and the write: a concurrent UPDATE that bumps c.version causes this UPDATE to
+    // match zero rows, surfacing as WKS-CFG-035 instead of silently winning via JPA merge.
+    int affected =
+        caseRepository.updateCaseTypeVersion(kase.id(), toVersion, kase.version());
+    if (affected == 0) {
+      throw new WksConcurrentModificationException(
+          ErrorCode.WKS_CFG_035,
+          "case modified concurrently during rebase (caseId="
+              + kase.id()
+              + ", expectedVersion="
+              + kase.version()
+              + ") — reload and retry");
+    }
+
+    // Publish the domain event INSIDE the surrounding @Transactional. The AFTER_COMMIT listener
+    // (RebaseAuditListener) emits the audit log line only after commit — see memory
+    // feedback_transactional_db_exception_postgres.md. Rollback ⇒ no audit line.
+    if (eventPublisher != null) {
+      eventPublisher.publish(
+          new RebaseApplied(
+              kase.id(),
+              kase.caseTypeId(),
+              fromVersion,
+              toVersion,
+              "migration-rebase",
+              "migration-rebase",
+              actor,
+              requestId,
+              clock.now()));
+    }
 
     return buildReport(kase, fromVersion, toVersion, fromConfig, toConfig, true);
   }
@@ -172,7 +209,21 @@ public class CaseRebaseService {
   }
 
   private void validateVersionArg(String caseTypeId, int fromVersion, int toVersion) {
-    if (toVersion <= fromVersion) {
+    // Story 3.9 review remediation — split no-op (toVersion == fromVersion) from reverse
+    // (toVersion < fromVersion) so SI devs grep distinct wire codes for distinct surfaces.
+    if (toVersion == fromVersion) {
+      throw new WksConfigException(
+          List.of(
+              ErrorDetail.of(
+                  ErrorCode.WKS_API_008.wire(),
+                  "toVersion equals current caseTypeVersion — no-op rebase rejected"
+                      + " (current="
+                      + fromVersion
+                      + ", requested="
+                      + toVersion
+                      + ")")));
+    }
+    if (toVersion < fromVersion) {
       throw new WksConfigException(
           List.of(
               ErrorDetail.of(
@@ -312,6 +363,24 @@ public class CaseRebaseService {
       }
     }
 
+    // Story 3.9 review remediation — stage-id rename detection. When the case currently sits on a
+    // stage S in fromVersion and toVersion does NOT declare a stage with the same id, the operator
+    // must manually decide where the case lands. Phase-0 surfaces this as irreconcilable; Story
+    // 3-9.1 will add operator-supplied mapping JSON for stage remap.
+    String currentStageId = kase.currentStageId();
+    if (currentStageId != null && !currentStageId.isBlank()) {
+      Set<String> toStageIds = collectStageIds(toConfig);
+      Set<String> fromStageIds = collectStageIds(fromConfig);
+      if (fromStageIds.contains(currentStageId) && !toStageIds.contains(currentStageId)) {
+        irreconcilable.add(
+            new IrreconcilableItem(
+                IrreconcilableKind.STAGE_REMOVED_WITH_ACTIVE_CASE,
+                null,
+                null,
+                currentStageId));
+      }
+    }
+
     return new CaseRebaseReport(
         kase.id(),
         kase.caseTypeId(),
@@ -321,6 +390,16 @@ public class CaseRebaseService {
         fieldMappings,
         statusMappings,
         irreconcilable);
+  }
+
+  private static Set<String> collectStageIds(CaseTypeConfig config) {
+    Set<String> ids = new HashSet<>();
+    if (config.stages() != null) {
+      for (StageDefinition stage : config.stages()) {
+        ids.add(stage.id());
+      }
+    }
+    return ids;
   }
 
   private static Map<String, FieldDefinition> indexFields(CaseTypeConfig config) {

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseRebaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseRebaseService.java
@@ -152,8 +152,7 @@ public class CaseRebaseService {
     // Story 3.9 review remediation — version-checked update. Closes the TOCTOU window between
     // resolveCase() and the write: a concurrent UPDATE that bumps c.version causes this UPDATE to
     // match zero rows, surfacing as WKS-CFG-035 instead of silently winning via JPA merge.
-    int affected =
-        caseRepository.updateCaseTypeVersion(kase.id(), toVersion, kase.version());
+    int affected = caseRepository.updateCaseTypeVersion(kase.id(), toVersion, kase.version());
     if (affected == 0) {
       throw new WksConcurrentModificationException(
           ErrorCode.WKS_CFG_035,
@@ -374,10 +373,7 @@ public class CaseRebaseService {
       if (fromStageIds.contains(currentStageId) && !toStageIds.contains(currentStageId)) {
         irreconcilable.add(
             new IrreconcilableItem(
-                IrreconcilableKind.STAGE_REMOVED_WITH_ACTIVE_CASE,
-                null,
-                null,
-                currentStageId));
+                IrreconcilableKind.STAGE_REMOVED_WITH_ACTIVE_CASE, null, null, currentStageId));
       }
     }
 

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/config/ConfigServiceConfig.java
@@ -155,7 +155,10 @@ public class ConfigServiceConfig {
   public CaseRebaseService caseRebaseService(
       CaseRepository caseRepository,
       CaseTypeVersionRegistry versionRegistry,
-      CaseTypeSource caseTypeSource) {
-    return new CaseRebaseService(caseRepository, versionRegistry, caseTypeSource);
+      CaseTypeSource caseTypeSource,
+      EventPublisher eventPublisher,
+      Clock clock) {
+    return new CaseRebaseService(
+        caseRepository, versionRegistry, caseTypeSource, eventPublisher, clock);
   }
 }

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/CaseRepositoryAdapter.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/CaseRepositoryAdapter.java
@@ -131,6 +131,12 @@ class CaseRepositoryAdapter implements CaseRepository {
     return Map.copyOf(filtered);
   }
 
+  @Override
+  @Transactional
+  public int updateCaseTypeVersion(UUID caseId, int toCaseTypeVersion, long expectedVersion) {
+    return cases.updateCaseTypeVersion(caseId, toCaseTypeVersion, expectedVersion);
+  }
+
   private static CaseSummary toDomainSummary(CaseSummaryProjection p) {
     // The list path returns empty fields here; the service post-enriches via findDataByIds using
     // caseType.listColumns (Story 2.3 D4).

--- a/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseEntityRepository.java
+++ b/backend/src/main/java/com/wkspower/platform/infrastructure/persistence/repository/CaseEntityRepository.java
@@ -69,4 +69,23 @@ public interface CaseEntityRepository extends JpaRepository<CaseEntity, UUID> {
       @Param("caseId") UUID caseId,
       @Param("status") String status,
       @Param("updatedAt") java.time.Instant updatedAt);
+
+  /**
+   * Story 3.9 review remediation — version-checked update of {@code case_type_version}. The {@code
+   * c.version = c.version + 1} clause bumps the optimistic-lock column atomically with the data
+   * write, and the {@code WHERE c.version = :ver} predicate rejects writes whose observed version
+   * is stale. {@code clearAutomatically} keeps the first-level cache from re-flushing the stale
+   * entity.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "UPDATE CaseEntity c "
+          + "   SET c.caseTypeVersion = :toCaseTypeVersion, "
+          + "       c.version = c.version + 1 "
+          + " WHERE c.id = :id "
+          + "   AND c.version = :ver")
+  int updateCaseTypeVersion(
+      @Param("id") UUID id,
+      @Param("toCaseTypeVersion") int toCaseTypeVersion,
+      @Param("ver") long ver);
 }

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerRebaseTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerRebaseTest.java
@@ -25,6 +25,7 @@ import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.port.UserRepository;
 import com.wkspower.platform.domain.service.CaseRebaseService;
 import com.wkspower.platform.domain.service.ConfigService;
+import com.wkspower.platform.domain.service.LicenseService;
 import com.wkspower.platform.security.JwtAuthenticationFilter;
 import com.wkspower.platform.security.JwtTokenProvider;
 import com.wkspower.platform.security.SecurityConfig;
@@ -52,6 +53,7 @@ class AdminControllerRebaseTest {
   @MockitoBean private CaseRebaseService caseRebaseService;
   @MockitoBean private JwtTokenProvider jwtTokenProvider;
   @MockitoBean private UserRepository userRepository;
+  @MockitoBean private LicenseService licenseService;
 
   private static final UUID CASE_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
   private static final String CT_ID = "bfsi-kyc";
@@ -94,7 +96,8 @@ class AdminControllerRebaseTest {
 
   @Test
   void apply_asAdmin_returns200WithAppliedTrue() throws Exception {
-    when(caseRebaseService.apply(eq(CT_ID), eq(CASE_ID), eq(3), anyString(), nullable(String.class)))
+    when(caseRebaseService.apply(
+            eq(CT_ID), eq(CASE_ID), eq(3), anyString(), nullable(String.class)))
         .thenReturn(cleanDryRunReport(true));
 
     mockMvc
@@ -112,7 +115,8 @@ class AdminControllerRebaseTest {
 
   @Test
   void apply_withIrreconcilable_returns422WithCfg034() throws Exception {
-    when(caseRebaseService.apply(eq(CT_ID), eq(CASE_ID), eq(3), anyString(), nullable(String.class)))
+    when(caseRebaseService.apply(
+            eq(CT_ID), eq(CASE_ID), eq(3), anyString(), nullable(String.class)))
         .thenThrow(
             new WksConfigException(
                 List.of(

--- a/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerRebaseTest.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/AdminControllerRebaseTest.java
@@ -2,7 +2,9 @@ package com.wkspower.platform.api.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -92,7 +94,7 @@ class AdminControllerRebaseTest {
 
   @Test
   void apply_asAdmin_returns200WithAppliedTrue() throws Exception {
-    when(caseRebaseService.apply(eq(CT_ID), eq(CASE_ID), eq(3)))
+    when(caseRebaseService.apply(eq(CT_ID), eq(CASE_ID), eq(3), anyString(), nullable(String.class)))
         .thenReturn(cleanDryRunReport(true));
 
     mockMvc
@@ -110,7 +112,7 @@ class AdminControllerRebaseTest {
 
   @Test
   void apply_withIrreconcilable_returns422WithCfg034() throws Exception {
-    when(caseRebaseService.apply(eq(CT_ID), eq(CASE_ID), eq(3)))
+    when(caseRebaseService.apply(eq(CT_ID), eq(CASE_ID), eq(3), anyString(), nullable(String.class)))
         .thenThrow(
             new WksConfigException(
                 List.of(

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseRebasePostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseRebasePostgresIT.java
@@ -1,21 +1,19 @@
 package com.wkspower.platform.api.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
 import com.wkspower.platform.domain.config.ValidationResult;
-import com.wkspower.platform.domain.config.rebase.CaseRebaseReport;
 import com.wkspower.platform.domain.exception.ErrorCode;
-import com.wkspower.platform.domain.exception.WksConfigException;
 import com.wkspower.platform.domain.model.Case;
 import com.wkspower.platform.domain.port.CaseRepository;
 import com.wkspower.platform.domain.port.CaseTypeVersionRegistry;
 import com.wkspower.platform.domain.port.UserRepository;
-import com.wkspower.platform.domain.service.CaseRebaseService;
 import com.wkspower.platform.domain.service.ConfigService;
 import com.wkspower.platform.infrastructure.persistence.repository.CaseEntityRepository;
 import com.wkspower.platform.infrastructure.persistence.repository.CaseTypeVersionJpaRepository;
-import jakarta.persistence.EntityManager;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
@@ -25,34 +23,48 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * Story 3.9 AC5 — Postgres-IT exercising end-to-end rebase: dry-run preview, apply success,
- * irreconcilable rejection, version-arg rejection.
+ * Story 3.9 AC5 — Postgres-IT exercising end-to-end rebase over HTTP. Per the review remediation:
  *
- * <p>Exercises:
- *
- * <ol>
- *   <li>Scenario 1 — dry-run additive (v1 → v2): irreconcilable=[], no DB mutation
- *   <li>Scenario 2 — apply success (v1 → v2): cases.case_type_version mutated to 2
- *   <li>Scenario 3 — irreconcilable rejection (legacyField removed with data): 422 + WKS-CFG-034,
- *       version unchanged
- *   <li>Scenario 4 — reverse rebase: 422 + WKS-API-007
- *   <li>Scenario 5 — non-existent toVersion: 422 + WKS-API-007
- * </ol>
+ * <ul>
+ *   <li>Class is NOT {@code @Transactional} — every test commits its setup writes; reads after the
+ *       HTTP call go through a fresh {@link TransactionTemplate} so we only observe the committed
+ *       view (irreconcilable rejection must NOT mutate {@code cases.case_type_version}).
+ *   <li>Endpoint exercised via {@link TestRestTemplate} on a random port, hitting the real {@code
+ *       AdminController} chain through the security filter — proves the apply path's commit
+ *       boundary and audit semantics, not just the service surface.
+ *   <li>Scenarios cover dry-run, apply success, irreconcilable rejection, apply-path reverse
+ *       ({@code WKS-API-007}), apply-path no-op ({@code WKS-API-008}), and apply-path
+ *       non-existent toVersion ({@code WKS-API-007}). All rejection paths assert the {@code cases}
+ *       row is UNCHANGED via fresh-tx read.
+ *   <li>Per-test UUIDs in {@code @BeforeEach} — no shared CASE_TYPE_ID literal carries state across
+ *       methods.
+ * </ul>
  *
  * <p>Memory {@code feedback_production_validator_opt_out.md}: production-validation disabled.
- * Memory {@code project_postgres_it_parity_gap.md}: Postgres-IT mandatory for BYTEA reads +
- * cases.case_type_version writes.
+ * Memory {@code project_postgres_it_parity_gap.md}: Postgres-IT mandatory for BYTEA reads + {@code
+ * cases.case_type_version} writes.
  */
-@SpringBootTest(properties = "wks.bootstrap.production-validation.enabled=false")
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = "wks.bootstrap.production-validation.enabled=false")
 @ActiveProfiles("production")
 @Testcontainers(disabledWithoutDocker = true)
 class CaseRebasePostgresIT {
@@ -80,26 +92,32 @@ class CaseRebasePostgresIT {
   }
 
   @Autowired private ConfigService configService;
-  @Autowired private CaseRebaseService caseRebaseService;
   @Autowired private CaseRepository caseRepository;
   @Autowired private CaseTypeVersionRegistry versionRegistry;
   @Autowired private CaseEntityRepository caseEntityRepo;
   @Autowired private CaseTypeVersionJpaRepository ctVersionRepo;
   @Autowired private UserRepository userRepository;
-  @Autowired private EntityManager em;
-
-  private static final String CT_PREFIX = "it-rebase-";
+  @Autowired private TestRestTemplate rest;
+  @Autowired private ObjectMapper json;
+  @Autowired private PlatformTransactionManager txManager;
 
   /** Resolved from the seeded admin user at {@code @BeforeEach}. */
   private UUID adminUserId;
 
+  /** Per-test CaseType id — defeats any cross-test state leakage. */
+  private String ctId;
+
+  private TransactionTemplate freshTx;
+
   @BeforeEach
-  void resolveAdminUser() {
+  void perTestSetup() {
     adminUserId =
         userRepository
             .findByEmail("admin@wkspower.local")
             .orElseThrow(() -> new IllegalStateException("Admin user not seeded"))
             .id();
+    ctId = "it-rebase-" + UUID.randomUUID().toString().substring(0, 8);
+    freshTx = new TransactionTemplate(txManager);
   }
 
   // ---- YAML helpers ----
@@ -167,9 +185,7 @@ class CaseRebasePostgresIT {
         .getBytes(StandardCharsets.UTF_8);
   }
 
-  /**
-   * v2 (registry version after bump): mutate-class change — removes legacy-field which has data.
-   */
+  /** v2 mutate-class — removes legacy-field which has data on the case. */
   private static byte[] v2RemovesLegacyFieldYaml(String ctId) {
     return ("""
         id: %s
@@ -195,7 +211,7 @@ class CaseRebasePostgresIT {
         .getBytes(StandardCharsets.UTF_8);
   }
 
-  /** v1 with legacy-field — used for irreconcilable scenario. */
+  /** v1 with legacy-field — paired with v2RemovesLegacyFieldYaml for irreconcilable scenario. */
   private static byte[] v1WithLegacyFieldYaml(String ctId) {
     return ("""
         id: %s
@@ -237,58 +253,109 @@ class CaseRebasePostgresIT {
             0L,
             null,
             null);
+    // Each save commits in its own tx (the IT itself is NOT @Transactional).
     return caseRepository.save(kase);
   }
 
   @AfterEach
   void wipe() {
+    // Each cleanup commits — no class-level @Transactional to roll the world back implicitly.
     caseEntityRepo.deleteAll();
     ctVersionRepo.deleteAll();
+  }
+
+  // ---- HTTP helpers ----
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity(
+            "/api/auth/login",
+            new LoginRequest("admin@wkspower.local", "admin"),
+            String.class);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).as("login Set-Cookie present").isNotNull();
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private ResponseEntity<String> rebaseDryRun(String cookie, String ctId, UUID caseId, int to) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(
+        "/api/admin/case-types/" + ctId + "/cases/" + caseId + "/rebase?to=" + to,
+        HttpMethod.GET,
+        new HttpEntity<>(headers),
+        String.class);
+  }
+
+  private ResponseEntity<String> rebaseApply(String cookie, String ctId, UUID caseId, int to) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(
+        "/api/admin/case-types/" + ctId + "/cases/" + caseId + "/rebase?to=" + to,
+        HttpMethod.POST,
+        new HttpEntity<>(headers),
+        String.class);
+  }
+
+  /** Fresh-tx read — only observes committed state. */
+  private int readCommittedCaseVersion(UUID caseId) {
+    Integer v =
+        freshTx.execute(
+            status ->
+                caseEntityRepo
+                    .findById(caseId)
+                    .orElseThrow(() -> new AssertionError("case not found: " + caseId))
+                    .getCaseTypeVersion());
+    return v == null ? -1 : v;
+  }
+
+  private String firstErrorCode(String body) throws Exception {
+    JsonNode root = json.readTree(body);
+    JsonNode error = root.path("error");
+    JsonNode errorsArr = error.path("errors");
+    if (errorsArr.isArray() && errorsArr.size() > 0) {
+      return errorsArr.get(0).path("code").asText();
+    }
+    return error.path("code").asText();
   }
 
   // ---- Scenario 1: dry-run additive — irreconcilable=[], no DB mutation ----
 
   @Test
-  @Transactional
-  void scenario1_dryRun_additive_noMutation() {
-    String ctId = CT_PREFIX + "s1";
+  void scenario1_dryRun_additive_noMutation() throws Exception {
+    String cookie = login();
 
-    // Deploy v1
     ValidationResult v1 = configService.validateAndRegister("api.yaml", v1Yaml(ctId), "test:s1");
     assertThat(v1.isInvalid()).as("v1 deploy: " + v1.errors()).isFalse();
-
-    // Deploy v2 (additive — bumpVersion required for v2 registration after v1)
     ValidationResult v2 =
         configService.validateAndRegister("api.yaml", v2Yaml(ctId), "test:s1", true);
     assertThat(v2.isInvalid()).as("v2 deploy: " + v2.errors()).isFalse();
 
-    // Create case at v1
-    int v1Num = versionRegistry.currentVersion(ctId).orElseThrow() - 1; // v1 is one before current
-    // Re-query: v2 is current so v1 is 1 less
-    int currentV = versionRegistry.currentVersion(ctId).orElseThrow();
-    assertThat(currentV).isEqualTo(2);
-
     Case kase = createCase(ctId, 1, Map.of("name", "Alice"));
 
-    // Dry-run v1 → v2
-    CaseRebaseReport report = caseRebaseService.dryRun(ctId, kase.id(), 2);
+    ResponseEntity<String> resp = rebaseDryRun(cookie, ctId, kase.id(), 2);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-    assertThat(report.fromVersion()).isEqualTo(1);
-    assertThat(report.toVersion()).isEqualTo(2);
-    assertThat(report.applied()).isFalse();
-    assertThat(report.irreconcilable()).isEmpty();
+    JsonNode body = json.readTree(resp.getBody());
+    JsonNode data = body.path("data");
+    assertThat(data.path("fromVersion").asInt()).isEqualTo(1);
+    assertThat(data.path("toVersion").asInt()).isEqualTo(2);
+    assertThat(data.path("applied").asBoolean()).isFalse();
+    assertThat(data.path("irreconcilable")).isEmpty();
 
-    // No DB mutation — case still at v1
-    int actualVersion = readCaseVersion(kase.id());
-    assertThat(actualVersion).as("dry-run must NOT mutate cases.case_type_version").isEqualTo(1);
+    // Fresh-tx read — dry-run must NOT mutate the cases row.
+    assertThat(readCommittedCaseVersion(kase.id())).isEqualTo(1);
   }
 
   // ---- Scenario 2: apply success — cases.case_type_version mutated ----
 
   @Test
-  @Transactional
-  void scenario2_apply_success_mutatesVersion() {
-    String ctId = CT_PREFIX + "s2";
+  void scenario2_apply_success_mutatesVersion() throws Exception {
+    String cookie = login();
 
     ValidationResult v1 = configService.validateAndRegister("api.yaml", v1Yaml(ctId), "test:s2");
     assertThat(v1.isInvalid()).as("v1 deploy: " + v1.errors()).isFalse();
@@ -298,70 +365,49 @@ class CaseRebasePostgresIT {
 
     Case kase = createCase(ctId, 1, Map.of("name", "Bob"));
 
-    // Apply v1 → v2
-    CaseRebaseReport report = caseRebaseService.apply(ctId, kase.id(), 2);
+    ResponseEntity<String> resp = rebaseApply(cookie, ctId, kase.id(), 2);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-    assertThat(report.applied()).isTrue();
-    assertThat(report.fromVersion()).isEqualTo(1);
-    assertThat(report.toVersion()).isEqualTo(2);
-    assertThat(report.irreconcilable()).isEmpty();
+    JsonNode body = json.readTree(resp.getBody());
+    assertThat(body.path("data").path("applied").asBoolean()).isTrue();
+    assertThat(body.path("data").path("toVersion").asInt()).isEqualTo(2);
 
-    // DB mutated — case now at v2
-    em.flush();
-    em.clear();
-    int actualVersion = readCaseVersion(kase.id());
-    assertThat(actualVersion).as("apply must mutate cases.case_type_version to 2").isEqualTo(2);
+    // Fresh-tx read — apply commit must be visible to a new transaction.
+    assertThat(readCommittedCaseVersion(kase.id())).isEqualTo(2);
   }
 
-  // ---- Scenario 3: irreconcilable rejection (legacyField removed with data) ----
+  // ---- Scenario 3: irreconcilable rejection — fresh-tx read shows row UNCHANGED ----
 
   @Test
-  @Transactional
-  void scenario3_apply_irreconcilable_rejects422_versionUnchanged() {
-    String ctId = CT_PREFIX + "s3";
+  void scenario3_apply_irreconcilable_rejects422_versionUnchanged_freshTxRead() throws Exception {
+    String cookie = login();
 
-    // Deploy v1 with legacyField
     ValidationResult v1 =
         configService.validateAndRegister("api.yaml", v1WithLegacyFieldYaml(ctId), "test:s3");
     assertThat(v1.isInvalid()).as("v1 deploy: " + v1.errors()).isFalse();
-
-    // Deploy v2 (legacy-field removed) — needs bumpVersion=true since it's mutate-class.
-    // force=false: bumpVersion=true alone is sufficient for the registry gate.
     ValidationResult v2 =
         configService.validateAndRegister(
             "api.yaml", v2RemovesLegacyFieldYaml(ctId), "test:s3", true, false);
     assertThat(v2.isInvalid()).as("v2 deploy: " + v2.errors()).isFalse();
 
-    // Create case at v1 with legacy-field data
     Case kase = createCase(ctId, 1, Map.of("name", "Charlie", "legacy-field", "some-data"));
 
-    // After deploying v1 then bumping to v2, registry current is 2
     int targetVersion = versionRegistry.currentVersion(ctId).orElseThrow();
     assertThat(targetVersion).isEqualTo(2);
 
-    // The case has legacyField data but v2 removes legacyField → irreconcilable
-    assertThatThrownBy(() -> caseRebaseService.apply(ctId, kase.id(), targetVersion))
-        .isInstanceOf(WksConfigException.class)
-        .satisfies(
-            ex -> {
-              WksConfigException wce = (WksConfigException) ex;
-              assertThat(wce.getErrors()).hasSize(1);
-              assertThat(wce.getErrors().get(0).code()).isEqualTo(ErrorCode.WKS_CFG_034.wire());
-            });
+    ResponseEntity<String> resp = rebaseApply(cookie, ctId, kase.id(), targetVersion);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(firstErrorCode(resp.getBody())).isEqualTo(ErrorCode.WKS_CFG_034.wire());
 
-    // Version unchanged
-    int actualVersion = readCaseVersion(kase.id());
-    assertThat(actualVersion)
-        .as("rejected apply must not mutate cases.case_type_version")
-        .isEqualTo(1);
+    // Fresh-tx read — proves the rejection did not commit a partial update.
+    assertThat(readCommittedCaseVersion(kase.id())).isEqualTo(1);
   }
 
-  // ---- Scenario 4: reverse rebase — 422 + WKS-API-007 ----
+  // ---- Scenario 4: apply-path reverse rebase — WKS-API-007 + UNCHANGED ----
 
   @Test
-  @Transactional
-  void scenario4_reverseRebase_rejects_api007() {
-    String ctId = CT_PREFIX + "s4";
+  void scenario4_applyPath_reverseRebase_rejects_api007_unchanged() throws Exception {
+    String cookie = login();
 
     ValidationResult v1 = configService.validateAndRegister("api.yaml", v1Yaml(ctId), "test:s4");
     assertThat(v1.isInvalid()).as("v1 deploy: " + v1.errors()).isFalse();
@@ -371,45 +417,49 @@ class CaseRebasePostgresIT {
 
     Case kase = createCase(ctId, 2, Map.of("name", "Dan"));
 
-    assertThatThrownBy(() -> caseRebaseService.dryRun(ctId, kase.id(), 1))
-        .isInstanceOf(WksConfigException.class)
-        .satisfies(
-            ex -> {
-              WksConfigException wce = (WksConfigException) ex;
-              assertThat(wce.getErrors().get(0).code()).isEqualTo(ErrorCode.WKS_API_007.wire());
-              assertThat(wce.getErrors().get(0).message()).contains("strictly greater");
-            });
+    // POST (apply path) reverse rebase: toVersion < fromVersion → WKS-API-007
+    ResponseEntity<String> resp = rebaseApply(cookie, ctId, kase.id(), 1);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(firstErrorCode(resp.getBody())).isEqualTo(ErrorCode.WKS_API_007.wire());
+
+    // Fresh-tx read — row UNCHANGED.
+    assertThat(readCommittedCaseVersion(kase.id())).isEqualTo(2);
   }
 
-  // ---- Scenario 5: non-existent toVersion — 422 + WKS-API-007 ----
+  // ---- Scenario 5: apply-path non-existent toVersion — WKS-API-007 + UNCHANGED ----
 
   @Test
-  @Transactional
-  void scenario5_nonExistentToVersion_rejects_api007() {
-    String ctId = CT_PREFIX + "s5";
+  void scenario5_applyPath_nonExistentToVersion_rejects_api007_unchanged() throws Exception {
+    String cookie = login();
 
     ValidationResult v1 = configService.validateAndRegister("api.yaml", v1Yaml(ctId), "test:s5");
     assertThat(v1.isInvalid()).as("v1 deploy: " + v1.errors()).isFalse();
 
     Case kase = createCase(ctId, 1, Map.of("name", "Eve"));
 
-    assertThatThrownBy(() -> caseRebaseService.dryRun(ctId, kase.id(), 99))
-        .isInstanceOf(WksConfigException.class)
-        .satisfies(
-            ex -> {
-              WksConfigException wce = (WksConfigException) ex;
-              assertThat(wce.getErrors().get(0).code()).isEqualTo(ErrorCode.WKS_API_007.wire());
-              assertThat(wce.getErrors().get(0).message())
-                  .contains("not found in case_type_versions");
-            });
+    ResponseEntity<String> resp = rebaseApply(cookie, ctId, kase.id(), 99);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(firstErrorCode(resp.getBody())).isEqualTo(ErrorCode.WKS_API_007.wire());
+
+    assertThat(readCommittedCaseVersion(kase.id())).isEqualTo(1);
   }
 
-  // ---- Helpers ----
+  // ---- Scenario 6: apply-path no-op rebase — WKS-API-008 + UNCHANGED ----
 
-  private int readCaseVersion(UUID caseId) {
-    return caseEntityRepo
-        .findById(caseId)
-        .orElseThrow(() -> new AssertionError("case not found: " + caseId))
-        .getCaseTypeVersion();
+  @Test
+  void scenario6_applyPath_noOpRebase_rejects_api008_unchanged() throws Exception {
+    String cookie = login();
+
+    ValidationResult v1 = configService.validateAndRegister("api.yaml", v1Yaml(ctId), "test:s6");
+    assertThat(v1.isInvalid()).as("v1 deploy: " + v1.errors()).isFalse();
+
+    Case kase = createCase(ctId, 1, Map.of("name", "Fae"));
+
+    // toVersion == fromVersion → WKS-API-008 (split from WKS-API-007 reverse)
+    ResponseEntity<String> resp = rebaseApply(cookie, ctId, kase.id(), 1);
+    assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    assertThat(firstErrorCode(resp.getBody())).isEqualTo(ErrorCode.WKS_API_008.wire());
+
+    assertThat(readCommittedCaseVersion(kase.id())).isEqualTo(1);
   }
 }

--- a/backend/src/test/java/com/wkspower/platform/api/controller/CaseRebasePostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/api/controller/CaseRebasePostgresIT.java
@@ -51,9 +51,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  *       AdminController} chain through the security filter — proves the apply path's commit
  *       boundary and audit semantics, not just the service surface.
  *   <li>Scenarios cover dry-run, apply success, irreconcilable rejection, apply-path reverse
- *       ({@code WKS-API-007}), apply-path no-op ({@code WKS-API-008}), and apply-path
- *       non-existent toVersion ({@code WKS-API-007}). All rejection paths assert the {@code cases}
- *       row is UNCHANGED via fresh-tx read.
+ *       ({@code WKS-API-007}), apply-path no-op ({@code WKS-API-008}), and apply-path non-existent
+ *       toVersion ({@code WKS-API-007}). All rejection paths assert the {@code cases} row is
+ *       UNCHANGED via fresh-tx read.
  *   <li>Per-test UUIDs in {@code @BeforeEach} — no shared CASE_TYPE_ID literal carries state across
  *       methods.
  * </ul>
@@ -269,9 +269,7 @@ class CaseRebasePostgresIT {
   private String login() {
     ResponseEntity<String> resp =
         rest.postForEntity(
-            "/api/auth/login",
-            new LoginRequest("admin@wkspower.local", "admin"),
-            String.class);
+            "/api/auth/login", new LoginRequest("admin@wkspower.local", "admin"), String.class);
     assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
     String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
     assertThat(setCookie).as("login Set-Cookie present").isNotNull();

--- a/backend/src/test/java/com/wkspower/platform/audit/RebaseAuditListenerCommitFailureTest.java
+++ b/backend/src/test/java/com/wkspower/platform/audit/RebaseAuditListenerCommitFailureTest.java
@@ -32,8 +32,8 @@ import org.springframework.transaction.support.TransactionTemplate;
  * {@link RebaseAuditListener} does NOT emit the {@code event=admin.case.rebase} audit line. The
  * test registers a {@link TransactionSynchronization} that throws in {@code beforeCommit}, forcing
  * a rollback after the {@code RebaseApplied} event has been published inside the tx. A Logback
- * {@link ListAppender} attached to the listener captures any audit lines so absence can be
- * asserted positively.
+ * {@link ListAppender} attached to the listener captures any audit lines so absence can be asserted
+ * positively.
  */
 @SpringBootTest
 @ActiveProfiles("dev")

--- a/backend/src/test/java/com/wkspower/platform/audit/RebaseAuditListenerCommitFailureTest.java
+++ b/backend/src/test/java/com/wkspower/platform/audit/RebaseAuditListenerCommitFailureTest.java
@@ -1,0 +1,121 @@
+package com.wkspower.platform.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.wkspower.platform.domain.event.RebaseApplied;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Story 3.9 review remediation — proves that when the surrounding transaction is rolled back, the
+ * {@link RebaseAuditListener} does NOT emit the {@code event=admin.case.rebase} audit line. The
+ * test registers a {@link TransactionSynchronization} that throws in {@code beforeCommit}, forcing
+ * a rollback after the {@code RebaseApplied} event has been published inside the tx. A Logback
+ * {@link ListAppender} attached to the listener captures any audit lines so absence can be
+ * asserted positively.
+ */
+@SpringBootTest
+@ActiveProfiles("dev")
+class RebaseAuditListenerCommitFailureTest {
+
+  @org.junit.jupiter.api.io.TempDir static java.nio.file.Path dbDir;
+
+  @DynamicPropertySource
+  static void props(DynamicPropertyRegistry reg) {
+    reg.add(
+        "spring.datasource.url",
+        () -> "jdbc:h2:file:" + dbDir.resolve("commit-fail-it") + ";DB_CLOSE_DELAY=-1");
+    reg.add("wks.case-types.dir", () -> "");
+    reg.add("camunda.bpm.generic-properties.properties.enforceHistoryTimeToLive", () -> "false");
+    reg.add("wks.jwt.secret", () -> "dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=");
+  }
+
+  @Autowired private ApplicationEventPublisher publisher;
+  @Autowired private PlatformTransactionManager txManager;
+
+  private ListAppender<ILoggingEvent> appender;
+  private Logger listenerLogger;
+
+  @BeforeEach
+  void attachAppender() {
+    listenerLogger = (Logger) LoggerFactory.getLogger(RebaseAuditListener.class);
+    appender = new ListAppender<>();
+    appender.start();
+    listenerLogger.addAppender(appender);
+  }
+
+  @AfterEach
+  void detachAppender() {
+    if (listenerLogger != null && appender != null) {
+      listenerLogger.detachAppender(appender);
+    }
+  }
+
+  @Test
+  void rollback_doesNotEmitAuditLine() {
+    TransactionTemplate tx = new TransactionTemplate(txManager);
+
+    assertThatThrownBy(
+            () ->
+                tx.execute(
+                    new TransactionCallbackWithoutResult() {
+                      @Override
+                      protected void doInTransactionWithoutResult(TransactionStatus status) {
+                        // Publish the RebaseApplied event inside the tx. With
+                        // @TransactionalEventListener(AFTER_COMMIT), delivery depends on commit.
+                        publisher.publishEvent(
+                            new RebaseApplied(
+                                UUID.randomUUID(),
+                                "test-ct",
+                                1,
+                                2,
+                                "migration-rebase",
+                                "migration-rebase",
+                                "operator@wkspower.local",
+                                "req-rollback-test",
+                                Instant.now()));
+
+                        // Register a synchronization that throws in beforeCommit → forces rollback.
+                        TransactionSynchronizationManager.registerSynchronization(
+                            new TransactionSynchronization() {
+                              @Override
+                              public void beforeCommit(boolean readOnly) {
+                                throw new RuntimeException(
+                                    "forced rollback (commit-failure proof)");
+                              }
+                            });
+                      }
+                    }))
+        .isInstanceOf(RuntimeException.class);
+
+    boolean anyAuditLine =
+        appender.list.stream()
+            .filter(e -> e.getLevel() == Level.INFO)
+            .map(ILoggingEvent::getFormattedMessage)
+            .anyMatch(m -> m.contains("event=admin.case.rebase"));
+    assertThat(anyAuditLine)
+        .as("audit line MUST NOT fire when the surrounding transaction rolled back")
+        .isFalse();
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseRebaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseRebaseServiceTest.java
@@ -7,13 +7,16 @@ import com.wkspower.platform.domain.config.ValidationResult;
 import com.wkspower.platform.domain.config.model.CaseTypeConfig;
 import com.wkspower.platform.domain.config.model.FieldDefinition;
 import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.StageDefinition;
 import com.wkspower.platform.domain.config.model.StatusColor;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.domain.config.rebase.CaseRebaseReport;
 import com.wkspower.platform.domain.config.rebase.CaseRebaseReport.FieldAction;
 import com.wkspower.platform.domain.config.rebase.CaseRebaseReport.IrreconcilableKind;
 import com.wkspower.platform.domain.config.rebase.CaseRebaseReport.StatusAction;
+import com.wkspower.platform.domain.event.RebaseApplied;
 import com.wkspower.platform.domain.exception.ErrorCode;
+import com.wkspower.platform.domain.exception.WksConcurrentModificationException;
 import com.wkspower.platform.domain.exception.WksConfigException;
 import com.wkspower.platform.domain.exception.WksNotFoundException;
 import com.wkspower.platform.domain.model.Case;
@@ -23,6 +26,8 @@ import com.wkspower.platform.domain.page.Page;
 import com.wkspower.platform.domain.page.PageRequest;
 import com.wkspower.platform.domain.port.CaseRepository;
 import com.wkspower.platform.domain.port.CaseTypeSource;
+import com.wkspower.platform.domain.port.Clock;
+import com.wkspower.platform.domain.port.EventPublisher;
 import com.wkspower.platform.testsupport.FakeCaseTypeVersionRegistry;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -34,6 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +58,7 @@ class CaseRebaseServiceTest {
   private FakeCaseTypeVersionRegistry versionRegistry;
   private FakeCaseRepository caseRepository;
   private FakeCaseTypeSource caseTypeSource;
+  private RecordingEventPublisher eventPublisher;
   private CaseRebaseService service;
 
   @BeforeEach
@@ -59,7 +66,11 @@ class CaseRebaseServiceTest {
     versionRegistry = new FakeCaseTypeVersionRegistry();
     caseRepository = new FakeCaseRepository();
     caseTypeSource = new FakeCaseTypeSource();
-    service = new CaseRebaseService(caseRepository, versionRegistry, caseTypeSource);
+    eventPublisher = new RecordingEventPublisher();
+    Clock clock = () -> Instant.parse("2026-05-11T00:00:00Z");
+    service =
+        new CaseRebaseService(
+            caseRepository, versionRegistry, caseTypeSource, eventPublisher, clock);
   }
 
   // ---- Helper: minimal CaseTypeConfig ----
@@ -120,6 +131,17 @@ class CaseRebaseServiceTest {
       String id, int version, List<StatusDefinition> statuses, List<FieldDefinition> fields) {
     return new CaseTypeConfig(
         id, "Test CT", version, null, null, fields, statuses, List.of(), List.of(), List.of(),
+        List.of());
+  }
+
+  private static CaseTypeConfig configWithStages(
+      String id,
+      int version,
+      List<StatusDefinition> statuses,
+      List<FieldDefinition> fields,
+      List<StageDefinition> stages) {
+    return new CaseTypeConfig(
+        id, "Test CT", version, null, null, fields, statuses, List.of(), List.of(), stages,
         List.of());
   }
 
@@ -421,6 +443,138 @@ class CaseRebaseServiceTest {
             });
   }
 
+  // ---- Test: concurrent modification detected by version-checked update ----
+
+  @Test
+  void apply_concurrentVersionBump_throwsCfg035() {
+    StatusDefinition open = new StatusDefinition("open", "Open", StatusColor.BLUE);
+    FieldDefinition nameField =
+        new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, null, null);
+
+    CaseTypeConfig fromConfig = minimalConfig(CT_ID, 1, List.of(open), List.of(nameField));
+    CaseTypeConfig toConfig = minimalConfig(CT_ID, 2, List.of(open), List.of(nameField));
+
+    versionRegistry.seed(CT_ID, 1, v1Yaml());
+    versionRegistry.seed(CT_ID, 2, v2Yaml());
+    caseTypeSource.registerConfig("rebase:" + CT_ID + ":1", fromConfig);
+    caseTypeSource.registerConfig("rebase:" + CT_ID + ":2", toConfig);
+
+    caseRepository.save(makeCase(1, Map.of("name", "Alice")));
+    // Simulate a concurrent UPDATE bumping the @Version column AFTER the service's findById
+    // (resolveCase) but BEFORE updateCaseTypeVersion fires. The hook is triggered inside the
+    // fake's updateCaseTypeVersion as the first thing, preserving TOCTOU ordering.
+    caseRepository.simulateConcurrentBumpOnNextUpdate = true;
+
+    assertThatThrownBy(() -> service.apply(CT_ID, CASE_ID, 2))
+        .isInstanceOf(WksConcurrentModificationException.class)
+        .satisfies(
+            ex -> {
+              WksConcurrentModificationException wce = (WksConcurrentModificationException) ex;
+              assertThat(wce.getCode()).isEqualTo(ErrorCode.WKS_CFG_035.wire());
+              assertThat(wce.getMessage()).contains("modified concurrently");
+            });
+
+    // No event emitted on the failure path
+    assertThat(eventPublisher.events).isEmpty();
+  }
+
+  // ---- Test: stage-removed-with-active-case detected as irreconcilable ----
+
+  @Test
+  void dryRun_stageRemovedWithActiveCase_irreconcilable() {
+    StatusDefinition open = new StatusDefinition("open", "Open", StatusColor.BLUE);
+    FieldDefinition nameField =
+        new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, null, null);
+    StageDefinition intake = new StageDefinition("intake", "Intake", 0);
+    StageDefinition decision = new StageDefinition("decision", "Decision", 1);
+    // toConfig removes the "intake" stage
+    StageDefinition decisionOnly = new StageDefinition("decision", "Decision", 0);
+
+    CaseTypeConfig fromConfig =
+        configWithStages(CT_ID, 1, List.of(open), List.of(nameField), List.of(intake, decision));
+    CaseTypeConfig toConfig =
+        configWithStages(CT_ID, 2, List.of(open), List.of(nameField), List.of(decisionOnly));
+
+    versionRegistry.seed(CT_ID, 1, v1Yaml());
+    versionRegistry.seed(CT_ID, 2, v2Yaml());
+    caseTypeSource.registerConfig("rebase:" + CT_ID + ":1", fromConfig);
+    caseTypeSource.registerConfig("rebase:" + CT_ID + ":2", toConfig);
+
+    // Case currently sits on "intake" stage which is removed in v2
+    Case kase =
+        new Case(
+            CASE_ID,
+            CT_ID,
+            1,
+            "open",
+            null,
+            Map.of("name", "Alice"),
+            null,
+            Instant.now(),
+            USER_ID,
+            Instant.now(),
+            0L,
+            "intake",
+            0);
+    caseRepository.save(kase);
+
+    CaseRebaseReport report = service.dryRun(CT_ID, CASE_ID, 2);
+
+    assertThat(report.irreconcilable())
+        .anySatisfy(
+            item -> {
+              assertThat(item.kind()).isEqualTo(IrreconcilableKind.STAGE_REMOVED_WITH_ACTIVE_CASE);
+              assertThat(item.currentValue()).isEqualTo("intake");
+            });
+  }
+
+  // ---- Test: no-op rebase (toVersion == fromVersion) → WKS-API-008 ----
+
+  @Test
+  void dryRun_noOpRebase_throwsApi008() {
+    versionRegistry.seed(CT_ID, 1, v1Yaml());
+    caseRepository.save(makeCase(1, Map.of()));
+
+    assertThatThrownBy(() -> service.dryRun(CT_ID, CASE_ID, 1))
+        .isInstanceOf(WksConfigException.class)
+        .satisfies(
+            ex -> {
+              WksConfigException wce = (WksConfigException) ex;
+              assertThat(wce.getErrors().get(0).code()).isEqualTo(ErrorCode.WKS_API_008.wire());
+              assertThat(wce.getErrors().get(0).message()).contains("no-op");
+            });
+  }
+
+  // ---- Test: apply publishes RebaseApplied event with actor/requestId ----
+
+  @Test
+  void apply_publishesRebaseAppliedEvent() {
+    StatusDefinition open = new StatusDefinition("open", "Open", StatusColor.BLUE);
+    FieldDefinition nameField =
+        new FieldDefinition("name", "Name", FieldType.TEXT, true, 0, null, null);
+
+    CaseTypeConfig fromConfig = minimalConfig(CT_ID, 1, List.of(open), List.of(nameField));
+    CaseTypeConfig toConfig = minimalConfig(CT_ID, 2, List.of(open), List.of(nameField));
+
+    versionRegistry.seed(CT_ID, 1, v1Yaml());
+    versionRegistry.seed(CT_ID, 2, v2Yaml());
+    caseTypeSource.registerConfig("rebase:" + CT_ID + ":1", fromConfig);
+    caseTypeSource.registerConfig("rebase:" + CT_ID + ":2", toConfig);
+
+    caseRepository.save(makeCase(1, Map.of("name", "Alice")));
+
+    service.apply(CT_ID, CASE_ID, 2, "operator@wkspower.local", "req-abc-123");
+
+    assertThat(eventPublisher.events).hasSize(1);
+    RebaseApplied event = (RebaseApplied) eventPublisher.events.get(0);
+    assertThat(event.caseId()).isEqualTo(CASE_ID);
+    assertThat(event.fromVersion()).isEqualTo(1);
+    assertThat(event.toVersion()).isEqualTo(2);
+    assertThat(event.actor()).isEqualTo("operator@wkspower.local");
+    assertThat(event.requestId()).isEqualTo("req-abc-123");
+    assertThat(event.forceOverrideReason()).isEqualTo("migration-rebase");
+  }
+
   // ---- Fakes ----
 
   /** Minimal fake CaseRepository backed by a map. */
@@ -449,9 +603,70 @@ class CaseRebaseServiceTest {
       throw new UnsupportedOperationException("not needed in unit tests");
     }
 
+    /** Test hook — when set, the next updateCaseTypeVersion call sees the bumped version. */
+    boolean simulateConcurrentBumpOnNextUpdate = false;
+
     @Override
     public int updateCaseTypeVersion(UUID caseId, int toCaseTypeVersion, long expectedVersion) {
-      return 0;
+      if (simulateConcurrentBumpOnNextUpdate) {
+        bumpStoredVersion(caseId);
+        simulateConcurrentBumpOnNextUpdate = false;
+      }
+      Case existing = store.get(caseId);
+      if (existing == null || existing.version() != expectedVersion) {
+        return 0;
+      }
+      Case bumped =
+          new Case(
+              existing.id(),
+              existing.caseTypeId(),
+              toCaseTypeVersion,
+              existing.status(),
+              existing.assignee(),
+              existing.data(),
+              existing.processInstanceId(),
+              existing.createdAt(),
+              existing.createdBy(),
+              existing.updatedAt(),
+              existing.version() + 1,
+              existing.currentStageId(),
+              existing.currentStageOrdinal());
+      store.put(caseId, bumped);
+      return 1;
+    }
+
+    /** Test helper — simulate a concurrent transaction bumping the @Version column. */
+    void bumpStoredVersion(UUID caseId) {
+      Case existing = store.get(caseId);
+      if (existing == null) {
+        return;
+      }
+      store.put(
+          caseId,
+          new Case(
+              existing.id(),
+              existing.caseTypeId(),
+              existing.caseTypeVersion(),
+              existing.status(),
+              existing.assignee(),
+              existing.data(),
+              existing.processInstanceId(),
+              existing.createdAt(),
+              existing.createdBy(),
+              existing.updatedAt(),
+              existing.version() + 1,
+              existing.currentStageId(),
+              existing.currentStageOrdinal()));
+    }
+  }
+
+  /** Recording EventPublisher for unit-test assertions on emitted events. */
+  static class RecordingEventPublisher implements EventPublisher {
+    final List<Object> events = new ArrayList<>();
+
+    @Override
+    public void publish(Object event) {
+      events.add(event);
     }
   }
 

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseRebaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseRebaseServiceTest.java
@@ -32,6 +32,7 @@ import com.wkspower.platform.testsupport.FakeCaseTypeVersionRegistry;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +40,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseRebaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseRebaseServiceTest.java
@@ -448,6 +448,11 @@ class CaseRebaseServiceTest {
         Collection<UUID> ids, Set<String> projectedFieldIds) {
       throw new UnsupportedOperationException("not needed in unit tests");
     }
+
+    @Override
+    public int updateCaseTypeVersion(UUID caseId, int toCaseTypeVersion, long expectedVersion) {
+      return 0;
+    }
   }
 
   /** Minimal fake CaseTypeSource that returns pre-registered configs. */

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceRequireCaseAccessTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceRequireCaseAccessTest.java
@@ -161,6 +161,11 @@ class CaseServiceRequireCaseAccessTest {
         Collection<UUID> ids, Set<String> fieldIds) {
       return Map.of();
     }
+
+    @Override
+    public int updateCaseTypeVersion(UUID caseId, int toCaseTypeVersion, long expectedVersion) {
+      return 0;
+    }
   }
 
   private static final class NullValidator implements CaseDataValidator {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/CaseServiceTest.java
@@ -477,6 +477,11 @@ class CaseServiceTest {
         java.util.Collection<UUID> ids, java.util.Set<String> projectedFieldIds) {
       return Map.of();
     }
+
+    @Override
+    public int updateCaseTypeVersion(UUID caseId, int toCaseTypeVersion, long expectedVersion) {
+      return 0;
+    }
   }
 
   private static final class StubValidator implements CaseDataValidator {

--- a/backend/src/test/java/com/wkspower/platform/domain/service/ZeroStageZeroProcessTest.java
+++ b/backend/src/test/java/com/wkspower/platform/domain/service/ZeroStageZeroProcessTest.java
@@ -260,6 +260,11 @@ class ZeroStageZeroProcessTest {
         Collection<UUID> ids, java.util.Set<String> projectedFieldIds) {
       return Map.of();
     }
+
+    @Override
+    public int updateCaseTypeVersion(UUID caseId, int toCaseTypeVersion, long expectedVersion) {
+      return 0;
+    }
   }
 
   private static final class NoopValidator implements CaseDataValidator {


### PR DESCRIPTION
## Why a follow-up PR

PR #424 was merged at 2026-05-11T22:08Z (commit `ff4e1edcd`) before the adversarial code-review findings could be applied. This PR carries the 5 per-concern remediation commits to address those findings in `v2-develop`.

## What it fixes

### Blockers (from #424 review)

1. **Audit log AFTER_COMMIT** — `AdminController.rebaseApply` was emitting `event=admin.case.rebase ...` via `log.info` inside `@Transactional`, firing before commit. Refactored to publish a `RebaseApplied` domain event inside the transaction; `RebaseAuditListener` (a `@TransactionalEventListener(phase=AFTER_COMMIT)`) emits the wire string. Commit-failure no longer produces an orphan audit line. New IT: `RebaseAuditListenerCommitFailureTest`.

2. **Optimistic-lock bypass on rebase apply** — `CaseRebaseService.apply` reconstructed `Case` with the read `@Version`, so JPA merge silently won on concurrent modify. Replaced with a `@Modifying @Query` JPQL `updateCaseTypeVersion(id, to, ver)` that increments version + checks rowCount; throws `WksConcurrentModificationException(WKS_CFG_035)` on rowCount==0.

3. **CaseRebasePostgresIT committed-read refactor** — test was `@Transactional` so it could not prove commit/rollback semantics. Now uses `@SpringBootTest(webEnvironment=RANDOM_PORT)` + `TestRestTemplate` against the admin endpoints, reads post-conditions via a fresh `TransactionTemplate`. Added scenarios: irreconcilable rejection (assert UNCHANGED), reverse-version on apply (WKS-API-007 + UNCHANGED), no-op rebase on apply (WKS-API-008 + UNCHANGED). Per-test UUIDs via `@BeforeEach`.

### Must-fix majors

4. **`toForceOverrideReason` fail-loud** — throws `IllegalStateException` on `NO_OVERRIDE_USED` instead of silently returning `LENIENT_SUCCESS`.

5. **WKS-API-007/008 split** — `toVersion == fromVersion` (no-op) and `toVersion < fromVersion` (reverse) were collapsed under WKS-API-007. New WKS-API-008 ("no-op rebase") split out cleanly.

6. **Stage-rename detection** — `CaseRebaseReport.buildReport` now detects `fromVersion` stages absent from `toVersion` and adds them to `irreconcilable[]` with new `IrreconcilableKind.STAGE_REMOVED_WITH_ACTIVE_CASE`. Full operator-supplied stage-remap remains deferred to Story 3-9.1.

## New error codes

- **WKS-CFG-035** — concurrent modification of Case during rebase apply
- **WKS-API-008** — no-op rebase (`toVersion == fromVersion`)

## Fix-forward commit

`6f0a66f25` adds `@MockitoBean LicenseService` to `AdminControllerRebaseTest`. Required because the test imports `SecurityConfig`, which since #422 wires `SamlGatingFilter` (constructor-injects `LicenseService`). Mirrors the pattern already used in `AdminControllerTest`. Same commit also picks up incidental `spotless:apply` re-wrapping on a few cherry-picked files.

## Deferred from review

- Full stage-id remap rules with operator-supplied mapping JSON in POST body — filed as Story 3-9.1 (`_bmad-output/implementation-artifacts/3-9-1-stage-id-rebase-semantics.md`, already in planning repo main).
- `GateOutcome.LENIENT_FAIL_BYPASS_USED` state for distinguishing "compensated for parser quirk" vs "shipped known-bad YAML" — deferred to Story 3-11 audit-log enrichment.
- `IrreconcilableItem.currentValue "<redacted>"` literal — type-hint decision deferred to next rebase-touching story.
- `caseId`/`caseTypeId` mismatch returns 422 not 404 — REST inconsistency, deferred to Story 3-11.

## Tests

- `RebaseAuditListenerCommitFailureTest` — proves audit line is absent when commit fails.
- `CaseRebaseServiceTest` scenarios for version-pre-bump (CFG-035) and no-op vs reverse (API-008).
- `CaseRebasePostgresIT` — HTTP/fresh-tx refactor + new scenarios.

Local ci.yml gauntlet green from worktree pre-push: `mvn verify` (590 unit + 168 IT, 0 errors), tenant-invariant scans (Story 3.0 + operator-surface), shellcheck, envsubst+docker compose config, frontend lint/format/test/build (348 tests).
