### PR TITLE
fix(v2-develop): PUT /api/cases/{id} @Transactional — restores audit chain

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/CaseController.java
@@ -308,6 +308,13 @@ public class CaseController {
     return ApiResponse.success(dtos, meta);
   }
 
+  // @Transactional pins the request-scoped TX so EventPublisher.publishAfterCommit fired by
+  // CaseService.update (CaseDataEdited per Story 6.3 / 9-3) takes the synchronization branch
+  // instead of falling through to a no-TX publishEvent — the latter is silently dropped by
+  // EditAuditEmitter's @TransactionalEventListener(AFTER_COMMIT). Sibling mutating endpoints
+  // (create, transition, advance-stage, skip-stage) are already @Transactional for the same
+  // reason; PUT was missed when the pattern was introduced.
+  @Transactional
   @PutMapping("/{id}")
   public ApiResponse<CaseDto> update(
       @PathVariable("id") UUID id,

--- a/backend/src/test/java/com/wkspower/platform/integration/CaseUpdateAuditChainIT.java
+++ b/backend/src/test/java/com/wkspower/platform/integration/CaseUpdateAuditChainIT.java
@@ -1,0 +1,154 @@
+package com.wkspower.platform.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wkspower.platform.api.dto.request.LoginRequest;
+import com.wkspower.platform.audit.AuditEvent;
+import com.wkspower.platform.domain.config.model.CaseTypeConfig;
+import com.wkspower.platform.domain.config.model.FieldDefinition;
+import com.wkspower.platform.domain.config.model.FieldType;
+import com.wkspower.platform.domain.config.model.Permission;
+import com.wkspower.platform.domain.config.model.RoleDefinition;
+import com.wkspower.platform.domain.config.model.StatusColor;
+import com.wkspower.platform.domain.config.model.StatusDefinition;
+import com.wkspower.platform.domain.event.CaseDataEdited;
+import com.wkspower.platform.domain.model.AuditSource;
+import com.wkspower.platform.domain.model.User;
+import com.wkspower.platform.domain.port.UserRepository;
+import com.wkspower.platform.infrastructure.config.CaseTypeRegistry;
+import com.wkspower.platform.infrastructure.persistence.AuditEventRepository;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Regression guard for the {@code PUT /api/cases/{id}} audit-emission chain. Before the
+ * {@code @Transactional} fix, the live HTTP path had no transaction around {@code
+ * CaseService.update}; {@code EventPublisher.publishAfterCommit} fell through to a no-TX {@code
+ * publishEvent}, and {@code EditAuditEmitter}'s {@code @TransactionalEventListener(AFTER_COMMIT)}
+ * silently dropped the event. Result: {@code audit_events} stayed empty even though endpoints,
+ * mapper, and frontend tab shipped correctly (Sprint 12 demo blocker, surfaced 2026-05-13).
+ *
+ * <p>Full HTTP round-trip via {@link TestRestTemplate} — the same shape as the live demo path —
+ * because slice tests (@WebMvcTest) and direct-call unit tests both miss the missing-annotation
+ * class of bug. Asserts via {@link AuditEventRepository#findByCaseId} that the listener fired.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:caseupdateauditchain;DB_CLOSE_DELAY=-1",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "wks.case-types.dir=",
+      "wks.jwt.secret=dGVzdC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3RzLTEyMzQ="
+    })
+class CaseUpdateAuditChainIT {
+
+  private static final String EMAIL = "case-update-audit-it@wkspower.local";
+  private static final String PASSWORD = "admin";
+  private static final String CASE_TYPE_ID = "audit-chain-it";
+
+  @Autowired private TestRestTemplate rest;
+  @Autowired private UserRepository users;
+  @Autowired private PasswordEncoder encoder;
+  @Autowired private CaseTypeRegistry registry;
+  @Autowired private AuditEventRepository auditEventRepository;
+
+  private String cookie;
+  private UUID actorId;
+
+  @BeforeEach
+  void setup() {
+    if (users.findByEmail(EMAIL).isEmpty()) {
+      users.save(
+          new User(UUID.randomUUID(), EMAIL, Set.of("admin"), true), encoder.encode(PASSWORD));
+    }
+    actorId = users.findByEmail(EMAIL).orElseThrow().id();
+    registry.register(auditChainCaseType());
+    cookie = login(EMAIL);
+  }
+
+  @Test
+  void putUpdate_emitsAuditEvent_endToEnd() {
+    UUID caseId = createCase();
+
+    HttpHeaders headers = jsonHeaders(cookie);
+    String body = "{\"data\":{\"applicant\":\"edited\"},\"version\":0}";
+    ResponseEntity<String> put =
+        rest.exchange(
+            "/api/cases/" + caseId, HttpMethod.PUT, new HttpEntity<>(body, headers), String.class);
+    assertThat(put.getStatusCode()).as("PUT body=%s", put.getBody()).isEqualTo(HttpStatus.OK);
+
+    List<AuditEvent> rows = auditEventRepository.findByCaseId(caseId, 10);
+    assertThat(rows).as("audit_events populated by EditAuditEmitter").hasSize(1);
+    AuditEvent row = rows.get(0);
+    assertThat(row.eventType()).isEqualTo(AuditEvent.EVENT_TYPE_CASE_DATA_EDIT);
+    assertThat(row.result()).isEqualTo(CaseDataEdited.Result.APPLIED.name());
+    assertThat(row.fieldId()).isEqualTo("applicant");
+    assertThat(row.source()).isInstanceOf(AuditSource.User.class);
+    assertThat(((AuditSource.User) row.source()).actorId()).isEqualTo(actorId);
+  }
+
+  private UUID createCase() {
+    HttpHeaders headers = jsonHeaders(cookie);
+    String body = "{\"caseTypeId\":\"" + CASE_TYPE_ID + "\",\"data\":{\"applicant\":\"initial\"}}";
+    ResponseEntity<String> resp =
+        rest.exchange("/api/cases", HttpMethod.POST, new HttpEntity<>(body, headers), String.class);
+    assertThat(resp.getStatusCode())
+        .as("POST /api/cases body=%s", resp.getBody())
+        .isEqualTo(HttpStatus.CREATED);
+    // Parse the id from `{"data":{"id":"<uuid>",...}}` — minimal extraction to avoid pulling in a
+    // JSON dep just for one field.
+    String b = resp.getBody();
+    int idx = b.indexOf("\"id\":\"");
+    String id = b.substring(idx + 6, idx + 6 + 36);
+    return UUID.fromString(id);
+  }
+
+  private String login(String email) {
+    ResponseEntity<String> resp =
+        rest.postForEntity("/api/auth/login", new LoginRequest(email, PASSWORD), String.class);
+    assertThat(resp.getStatusCode()).as("login for %s", email).isEqualTo(HttpStatus.OK);
+    String setCookie = resp.getHeaders().getFirst(HttpHeaders.SET_COOKIE);
+    int semi = setCookie.indexOf(';');
+    return semi > 0 ? setCookie.substring(0, semi) : setCookie;
+  }
+
+  private static HttpHeaders jsonHeaders(String cookie) {
+    HttpHeaders h = new HttpHeaders();
+    h.add(HttpHeaders.COOKIE, cookie);
+    h.add(HttpHeaders.CONTENT_TYPE, "application/json");
+    return h;
+  }
+
+  private static CaseTypeConfig auditChainCaseType() {
+    return new CaseTypeConfig(
+        CASE_TYPE_ID,
+        "Audit Chain IT",
+        1,
+        null,
+        null, // zero-process — no BPMN attachment required
+        List.of(
+            new FieldDefinition(
+                "applicant", "Applicant", FieldType.TEXT, true, 0, List.of(), null)),
+        List.of(new StatusDefinition("open", "Open", StatusColor.ZINC)),
+        List.of("applicant"),
+        List.of(
+            new RoleDefinition(
+                "admin", List.of(Permission.VIEW, Permission.CREATE, Permission.EDIT))),
+        List.of(),
+        List.of());
+  }
+}


