### PR TITLE
fix(v2-develop): TaskController toDtos signature collision (PR #439 × #441)

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/TaskController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/TaskController.java
@@ -76,7 +76,12 @@ public class TaskController {
             .collect(Collectors.toUnmodifiableSet());
     CrossCaseTaskListResult result =
         taskService.listAcrossCases(permittedCaseTypeIds, CROSS_CASE_TASK_LIMIT);
-    List<TaskDto> items = TaskDtoMapper.toDtos(result.tasks(), taskService::readActionLabel);
+    // Cross-case task list (Story 13-1) does not yet surface the open-form affordance — the
+    // null formIdLookup yields formId=null per task, which the frontend renders as "no open-form
+    // button". Whether 13-1 adopts formId is a deferred UX decision; until then this path stays
+    // explicitly null rather than pretending no mapping exists.
+    List<TaskDto> items =
+        TaskDtoMapper.toDtos(result.tasks(), taskService::readActionLabel, (pdId, tdKey) -> null);
     return ApiResponse.success(new CrossCaseTaskListDto(items, result.truncated()));
   }
 

--- a/frontend/src/pages/TasksPage.test.tsx
+++ b/frontend/src/pages/TasksPage.test.tsx
@@ -24,6 +24,7 @@ function taskFixture(overrides: Partial<TaskDto>): TaskDto {
     assignee: null,
     archetype: 'draft_section',
     actionLabel: 'Draft application',
+    formId: null,
     createdAt: '2026-04-26T10:00:00Z',
     dueAt: null,
     ...overrides,


### PR DESCRIPTION
## Summary

- v2-develop tip ccb528606 does not compile: silent merge collision between PR #439 (Story 13-1) and PR #441 (Story 2-6-1).
- #441 evolved \`TaskDtoMapper.toDtos\` to a 3-arg signature \`(tasks, actionLabelLookup, formIdLookup)\` and updated \`CaseController.listTasks\` to pass the 3rd arg.
- #439 added \`TaskController.listAcrossCases\` with a 2-arg call (\`toDtos(tasks, actionLabelLookup)\`).
- Different files → git auto-merged cleanly → broken tip. #441's CI ran against pre-#439 base, masking it. GH Actions CI on v2-develop tip is currently failed.

This hotfix passes an explicit \`(pdId, tdKey) -> null\` formIdLookup from \`listAcrossCases\`. The cross-case task screen (13-1) has not yet been asked whether it wants the open-form affordance — leaving formId explicitly null here defers that UX decision rather than papering it over.

## Why null and not real lookup?

The per-case path (\`CaseController.listTasks\`) resolves formId from the case's pinned mapping. Cross-case lists span many cases with different mappings — surfacing formId would need a per-task mapping resolve, and 13-1 hasn't been asked whether the cross-case row needs the open-form button at all. If/when 13-1 adopts it, the scope decision lives in that story.

## Test plan

- [x] \`mvn -pl backend -Pfast-it verify\` → BUILD SUCCESS (151 tests, 0 failures, 1 skipped — same baseline as v2-develop pre-collision)
- [x] Spotless clean
- [ ] CI green on this branch
- [ ] Merge unblocks Story 9-2 dispatch

## Follow-ups (not in this PR)

- Decide whether cross-case task screen (Story 13-1 follow-up or new tiny story) wants formId surfacing
- Strengthen pre-merge integration check between independently-CI'd PRs that touch shared method signatures — exactly the kind of miss the 2026-05-13 CI split was predicted to surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)