### PR TITLE
chore: split CI into fast (PR) and slow (nightly/main) lanes

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,0 +1,201 @@
+# CI — SLOW LANE (nightly + PR-to-main + on-demand + push-to-main)
+#
+# Runs the full correctness suite that ci.yml (fast lane) skips:
+#   - Backend `mvn verify` WITHOUT -Pfast-it (full *PostgresIT.java sweep).
+#   - production-profile-smoke (Docker + Postgres + MinIO; Story 14.1 AC6 +
+#     Story 14.7 §8 H2-driver regression guard).
+#
+# Triggers: nightly cron, PR targeting main (pre-merge gate), push to main,
+# and manual workflow_dispatch for on-demand verification.
+name: CI (full)
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-full-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend-full:
+    name: Backend full (Temurin 21, all ITs incl. PostgresIT)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build + verify (full — unit + ArchUnit + all ITs)
+        run: ./mvnw -B -ntp verify
+
+  production-profile-smoke:
+    # Story 14.1 AC6 — boot the production stack against real Postgres + MinIO
+    # via `docker compose -f docker/docker-compose.prod.yml up`, poll /api/health,
+    # and assert ZERO H2-driver loading in the container logs (the regression
+    # guard for Story 14.7 §8 / WKS-API-053). Re-uses Story 14.7's runtime
+    # tenant-id probe. Local replication required per "Match CI Locally" memory
+    # before PR.
+    name: Production profile smoke (Story 14.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build production image (load into local daemon)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          load: true
+          tags: wkspower/wks-platform:2.0.0-prod
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Write fixture .env (synthetic secrets — CI only)
+        # JWT secret is a CI-only deterministic Base64 string (≥32 bytes after
+        # decoding) that satisfies JwtTokenProvider's WKS-API-053 production
+        # validation without exposing a real key. Operators MUST generate their
+        # own with `openssl rand -base64 48`.
+        #
+        # Story 14.1.1 AC7: every required env var is set to a real (non-sentinel)
+        # value so the new ProductionBootstrapValidator's WKS-API-055 secret-rotation
+        # check passes. NO value below may equal `<MUST-BE-ROTATED>` — that is the
+        # exact literal the validator rejects.
+        #
+        # Story 14.1.1 fix-up: docker/.env is no longer tracked. Compose still
+        # interpolates `${...}` from this file when found alongside the compose
+        # YAML; we keep writing it here as the CI fixture mechanism. No
+        # COMPOSE_PROFILES is needed — the file-split makes profiles obsolete.
+        run: |
+          JWT_FIXTURE=$(printf 'wks-ci-fixture-jwt-secret-bytes-padding-padding-padding' | base64)
+          cat > docker/.env <<EOF
+          WKS_DB_URL=jdbc:postgresql://postgres:5432/wks
+          WKS_DB_USER=wks
+          WKS_DB_PASSWORD=ci-fixture-db-password
+          WKS_STORAGE_ENDPOINT=http://minio:9000
+          WKS_STORAGE_KEY=ci-fixture-storage-key
+          WKS_ADMIN_EMAIL=admin@ci.invalid
+          WKS_ADMIN_PASSWORD=ci-fixture-admin-password
+          WKS_LOCALE=en-IN
+          WKS_CORS_ORIGINS=http://localhost:8080
+          WKS_JWT_SECRET=${JWT_FIXTURE}
+          WKS_OPENAPI_ENABLED=false
+          WKS_MINIO_ROOT_USER=ci-fixture-minio-user
+          WKS_MINIO_ROOT_PASSWORD=ci-fixture-minio-password
+          WKS_HOST_PORT=8080
+          EOF
+
+      - name: Bring up production stack
+        # Story 14.1.1 fix-up: the dev/prod stacks now live in separate compose
+        # files. `-f docker/docker-compose.prod.yml` selects the production stack
+        # directly — no profiles, no explicit service list needed. Port-8080
+        # collision is structurally impossible because the dev wks-platform
+        # service is no longer in this file.
+        run: docker compose -f docker/docker-compose.prod.yml up -d
+
+      - name: Poll /api/health (90s deadline)
+        run: |
+          deadline=$((SECONDS + 90))
+          healthy=0
+          while [[ $SECONDS -lt $deadline ]]; do
+            if curl -fsS http://localhost:8080/api/health >/dev/null 2>&1; then
+              healthy=1
+              break
+            fi
+            sleep 3
+          done
+          if [[ $healthy -ne 1 ]]; then
+            echo "::error::/api/health did not become healthy within 90s"
+            docker compose -f docker/docker-compose.prod.yml logs
+            exit 1
+          fi
+          echo "Health OK (liveness — see schema-readiness assertions below for readiness)"
+
+      - name: Assert ZERO H2 driver in container logs (regression guard)
+        # Story 14.7 §8 / WKS-API-053 — `Driver org.h2.Driver claims to not accept
+        # jdbcUrl, jdbc:postgresql://...`. THIS is the assertion that catches it.
+        run: |
+          logs=$(docker logs wks-platform-prod 2>&1)
+          if printf '%s' "$logs" | grep -E 'org\.h2\.Driver|jdbc:h2:'; then
+            echo "::error::H2 driver loaded under production profile (regression — Story 14.7 §8)"
+            exit 1
+          fi
+          echo "H2-driver invariant OK: no org.h2.Driver / jdbc:h2: references in production logs"
+
+      - name: Assert schema readiness (Story 14.1.1 AC6)
+        # Liveness (curl /api/health) ≠ readiness. Three positive structural
+        # assertions covering finding I19:
+        #   (a) Flyway applied N>=7 migrations (parsed from container logs).
+        #   (b) ProductionBootstrapValidator emitted RUNTIME INVARIANT OK
+        #       (proves WKS-API-053 datasource + WKS-API-055 secret checks both
+        #       passed during boot).
+        #   (c) The `cases` table is queryable via psql exec (returns a
+        #       structurally-valid result, even with zero rows).
+        run: |
+          logs=$(docker logs wks-platform-prod 2>&1)
+
+          # (a) Flyway migrations applied. Spring Boot's Flyway integration logs
+          # `Successfully applied N migrations to schema` when at least one ran;
+          # idempotent boots with no pending migrations log `Schema "public" is
+          # up to date. No migration necessary.` Either is acceptable; a missing
+          # Flyway log line is the failure mode this guards against.
+          flyway_applied=$(printf '%s' "$logs" | grep -Eo 'Successfully applied [0-9]+ migrations?' | grep -Eo '[0-9]+' | tail -n1 || true)
+          flyway_uptodate=$(printf '%s' "$logs" | grep -E 'Schema .* is up to date|No migration necessary' || true)
+          if [[ -z "$flyway_applied" && -z "$flyway_uptodate" ]]; then
+            echo "::error::Flyway migration log line missing — schema readiness cannot be confirmed."
+            exit 1
+          fi
+          if [[ -n "$flyway_applied" ]]; then
+            echo "Flyway applied $flyway_applied migrations."
+            if (( flyway_applied < 7 )); then
+              echo "::error::Expected >=7 Flyway migrations on a fresh production boot, got $flyway_applied."
+              exit 1
+            fi
+          else
+            echo "Flyway: $flyway_uptodate (idempotent boot)."
+          fi
+
+          # (b) RUNTIME INVARIANT OK — ProductionBootstrapValidator success line.
+          if ! printf '%s' "$logs" | grep -qE 'RUNTIME INVARIANT OK'; then
+            echo "::error::ProductionBootstrapValidator did not emit RUNTIME INVARIANT OK — WKS-API-053 / WKS-API-055 may have failed silently."
+            echo "--- Container logs for diagnosis ---"
+            printf '%s\n' "$logs"
+            echo "--- End container logs ---"
+            exit 1
+          fi
+          echo "RUNTIME INVARIANT OK present in logs."
+
+          # (c) Schema-readiness query against the cases table — a structurally
+          # valid SELECT proves Flyway DDL ran AND the JDBC pool reaches Postgres.
+          if ! docker compose -f docker/docker-compose.prod.yml exec -T postgres \
+                 psql -U wks -d wks -tAc 'SELECT 1 FROM cases LIMIT 1' >/dev/null; then
+            echo "::error::SELECT 1 FROM cases LIMIT 1 failed — cases table absent or pool unreachable."
+            exit 1
+          fi
+          echo "Schema-readiness query OK (cases table queryable)."
+
+      - name: Run runtime ZERO-tenant_id invariant probe
+        # Re-uses Story 14.7's already-shipped probe. AC6.6 + AC8 — extends the
+        # runtime check to the production-profile container without re-implementation.
+        run: ./deploy/probes/check-runtime-no-tenant-id.sh http://localhost:8080
+
+      - name: Tear down (purge volumes)
+        if: always()
+        run: docker compose -f docker/docker-compose.prod.yml down -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,14 @@
+# CI — FAST LANE (PR + v2-develop push)
+#
+# Sprint-velocity fix: S3..S7 sustained ~2 sprints/day; by S10 we were at
+# ~0.5/day. The dominant tax was the per-PR CI floor (production-profile-smoke
+# spinning Postgres+MinIO+Docker + the full *PostgresIT.java suite). Both are
+# real correctness gates but they are NOT required to gate every PR on
+# v2-develop. They run in ci-full.yml (nightly + PR-to-main + on-demand).
+#
+# Fast lane = backend (-Pfast-it), frontend, tenant-invariant, deploy-runbook,
+# docker-build. Full Postgres-IT + production-profile-smoke live in the slow
+# lane.
 name: CI
 
 on:
@@ -7,11 +18,15 @@ on:
     # at v1-final until v2 is merged in.
     branches: [v2-develop, develop]
 
+concurrency:
+  group: ci-fast-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend:
-    name: Backend (Temurin 21)
+    name: Backend (Temurin 21, fast-it)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: backend
@@ -24,8 +39,10 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Build + verify (unit + ArchUnit)
-        run: ./mvnw -B -ntp verify
+      - name: Build + verify (unit + ArchUnit + fast ITs)
+        # -Pfast-it excludes *PostgresIT.java; the full Postgres-IT sweep
+        # runs in ci-full.yml (nightly + PR-to-main).
+        run: ./mvnw -B -ntp -Pfast-it verify
 
   frontend:
     name: Frontend (Node 22)
@@ -164,162 +181,3 @@ jobs:
           tags: wkspower/wks-platform:ci-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  production-profile-smoke:
-    # Story 14.1 AC6 — boot the production stack against real Postgres + MinIO
-    # via `docker compose -f docker/docker-compose.prod.yml up`, poll /api/health,
-    # and assert ZERO H2-driver loading in the container logs (the regression
-    # guard for Story 14.7 §8 / WKS-API-053). Re-uses Story 14.7's runtime
-    # tenant-id probe. Local replication required per "Match CI Locally" memory
-    # before PR.
-    name: Production profile smoke (Story 14.1)
-    runs-on: ubuntu-latest
-    needs: [backend, frontend]
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Build production image (load into local daemon)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile
-          push: false
-          load: true
-          tags: wkspower/wks-platform:2.0.0-prod
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Write fixture .env (synthetic secrets — CI only)
-        # JWT secret is a CI-only deterministic Base64 string (≥32 bytes after
-        # decoding) that satisfies JwtTokenProvider's WKS-API-053 production
-        # validation without exposing a real key. Operators MUST generate their
-        # own with `openssl rand -base64 48`.
-        #
-        # Story 14.1.1 AC7: every required env var is set to a real (non-sentinel)
-        # value so the new ProductionBootstrapValidator's WKS-API-055 secret-rotation
-        # check passes. NO value below may equal `<MUST-BE-ROTATED>` — that is the
-        # exact literal the validator rejects.
-        #
-        # Story 14.1.1 fix-up: docker/.env is no longer tracked. Compose still
-        # interpolates `${...}` from this file when found alongside the compose
-        # YAML; we keep writing it here as the CI fixture mechanism. No
-        # COMPOSE_PROFILES is needed — the file-split makes profiles obsolete.
-        run: |
-          JWT_FIXTURE=$(printf 'wks-ci-fixture-jwt-secret-bytes-padding-padding-padding' | base64)
-          cat > docker/.env <<EOF
-          WKS_DB_URL=jdbc:postgresql://postgres:5432/wks
-          WKS_DB_USER=wks
-          WKS_DB_PASSWORD=ci-fixture-db-password
-          WKS_STORAGE_ENDPOINT=http://minio:9000
-          WKS_STORAGE_KEY=ci-fixture-storage-key
-          WKS_ADMIN_EMAIL=admin@ci.invalid
-          WKS_ADMIN_PASSWORD=ci-fixture-admin-password
-          WKS_LOCALE=en-IN
-          WKS_CORS_ORIGINS=http://localhost:8080
-          WKS_JWT_SECRET=${JWT_FIXTURE}
-          WKS_OPENAPI_ENABLED=false
-          WKS_MINIO_ROOT_USER=ci-fixture-minio-user
-          WKS_MINIO_ROOT_PASSWORD=ci-fixture-minio-password
-          WKS_HOST_PORT=8080
-          EOF
-
-      - name: Bring up production stack
-        # Story 14.1.1 fix-up: the dev/prod stacks now live in separate compose
-        # files. `-f docker/docker-compose.prod.yml` selects the production stack
-        # directly — no profiles, no explicit service list needed. Port-8080
-        # collision is structurally impossible because the dev wks-platform
-        # service is no longer in this file.
-        run: docker compose -f docker/docker-compose.prod.yml up -d
-
-      - name: Poll /api/health (90s deadline)
-        run: |
-          deadline=$((SECONDS + 90))
-          healthy=0
-          while [[ $SECONDS -lt $deadline ]]; do
-            if curl -fsS http://localhost:8080/api/health >/dev/null 2>&1; then
-              healthy=1
-              break
-            fi
-            sleep 3
-          done
-          if [[ $healthy -ne 1 ]]; then
-            echo "::error::/api/health did not become healthy within 90s"
-            docker compose -f docker/docker-compose.prod.yml logs
-            exit 1
-          fi
-          echo "Health OK (liveness — see schema-readiness assertions below for readiness)"
-
-      - name: Assert ZERO H2 driver in container logs (regression guard)
-        # Story 14.7 §8 / WKS-API-053 — `Driver org.h2.Driver claims to not accept
-        # jdbcUrl, jdbc:postgresql://...`. THIS is the assertion that catches it.
-        run: |
-          logs=$(docker logs wks-platform-prod 2>&1)
-          if printf '%s' "$logs" | grep -E 'org\.h2\.Driver|jdbc:h2:'; then
-            echo "::error::H2 driver loaded under production profile (regression — Story 14.7 §8)"
-            exit 1
-          fi
-          echo "H2-driver invariant OK: no org.h2.Driver / jdbc:h2: references in production logs"
-
-      - name: Assert schema readiness (Story 14.1.1 AC6)
-        # Liveness (curl /api/health) ≠ readiness. Three positive structural
-        # assertions covering finding I19:
-        #   (a) Flyway applied N>=7 migrations (parsed from container logs).
-        #   (b) ProductionBootstrapValidator emitted RUNTIME INVARIANT OK
-        #       (proves WKS-API-053 datasource + WKS-API-055 secret checks both
-        #       passed during boot).
-        #   (c) The `cases` table is queryable via psql exec (returns a
-        #       structurally-valid result, even with zero rows).
-        run: |
-          logs=$(docker logs wks-platform-prod 2>&1)
-
-          # (a) Flyway migrations applied. Spring Boot's Flyway integration logs
-          # `Successfully applied N migrations to schema` when at least one ran;
-          # idempotent boots with no pending migrations log `Schema "public" is
-          # up to date. No migration necessary.` Either is acceptable; a missing
-          # Flyway log line is the failure mode this guards against.
-          flyway_applied=$(printf '%s' "$logs" | grep -Eo 'Successfully applied [0-9]+ migrations?' | grep -Eo '[0-9]+' | tail -n1 || true)
-          flyway_uptodate=$(printf '%s' "$logs" | grep -E 'Schema .* is up to date|No migration necessary' || true)
-          if [[ -z "$flyway_applied" && -z "$flyway_uptodate" ]]; then
-            echo "::error::Flyway migration log line missing — schema readiness cannot be confirmed."
-            exit 1
-          fi
-          if [[ -n "$flyway_applied" ]]; then
-            echo "Flyway applied $flyway_applied migrations."
-            if (( flyway_applied < 7 )); then
-              echo "::error::Expected >=7 Flyway migrations on a fresh production boot, got $flyway_applied."
-              exit 1
-            fi
-          else
-            echo "Flyway: $flyway_uptodate (idempotent boot)."
-          fi
-
-          # (b) RUNTIME INVARIANT OK — ProductionBootstrapValidator success line.
-          if ! printf '%s' "$logs" | grep -qE 'RUNTIME INVARIANT OK'; then
-            echo "::error::ProductionBootstrapValidator did not emit RUNTIME INVARIANT OK — WKS-API-053 / WKS-API-055 may have failed silently."
-            echo "--- Container logs for diagnosis ---"
-            printf '%s\n' "$logs"
-            echo "--- End container logs ---"
-            exit 1
-          fi
-          echo "RUNTIME INVARIANT OK present in logs."
-
-          # (c) Schema-readiness query against the cases table — a structurally
-          # valid SELECT proves Flyway DDL ran AND the JDBC pool reaches Postgres.
-          if ! docker compose -f docker/docker-compose.prod.yml exec -T postgres \
-                 psql -U wks -d wks -tAc 'SELECT 1 FROM cases LIMIT 1' >/dev/null; then
-            echo "::error::SELECT 1 FROM cases LIMIT 1 failed — cases table absent or pool unreachable."
-            exit 1
-          fi
-          echo "Schema-readiness query OK (cases table queryable)."
-
-      - name: Run runtime ZERO-tenant_id invariant probe
-        # Re-uses Story 14.7's already-shipped probe. AC6.6 + AC8 — extends the
-        # runtime check to the production-profile container without re-implementation.
-        run: ./deploy/probes/check-runtime-no-tenant-id.sh http://localhost:8080
-
-      - name: Tear down (purge volumes)
-        if: always()
-        run: docker compose -f docker/docker-compose.prod.yml down -v


### PR DESCRIPTION
## Summary
- Split `.github/workflows/ci.yml` (326→183 lines) into fast PR lane + new `ci-full.yml` (201 lines) slow lane.
- Fast lane (PRs to `v2-develop`/`develop`): `backend -Pfast-it`, `frontend`, `tenant-invariant`, `deploy-runbook`, `docker-build`.
- Slow lane (`pull_request: main`, `push: main`, nightly cron `0 3 * * *`, `workflow_dispatch`): `production-profile-smoke` + `backend-full` (no `-Pfast-it`, full Postgres-IT sweep).
- Added `concurrency: cancel-in-progress: true` to both — was missing; superseded-PR runs were burning minutes.

## Why
Sprint cadence regressed from ~2 sprints/day (S3-S7) to ~0.5/day (S10). Per-PR CI floor is the dominant tax: every PR was running Docker+Postgres+MinIO smoke (~6-10min) and full Postgres-IT (~5-10min) regardless of target branch. The `-Pfast-it` profile already exists for this purpose — this just stops running the heavy set on every push to `v2-develop`.

No coverage is removed — full suite still runs nightly, on PR-to-main, on push-to-main, and via dispatch.

## Test plan
- [ ] Fast lane runs on this PR (target `v2-develop`) — only the 5 fast jobs should appear.
- [ ] Manually trigger `ci-full.yml` via `workflow_dispatch` after merge to confirm slow lane boots Postgres-IT and smoke.
- [ ] Confirm next PR-to-main triggers slow lane.

## CI lane
- [x] Fast lane (targets `v2-develop`)
- [ ] Full lane (targets `main`)