### PR DESCRIPTION
## Summary

Sprint 12 demo smoke (2026-05-13) found \`audit_events\` stays empty after PUT edits even though Stories 9-3 (writer/table) and 9-2 (read endpoint + ActivityTab) shipped correctly. Root cause: \`CaseController.update\` was missing \`@Transactional\`, while sibling mutating endpoints (\`create\`, \`transition\`, \`advance-stage\`, \`skip-stage\`) have it.

Without an outer TX:
1. \`caseRepository.save\` runs in its own short TX, commits, ends
2. \`eventPublisher.publishAfterCommit(CaseDataEdited)\` then sees \`isSynchronizationActive() == false\` → falls through to direct \`publishEvent\` (no synchronization registered)
3. \`EditAuditEmitter\` listens with \`@TransactionalEventListener(phase = AFTER_COMMIT)\` and no \`fallbackExecution\` → Spring silently drops events published outside an active TX

Net: every direct edit since 6-3 / 9-3 shipped has been silently missing from the audit channel. The slf4j wire-contract line \`event=case.data.edit\` also never fired in this path.

## Fix

One annotation: \`@Transactional\` on \`CaseController.update\` (\`CaseController.java:311\`).

## Test plan

- [x] New \`CaseUpdateAuditChainIT\` — full HTTP round-trip via \`TestRestTemplate\` (login → create case → PUT edit → assert \`auditEventRepository.findByCaseId\` has the row with \`source = User(actorId)\`, \`result = APPLIED\`, \`fieldId = applicant\`)
- [x] **Regression guard verified locally**: IT FAILS without the \`@Transactional\` (audit row missing); PASSES with it
- [x] \`mvn -pl backend -Pfast-it verify\` — BUILD SUCCESS (full backend suite green, spotless clean)
- [ ] CI green on this branch

## Why CI didn't catch it earlier

- \`EditAuditEmitterTest\` calls \`emitter.onCaseDataEdited(event)\` directly — bypasses the publisher chain
- \`EditAuditPersistenceIT\` calls \`auditEventRepository.insert(...)\` directly — bypasses publisher AND listener
- \`CaseControllerTest\` is a \`@WebMvcTest\` slice that mocks the service — no real Spring TX semantics
- No prior IT drove \`CaseService.update\` through the HTTP boundary. This PR adds the missing one.

## Sprint 12 impact

Closes the Sprint 12 demo-AC gap "view audit in-app" for direct-edit cases. Once merged, the 30-second demo recording can land on a green tip; ActivityTab will show real edit lines.

## Follow-ups (not in this PR)

- Audit other \`publishAfterCommit\` callsites in \`CaseService\` (form submission, stage transitions, execution signals) for the same listener-phase mismatch. Likely Sprint 13 spike.
- Consider whether \`SpringEventPublisher.publishAfterCommit\` should refuse to publish outside an active TX (loud failure) rather than silently falling through to \`publishEvent\` — architecture call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)