### PR TITLE
chore: add PR template with review-remediation policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+-
+-
+
+## Story / linked issue
+Closes #
+
+## Test plan
+- [ ]
+- [ ]
+
+## Review remediation policy
+If adversarial review surfaces blocker findings, fix on this branch and force-push. Do not open a follow-up PR unless the remediation is genuinely orthogonal scope.
+
+- [ ] If review found blockers, remediation was force-pushed to this PR (not a separate PR)
+
+## CI lane
+- [ ] Fast lane (targets `v2-develop`)
+- [ ] Full lane (targets `main`)
+- [ ] `WKS_SKIP_CI_LOCAL=1` was used — disclosed below with evidence, awaiting ratify (per `feedback_ci_skip_bypass_requires_ratify`)
+
+<!-- Bypass evidence (if applicable): -->


### PR DESCRIPTION
## Summary
- New `.github/PULL_REQUEST_TEMPLATE.md` (22 lines).
- Codifies: if adversarial review finds blockers, force-push to the same PR — do not open a follow-up PR.
- CI-lane checkboxes (fast vs full) + `WKS_SKIP_CI_LOCAL` disclosure line per `feedback_ci_skip_bypass_requires_ratify`.

## Why
S10 shipped 6 PRs for 4 stories — 3 of 4 stories needed remediation, each as a separate follow-up PR (e.g. #432 fixing #429, #431 fixing #424). Each follow-up = full second CI cycle + second review pass. Halving that to one PR per story directly cuts sprint cycle time.

## Test plan
- [ ] After merge, open a test PR and confirm the template renders.
- [ ] Verify the remediation checkbox appears in the default PR body.

## Review remediation policy
- [x] If review found blockers, remediation was force-pushed to this PR (not a separate PR)

## CI lane
- [x] Fast lane (targets `v2-develop`)