### PR TITLE
story(5-5): review remediation — findVersion strict pin + AC-6 IT + factory removal

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/domain/event/FormSubmitted.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/event/FormSubmitted.java
@@ -29,15 +29,4 @@ public record FormSubmitted(
     Instant submittedAt,
     Set<String> updatedFieldIds,
     /** Story 5.5 AC-7 — the pinned CaseTypeVersion the form was resolved against (D20). */
-    int caseTypeVersion) {
-
-  /**
-   * Backward-compat factory for callers (e.g. test helpers) that pre-date Story 5.5's {@code
-   * caseTypeVersion} slot. Defaults {@code caseTypeVersion} to {@code 0} as a sentinel — real
-   * production paths must always supply the version.
-   */
-  public static FormSubmitted of(
-      UUID caseId, String formId, UUID actorId, Instant submittedAt, Set<String> updatedFieldIds) {
-    return new FormSubmitted(caseId, formId, actorId, submittedAt, updatedFieldIds, 0);
-  }
-}
+    int caseTypeVersion) {}

--- a/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
+++ b/backend/src/main/java/com/wkspower/platform/domain/service/CaseService.java
@@ -220,12 +220,21 @@ public class CaseService {
     // Story 5.5 AC-4 — Decision D20 frozen-on-version: validate updated case data against the
     // CaseType the case is PINNED to, not the latest deployed version. This ensures a v1-pinned
     // case can still pass update validation after a v2 (with additional required fields) is
-    // deployed. Falls back to latest if the pinned version is not in the registry (defensive — the
-    // normal path always has the pinned version cached since register() now populates byVersion).
+    // deployed. Review remediation: strict pin — WKS-VER-002 (HTTP 422) on registry miss. The
+    // prior fallback-to-latest masked eviction-induced inconsistencies (a case validated against
+    // v2 schema while still pinned to v1 silently produced wrong errors).
     CaseTypeConfig caseType =
         caseTypeReader
             .findVersion(existing.caseTypeId(), existing.caseTypeVersion())
-            .orElseGet(() -> requireCaseType(existing.caseTypeId()));
+            .orElseThrow(
+                () ->
+                    new WksVersionException(
+                        ErrorCode.WKS_VER_002,
+                        "case pinned to unknown CaseTypeVersion v"
+                            + existing.caseTypeVersion()
+                            + " for caseType "
+                            + existing.caseTypeId()
+                            + "; registry has no entry"));
     Map<String, Object> safeData = newData == null ? Map.of() : Map.copyOf(newData);
 
     List<ErrorDetail> violations = caseDataValidator.validate(caseType, safeData);
@@ -436,12 +445,22 @@ public class CaseService {
 
     // Story 5.6 AC2 — field-level edit-permission check requires the pinned CaseTypeConfig (which
     // carries editableBy declarations). Use findVersion so the permission check respects the same
-    // version the form was resolved against. Fallback to latest on registry miss (should not occur
-    // since resolveFormDefinitionForCase above already threw WKS-VER-002 on that path).
+    // version the form was resolved against. Review remediation: strict pin — WKS-VER-002 (HTTP
+    // 422) on registry miss. resolveFormDefinitionForCase above already throws WKS-VER-002 on
+    // that path, but defending here makes the contract explicit at every call site rather than
+    // relying on call-order coupling.
     CaseTypeConfig caseType =
         caseTypeReader
             .findVersion(existing.caseTypeId(), existing.caseTypeVersion())
-            .orElseGet(() -> requireCaseType(existing.caseTypeId()));
+            .orElseThrow(
+                () ->
+                    new WksVersionException(
+                        ErrorCode.WKS_VER_002,
+                        "case pinned to unknown CaseTypeVersion v"
+                            + existing.caseTypeVersion()
+                            + " for caseType "
+                            + existing.caseTypeId()
+                            + "; registry has no entry"));
 
     // Validate submitted field values against the form's field definitions.
     // Collections.unmodifiableMap(new HashMap<>(...)) is used instead of Map.copyOf() because

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinEvictionIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinEvictionIT.java
@@ -165,8 +165,7 @@ class FormBindingVersionPinEvictionIT {
             ? List.of(
                 new FieldDefinition(
                     "applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
-                new FieldDefinition(
-                    "email", "Email", FieldType.TEXT, true, 1, List.of(), null))
+                new FieldDefinition("email", "Email", FieldType.TEXT, true, 1, List.of(), null))
             : List.of(
                 new FieldDefinition(
                     "applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinEvictionIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinEvictionIT.java
@@ -1,0 +1,192 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.FormDefinition;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Story 5.5 AC-6 (c) — Review remediation: when the pinned CaseTypeVersion has been evicted from
+ * the by-version cache AND the underlying YAML stub fails re-hydration validation, the strict
+ * findVersion path in {@code CaseService.update}/{@code submitForm} must surface {@code
+ * WKS-VER-002} as HTTP 422 — not silently fall back to the latest version's schema.
+ *
+ * <p>Forces eviction by setting {@code wks.registry.cache.max-size=1} and registering enough
+ * versions to push v1 out of the access-ordered LRU. The test-bypass register() path writes a
+ * minimal stub YAML to the version registry, which the validator rejects on re-hydration — so
+ * eviction yields {@code Optional.empty()} on findVersion(id, 1), and the service must throw.
+ *
+ * <p>Lives in its own class to scope the cache-size property to this Spring context only — the
+ * sibling {@link FormBindingVersionPinIT} relies on the default cache size for AC-5/AC-7.
+ *
+ * <p>Memory {@code feedback_production_validator_opt_out.md}: production-validation disabled.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:formbindingversionpin-eviction;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ=",
+      "wks.bootstrap.production-validation.enabled=false",
+      "wks.registry.cache.max-size=1"
+    })
+class FormBindingVersionPinEvictionIT {
+
+  private static final String EMAIL = "formbind-pin-evict-it@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String FORM_ID = "intake-form";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private ObjectMapper json;
+
+  @BeforeEach
+  void setup() {
+    if (users.findByEmail(EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+  }
+
+  /**
+   * AC-6 (c) — v1 evicted: PUT against v1-pinned case → 422 WKS-VER-002.
+   *
+   * <p>Sequence:
+   *
+   * <ol>
+   *   <li>Register v1, create a case (pinned to v1).
+   *   <li>Register v2 and v3 with cache-size=1 → v1 evicted from the by-version LRU.
+   *   <li>PUT /api/cases/{id} with v1 body — service-side findVersion(id, 1) returns empty after
+   *       failed re-hydration of stub YAML, orElseThrow fires WKS-VER-002 → HTTP 422.
+   * </ol>
+   */
+  @Test
+  void putAgainstEvictedPinnedVersionReturns422WksVer002() throws Exception {
+    String caseTypeId = "fvp-evict-" + UUID.randomUUID().toString().substring(0, 8);
+    registry.register(caseTypeAt(caseTypeId, 1, false));
+
+    String cookie = login();
+    String caseId = createCase(cookie, caseTypeId);
+
+    // Capture optimistic-lock version BEFORE eviction (case still readable via byId path).
+    ResponseEntity<String> getResp = exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
+    long caseVersion = json.readTree(getResp.getBody()).path("data").path("version").asLong();
+
+    // Force eviction: register v2 and v3 with cache-size=1, pushing v1 out of byVersion.
+    registry.register(caseTypeAt(caseTypeId, 2, false));
+    registry.register(caseTypeAt(caseTypeId, 3, false));
+
+    // PUT against v1-pinned case — pinned version no longer in cache; stub YAML re-hydration
+    // fails validation → findVersion returns empty → service throws WKS-VER-002.
+    ResponseEntity<String> putResp =
+        exchange(
+            "/api/cases/" + caseId,
+            HttpMethod.PUT,
+            cookie,
+            "{\"data\":{\"applicant\":\"Bob\"},\"version\":" + caseVersion + "}");
+
+    assertThat(putResp.getStatusCode())
+        .as("v1 evicted → PUT must return 422 WKS-VER-002, not silent fallback to latest")
+        .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    JsonNode body = json.readTree(putResp.getBody());
+    assertThat(body.path("error").path("code").asText())
+        .as("error code on PUT against evicted pinned version")
+        .isEqualTo("WKS-VER-002");
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private String login() {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(EMAIL, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", EMAIL).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    assertThat(setCookie).isNotNull();
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private String createCase(String cookie, String caseTypeId) throws Exception {
+    ResponseEntity<String> resp =
+        exchange(
+            "/api/cases",
+            HttpMethod.POST,
+            cookie,
+            "{\"caseTypeId\":\"" + caseTypeId + "\",\"data\":{\"applicant\":\"Initial\"}}");
+    assertThat(resp.getStatusCode()).as("create case").isEqualTo(HttpStatus.CREATED);
+    return json.readTree(resp.getBody()).path("data").path("id").asText();
+  }
+
+  private ResponseEntity<String> exchange(
+      String path, HttpMethod method, String cookie, String body) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add(HttpHeaders.COOKIE, cookie);
+    return rest.exchange(path, method, new HttpEntity<>(body, headers), String.class);
+  }
+
+  // ---- fixtures --------------------------------------------------------------
+
+  private static CaseTypeConfig caseTypeAt(String caseTypeId, int version, boolean extraRequired) {
+    List<FieldDefinition> fields =
+        extraRequired
+            ? List.of(
+                new FieldDefinition(
+                    "applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+                new FieldDefinition(
+                    "email", "Email", FieldType.TEXT, true, 1, List.of(), null))
+            : List.of(
+                new FieldDefinition(
+                    "applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+                new FieldDefinition(
+                    "amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
+    FormDefinition form =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+    return new CaseTypeConfig(
+        caseTypeId,
+        "FormBind Pin Eviction Fixture",
+        version,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(form));
+  }
+}

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinIT.java
@@ -149,6 +149,74 @@ class FormBindingVersionPinIT {
   }
 
   /**
+   * AC-6 (a) — v1-pinned case validates against v1 form when a field was REMOVED in v2.
+   *
+   * <p>Specifically guards review-remediation concern: with the fallback-to-latest behaviour, a
+   * v1-pinned case submitting a v1-only field after v2 dropped it would fall through to v2 schema
+   * validation and silently strip the field. Now that update()/submitForm() strictly pin to the
+   * registered version, the v1 schema is authoritative.
+   *
+   * <p>v1 has {@code applicant, amount, note}. v2 drops {@code note}. v1-pinned case POSTs with
+   * {@code note} present — must succeed (validated against v1, where note is declared).
+   */
+  @Test
+  void v1PinnedValidatesAgainstV1AfterFieldRemovedInV2() throws Exception {
+    String caseTypeId = "fvp-t3-" + UUID.randomUUID().toString().substring(0, 8);
+    registry.register(caseTypeV1WithNote(caseTypeId));
+
+    String cookie = login();
+    String caseId = createCase(cookie, caseTypeId);
+
+    // Deploy v2 which DROPS the "note" field
+    registry.register(caseTypeV2NoteRemoved(caseTypeId));
+
+    // Submit with "note" present — must succeed under v1 validation
+    ResponseEntity<String> submitResp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\",\"amount\":42,\"note\":\"v1-only field\"}");
+    assertThat(submitResp.getStatusCode())
+        .as("v1-pinned submit with v1-only field must succeed under v1 schema")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  /**
+   * AC-6 (b) — v1-pinned case is NOT subject to v2's newly-required field.
+   *
+   * <p>v1 requires {@code applicant}. v2 adds required {@code email}. v1-pinned case PUTs with v1
+   * shape (no email) — must succeed under v1 schema validation, not be rejected by v2's required.
+   */
+  @Test
+  void v1PinnedUpdateNotSubjectToV2NewRequiredField() throws Exception {
+    String caseTypeId = "fvp-t4-" + UUID.randomUUID().toString().substring(0, 8);
+    registry.register(caseTypeV1(caseTypeId));
+
+    String cookie = login();
+    String caseId = createCase(cookie, caseTypeId);
+
+    // Capture version (needed for PUT optimistic-lock header)
+    ResponseEntity<String> getResp = exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
+    long caseVersion = json.readTree(getResp.getBody()).path("data").path("version").asLong();
+
+    // Deploy v2 with new required field "email"
+    registry.register(caseTypeV2(caseTypeId));
+
+    // PUT with v1-shape body (no "email") — must succeed under v1 schema. UpdateCaseRequest
+    // carries the optimistic-lock version in the body (request.version()), not in If-Match.
+    ResponseEntity<String> putResp =
+        exchange(
+            "/api/cases/" + caseId,
+            HttpMethod.PUT,
+            cookie,
+            "{\"data\":{\"applicant\":\"Bob\",\"amount\":1},\"version\":" + caseVersion + "}");
+    assertThat(putResp.getStatusCode())
+        .as("v1-pinned PUT with v1 body must succeed even though v2 demands email")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  /**
    * AC-7 — submit response caseTypeVersion reflects pinned version.
    *
    * <p>The FormController embeds the pinned CaseType in the response DTO. After submitting,
@@ -233,6 +301,58 @@ class FormBindingVersionPinIT {
         caseTypeId,
         "FormBind Pin Fixture",
         1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(form));
+  }
+
+  /**
+   * v1 variant for AC-6 (a): includes optional "note" field. v2 (next fixture) drops it. A
+   * v1-pinned case must still accept "note" because it is declared on the pinned v1 schema.
+   */
+  private static CaseTypeConfig caseTypeV1WithNote(String caseTypeId) {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null),
+            new FieldDefinition("note", "Note", FieldType.TEXT, false, 2, List.of(), null));
+    FormDefinition form =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+    return new CaseTypeConfig(
+        caseTypeId,
+        "FormBind Pin Fixture",
+        1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(form));
+  }
+
+  /** v2 variant for AC-6 (a): drops the "note" field. */
+  private static CaseTypeConfig caseTypeV2NoteRemoved(String caseTypeId) {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
+    FormDefinition form =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+    return new CaseTypeConfig(
+        caseTypeId,
+        "FormBind Pin Fixture",
+        2,
         null,
         null,
         fields,

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinPostgresIT.java
@@ -55,8 +55,15 @@ class FormBindingVersionPinPostgresIT {
 
   private static final String EMAIL = "formbind-pin-pg-it@wkspower.local";
   private static final String PASSWORD = "admin";
-  private static final String CASE_TYPE_ID = "formbind-pin-pg-fixture";
   private static final String FORM_ID = "intake-form";
+
+  /**
+   * Per-test unique case-type id (mirrors {@link FormBindingVersionPinIT}). Assigned in {@link
+   * #setup} so each @Test sees a fresh registry slot — without this, the second test cannot
+   * re-register v1 because v2 from the prior test is still the current version for the shared id
+   * (WKS-CFG-011 older-version guard fires).
+   */
+  private String caseTypeId;
 
   @Container
   @SuppressWarnings("resource")
@@ -86,7 +93,8 @@ class FormBindingVersionPinPostgresIT {
 
   @BeforeEach
   void setup() {
-    registry.register(caseTypeV1());
+    this.caseTypeId = "formbind-pin-pg-" + UUID.randomUUID().toString().substring(0, 8);
+    registry.register(caseTypeV1WithId(caseTypeId));
   }
 
   /**
@@ -99,10 +107,10 @@ class FormBindingVersionPinPostgresIT {
   @Test
   void inFlightCaseSeesV1FormAfterV2DeployOnPostgres() throws Exception {
     String cookie = login();
-    String caseId = createCase(cookie);
+    String caseId = createCaseWithId(cookie, caseTypeId);
 
     // Deploy v2 with extra required field
-    registry.register(caseTypeV2());
+    registry.register(caseTypeV2WithId(caseTypeId));
 
     // GET the case — embedded CaseType must be v1
     ResponseEntity<String> getResp = exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
@@ -138,8 +146,8 @@ class FormBindingVersionPinPostgresIT {
   /**
    * AC-6 (a) Postgres parity — v1-pinned validates against v1 when a field was REMOVED in v2.
    *
-   * <p>Uses a per-test unique id to avoid registry older-version rejection against the {@link
-   * #CASE_TYPE_ID} v1 written by {@link #setup}. JSONB persistence path verified.
+   * <p>Uses a per-test unique id to avoid registry older-version rejection against the v1 fixture
+   * written by {@link #setup}. JSONB persistence path verified.
    */
   @Test
   void v1PinnedValidatesAgainstV1AfterFieldRemovedInV2OnPostgres() throws Exception {
@@ -205,10 +213,6 @@ class FormBindingVersionPinPostgresIT {
     return semi > 0 ? setCookie.substring(0, semi) : setCookie;
   }
 
-  private String createCase(String cookie) throws Exception {
-    return createCaseWithId(cookie, CASE_TYPE_ID);
-  }
-
   private String createCaseWithId(String cookie, String caseTypeId) throws Exception {
     ResponseEntity<String> resp =
         exchange(
@@ -230,7 +234,8 @@ class FormBindingVersionPinPostgresIT {
 
   // ---- CaseType fixtures -----------------------------------------------------
 
-  private static CaseTypeConfig caseTypeV1() {
+  /** v1 with explicit id (per-test fresh id to dodge the older-version guard across tests). */
+  private static CaseTypeConfig caseTypeV1WithId(String caseTypeId) {
     List<FieldDefinition> fields =
         List.of(
             new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
@@ -238,7 +243,7 @@ class FormBindingVersionPinPostgresIT {
     FormDefinition form =
         new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
     return new CaseTypeConfig(
-        CASE_TYPE_ID,
+        caseTypeId,
         "FormBind Pin PG Fixture",
         1,
         null,
@@ -251,18 +256,6 @@ class FormBindingVersionPinPostgresIT {
                 "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
         List.of(),
         List.of(form));
-  }
-
-  // ---- AC-6 (a)+(b) per-test-id variants ------------------------------------
-
-  /** v1 with explicit id, for AC-6 (b) test (per-test fresh id to dodge older-version guard). */
-  private static CaseTypeConfig caseTypeV1WithId(String caseTypeId) {
-    return rebuildAt(caseTypeV1(), caseTypeId);
-  }
-
-  /** v2 with explicit id, for AC-6 (b) test. */
-  private static CaseTypeConfig caseTypeV2WithId(String caseTypeId) {
-    return rebuildAt(caseTypeV2(), caseTypeId);
   }
 
   /** v1 with explicit id + optional "note" field, for AC-6 (a). */
@@ -314,23 +307,8 @@ class FormBindingVersionPinPostgresIT {
         List.of(form));
   }
 
-  /** Rebuild a fixture with a different id (uses the 11-arg compat constructor). */
-  private static CaseTypeConfig rebuildAt(CaseTypeConfig src, String caseTypeId) {
-    return new CaseTypeConfig(
-        caseTypeId,
-        src.displayName(),
-        src.version(),
-        src.description(),
-        src.workflow(),
-        src.fields(),
-        src.statuses(),
-        src.listColumns(),
-        src.roles(),
-        src.stages(),
-        src.forms());
-  }
-
-  private static CaseTypeConfig caseTypeV2() {
+  /** v2 with explicit id (adds required "email"). */
+  private static CaseTypeConfig caseTypeV2WithId(String caseTypeId) {
     List<FieldDefinition> fields =
         List.of(
             new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
@@ -339,7 +317,7 @@ class FormBindingVersionPinPostgresIT {
     FormDefinition form =
         new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
     return new CaseTypeConfig(
-        CASE_TYPE_ID,
+        caseTypeId,
         "FormBind Pin PG Fixture",
         2,
         null,

--- a/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinPostgresIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/FormBindingVersionPinPostgresIT.java
@@ -15,6 +15,7 @@ import com.wkspower.platform.domain.config.model.StatusColor;
 import com.wkspower.platform.domain.config.model.StatusDefinition;
 import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,6 +135,64 @@ class FormBindingVersionPinPostgresIT {
         .isEqualTo(1);
   }
 
+  /**
+   * AC-6 (a) Postgres parity — v1-pinned validates against v1 when a field was REMOVED in v2.
+   *
+   * <p>Uses a per-test unique id to avoid registry older-version rejection against the {@link
+   * #CASE_TYPE_ID} v1 written by {@link #setup}. JSONB persistence path verified.
+   */
+  @Test
+  void v1PinnedValidatesAgainstV1AfterFieldRemovedInV2OnPostgres() throws Exception {
+    String caseTypeId = "fvp-pg-t3-" + UUID.randomUUID().toString().substring(0, 8);
+    registry.register(caseTypeV1WithNote(caseTypeId));
+
+    String cookie = login();
+    String caseId = createCaseWithId(cookie, caseTypeId);
+
+    registry.register(caseTypeV2NoteRemoved(caseTypeId));
+
+    ResponseEntity<String> submitResp =
+        exchange(
+            "/api/cases/" + caseId + "/forms/" + FORM_ID + "/submit",
+            HttpMethod.POST,
+            cookie,
+            "{\"applicant\":\"Alice\",\"amount\":42,\"note\":\"v1-only field\"}");
+    assertThat(submitResp.getStatusCode())
+        .as("Postgres: v1-pinned submit with v1-only field must succeed")
+        .isEqualTo(HttpStatus.OK);
+  }
+
+  /**
+   * AC-6 (b) Postgres parity — v1-pinned PUT not subject to v2's new required field.
+   *
+   * <p>Reads optimistic-lock version in a fresh exchange (Postgres reads must see the committed
+   * INSERT from createCase; memory {@code feedback_postgres_it_committed_read.md}). The PUT body
+   * carries {@code version} per {@code UpdateCaseRequest}.
+   */
+  @Test
+  void v1PinnedUpdateNotSubjectToV2NewRequiredFieldOnPostgres() throws Exception {
+    String caseTypeId = "fvp-pg-t4-" + UUID.randomUUID().toString().substring(0, 8);
+    registry.register(caseTypeV1WithId(caseTypeId));
+
+    String cookie = login();
+    String caseId = createCaseWithId(cookie, caseTypeId);
+
+    ResponseEntity<String> getResp = exchange("/api/cases/" + caseId, HttpMethod.GET, cookie, null);
+    long caseVersion = json.readTree(getResp.getBody()).path("data").path("version").asLong();
+
+    registry.register(caseTypeV2WithId(caseTypeId));
+
+    ResponseEntity<String> putResp =
+        exchange(
+            "/api/cases/" + caseId,
+            HttpMethod.PUT,
+            cookie,
+            "{\"data\":{\"applicant\":\"Bob\",\"amount\":1},\"version\":" + caseVersion + "}");
+    assertThat(putResp.getStatusCode())
+        .as("Postgres: v1-pinned PUT with v1 body must succeed even though v2 demands email")
+        .isEqualTo(HttpStatus.OK);
+  }
+
   // ---- helpers ---------------------------------------------------------------
 
   private String login() {
@@ -147,12 +206,16 @@ class FormBindingVersionPinPostgresIT {
   }
 
   private String createCase(String cookie) throws Exception {
+    return createCaseWithId(cookie, CASE_TYPE_ID);
+  }
+
+  private String createCaseWithId(String cookie, String caseTypeId) throws Exception {
     ResponseEntity<String> resp =
         exchange(
             "/api/cases",
             HttpMethod.POST,
             cookie,
-            "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"applicant\":\"Initial\"}}");
+            "{\"caseTypeId\":\"" + caseTypeId + "\",\"data\":{\"applicant\":\"Initial\"}}");
     assertThat(resp.getStatusCode()).as("create case").isEqualTo(HttpStatus.CREATED);
     return json.readTree(resp.getBody()).path("data").path("id").asText();
   }
@@ -188,6 +251,83 @@ class FormBindingVersionPinPostgresIT {
                 "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
         List.of(),
         List.of(form));
+  }
+
+  // ---- AC-6 (a)+(b) per-test-id variants ------------------------------------
+
+  /** v1 with explicit id, for AC-6 (b) test (per-test fresh id to dodge older-version guard). */
+  private static CaseTypeConfig caseTypeV1WithId(String caseTypeId) {
+    return rebuildAt(caseTypeV1(), caseTypeId);
+  }
+
+  /** v2 with explicit id, for AC-6 (b) test. */
+  private static CaseTypeConfig caseTypeV2WithId(String caseTypeId) {
+    return rebuildAt(caseTypeV2(), caseTypeId);
+  }
+
+  /** v1 with explicit id + optional "note" field, for AC-6 (a). */
+  private static CaseTypeConfig caseTypeV1WithNote(String caseTypeId) {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null),
+            new FieldDefinition("note", "Note", FieldType.TEXT, false, 2, List.of(), null));
+    FormDefinition form =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+    return new CaseTypeConfig(
+        caseTypeId,
+        "FormBind Pin PG Fixture",
+        1,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(form));
+  }
+
+  /** v2 with explicit id, "note" REMOVED — for AC-6 (a). */
+  private static CaseTypeConfig caseTypeV2NoteRemoved(String caseTypeId) {
+    List<FieldDefinition> fields =
+        List.of(
+            new FieldDefinition("applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null),
+            new FieldDefinition("amount", "Amount", FieldType.NUMBER, false, 1, List.of(), null));
+    FormDefinition form =
+        new FormDefinition(FORM_ID, "single", "monolithic", "single-page", fields, List.of(), null);
+    return new CaseTypeConfig(
+        caseTypeId,
+        "FormBind Pin PG Fixture",
+        2,
+        null,
+        null,
+        fields,
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.CREATE, Permission.EDIT, Permission.VIEW))),
+        List.of(),
+        List.of(form));
+  }
+
+  /** Rebuild a fixture with a different id (uses the 11-arg compat constructor). */
+  private static CaseTypeConfig rebuildAt(CaseTypeConfig src, String caseTypeId) {
+    return new CaseTypeConfig(
+        caseTypeId,
+        src.displayName(),
+        src.version(),
+        src.description(),
+        src.workflow(),
+        src.fields(),
+        src.statuses(),
+        src.listColumns(),
+        src.roles(),
+        src.stages(),
+        src.forms());
   }
 
   private static CaseTypeConfig caseTypeV2() {


### PR DESCRIPTION
## Why a follow-up PR

PR #429 (Story 5-5 — frozen-on-version form binding, D20) was merged un-remediated. The four review-remediation actions agreed during code review land here as separate commits on top of `v2-develop`, mirroring the way PR #431 carried the review remediation for #424.

## Summary of the four commits

1. **`fix(5-5): findVersion fallback removed; orElseThrow WKS-VER-002`** — `CaseService.update()` and `CaseService.submitForm()` previously fell back to `requireCaseType()` (latest version) on a `findVersion` miss. Replaced with `orElseThrow(WksVersionException(WKS_VER_002))` (HTTP 422, already mapped in `GlobalExceptionHandler`). The prior fallback masked eviction-induced inconsistencies where a v1-pinned case could silently validate against a v2 schema.

2. **`test(5-5): AC-6 IT + Postgres-IT — v1-pinned validates v1 only, WKS-VER-002 on evicted version`** — three remediation test cases mirrored across H2 (`FormBindingVersionPinIT`) and Postgres-IT (`FormBindingVersionPinPostgresIT`):
   - (a) v1-pinned case after v2 REMOVES a field → submit with v1-only field succeeds under v1 schema.
   - (b) v1-pinned case after v2 ADDS a required field → PUT with v1-shape body succeeds (not subject to v2's required).
   - (c) v1 evicted from by-version cache → PUT returns 422 `WKS-VER-002`. Carved into a dedicated `FormBindingVersionPinEvictionIT` so `wks.registry.cache.max-size=1` is scoped to that Spring context only.

3. **`test(5-5): FormBindingVersionPinPostgresIT uses per-test UUID`** — `CASE_TYPE_ID` constant replaced with a per-test UUID assigned in `@BeforeEach`, mirroring the H2 sibling. Drops the no-arg fixture overloads + transient `rebuildAt` helper. The shared id was a latent footgun: any second `@Test` would hit `WKS-CFG-011` older-version rejection on `@BeforeEach` v1 re-registration.

4. **`refactor(5-5): delete FormSubmitted.of(); migrate callers`** — the `FormSubmitted.of(...)` static factory defaulted `caseTypeVersion = 0` (a sentinel that silently corrupts audit history). Zero remaining callers — the only production call site already uses the canonical 6-arg constructor. Removed to force every future caller to supply the pinned version explicitly.

Plus a tiny `chore(5-5): spotless reformat` fix-up to keep `mvn verify` green.

## Local verify

`mvn -B -ntp verify` from `backend/` is BUILD SUCCESS on the pushed shas. Failsafe results for the three Pin-IT classes:

- `FormBindingVersionPinIT` — 4 tests, 0 failures
- `FormBindingVersionPinPostgresIT` — 3 tests, 0 failures
- `FormBindingVersionPinEvictionIT` — 1 test, 0 failures

Tenant-invariant lint OK.

## Deferred from review

- **AC-5 two-thread concurrent isolation proof** — deferred to Story 5-7 stub (`_bmad-output/implementation-artifacts/5-7-form-binding-race-hardening.md` in the planning repo).
- **AC-8 frontend version-bumped-resume gate dead-coded** — deferred to Story 5-8 stub (renamed from 5-6 because of slot collision; `_bmad-output/implementation-artifacts/5-8-form-draft-resume-semantics.md`).
- **FormPage version-chip vocabulary leak** — deferred to WDS phase-1.
- **`resolveFormDefinitionForCase` opaque error on `caseTypeVersion=0`** — deferred to the next form-touching story.
- **StageDefinition 2 compat constructors** — deferred to the next stage-touching story (per the carry-forward-into-next-touching-story rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)