### PR TITLE
ci: add ci-full workflow (workflow_dispatch only) to main

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,0 +1,240 @@
+# CI — SLOW LANE (on-demand)
+#
+# Runs the full correctness suite that ci.yml (fast lane) skips:
+#   - Backend `mvn verify` WITHOUT -Pfast-it (full *PostgresIT.java sweep).
+#   - production-profile-smoke (Docker + Postgres + MinIO; Story 14.1 AC6 +
+#     Story 14.7 §8 H2-driver regression guard).
+#
+# Triggers: manual workflow_dispatch only. Auto-triggers (nightly cron, PR-to-main,
+# push-to-main) are disabled while `main` still holds the v1 tree — the v2 paths
+# this workflow targets (`backend/mvnw`, `-Pfast-it`, `docker/docker-compose.prod.yml`)
+# do not exist there. Re-enable on v2 merge-back.
+name: CI (full)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-full-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  backend-full:
+    name: Backend full (Temurin 21, all ITs incl. PostgresIT)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build + verify (full — unit + ArchUnit + all ITs)
+        run: ./mvnw -B -ntp verify
+
+  production-profile-smoke:
+    # Story 14.1 AC6 — boot the production stack against real Postgres + MinIO
+    # via `docker compose -f docker/docker-compose.prod.yml up`, poll /api/health,
+    # and assert ZERO H2-driver loading in the container logs (the regression
+    # guard for Story 14.7 §8 / WKS-API-053). Re-uses Story 14.7's runtime
+    # tenant-id probe. Local replication required per "Match CI Locally" memory
+    # before PR.
+    name: Production profile smoke (Story 14.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build production image (load into local daemon)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          load: true
+          tags: wkspower/wks-platform:2.0.0-prod
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Write fixture .env (synthetic secrets — CI only)
+        # JWT secret is a CI-only deterministic Base64 string (≥32 bytes after
+        # decoding) that satisfies JwtTokenProvider's WKS-API-053 production
+        # validation without exposing a real key. Operators MUST generate their
+        # own with `openssl rand -base64 48`.
+        #
+        # Story 14.1.1 AC7: every required env var is set to a real (non-sentinel)
+        # value so the new ProductionBootstrapValidator's WKS-API-055 secret-rotation
+        # check passes. NO value below may equal `<MUST-BE-ROTATED>` — that is the
+        # exact literal the validator rejects.
+        #
+        # Story 14.1.1 fix-up: docker/.env is no longer tracked. Compose still
+        # interpolates `${...}` from this file when found alongside the compose
+        # YAML; we keep writing it here as the CI fixture mechanism. No
+        # COMPOSE_PROFILES is needed — the file-split makes profiles obsolete.
+        run: |
+          JWT_FIXTURE=$(printf 'wks-ci-fixture-jwt-secret-bytes-padding-padding-padding' | base64)
+          cat > docker/.env <<EOF
+          WKS_DB_URL=jdbc:postgresql://postgres:5432/wks
+          WKS_DB_USER=wks
+          WKS_DB_PASSWORD=ci-fixture-db-password
+          WKS_STORAGE_ENDPOINT=http://minio:9000
+          WKS_STORAGE_KEY=ci-fixture-storage-key
+          WKS_ADMIN_EMAIL=admin@ci.invalid
+          WKS_ADMIN_PASSWORD=ci-fixture-admin-password
+          WKS_LOCALE=en-IN
+          WKS_CORS_ORIGINS=http://localhost:8080
+          WKS_JWT_SECRET=${JWT_FIXTURE}
+          WKS_OPENAPI_ENABLED=false
+          WKS_MINIO_ROOT_USER=ci-fixture-minio-user
+          WKS_MINIO_ROOT_PASSWORD=ci-fixture-minio-password
+          WKS_HOST_PORT=8080
+          EOF
+
+      - name: Bring up production stack
+        # Story 14.1.1 fix-up: the dev/prod stacks now live in separate compose
+        # files. `-f docker/docker-compose.prod.yml` selects the production stack
+        # directly — no profiles, no explicit service list needed. Port-8080
+        # collision is structurally impossible because the dev wks-platform
+        # service is no longer in this file.
+        run: docker compose -f docker/docker-compose.prod.yml up -d
+
+      - name: Poll /api/health (90s deadline)
+        run: |
+          deadline=$((SECONDS + 90))
+          healthy=0
+          while [[ $SECONDS -lt $deadline ]]; do
+            if curl -fsS http://localhost:8080/api/health >/dev/null 2>&1; then
+              healthy=1
+              break
+            fi
+            sleep 3
+          done
+          if [[ $healthy -ne 1 ]]; then
+            echo "::error::/api/health did not become healthy within 90s"
+            docker compose -f docker/docker-compose.prod.yml logs
+            exit 1
+          fi
+          echo "Health OK (liveness — see schema-readiness assertions below for readiness)"
+
+      - name: Assert ZERO H2 driver in container logs (regression guard)
+        # Story 14.7 §8 / WKS-API-053 — `Driver org.h2.Driver claims to not accept
+        # jdbcUrl, jdbc:postgresql://...`. THIS is the assertion that catches it.
+        run: |
+          logs=$(docker logs wks-platform-prod 2>&1)
+          if printf '%s' "$logs" | grep -E 'org\.h2\.Driver|jdbc:h2:'; then
+            echo "::error::H2 driver loaded under production profile (regression — Story 14.7 §8)"
+            exit 1
+          fi
+          echo "H2-driver invariant OK: no org.h2.Driver / jdbc:h2: references in production logs"
+
+      - name: Assert schema readiness (Story 14.1.1 AC6)
+        # Liveness (curl /api/health) ≠ readiness. Three positive structural
+        # assertions covering finding I19:
+        #   (a) Flyway applied N>=8 migrations (parsed from container logs).
+        #   (b) ProductionBootstrapValidator emitted RUNTIME INVARIANT OK
+        #       (proves WKS-API-053 datasource + WKS-API-055 secret checks both
+        #       passed during boot).
+        #   (c) The `cases` table is queryable via psql exec (returns a
+        #       structurally-valid result, even with zero rows).
+        run: |
+          logs=$(docker logs wks-platform-prod 2>&1)
+
+          # (a) Flyway migrations applied. Spring Boot's Flyway integration logs
+          # `Successfully applied N migrations to schema` when at least one ran;
+          # idempotent boots with no pending migrations log `Schema "public" is
+          # up to date. No migration necessary.` Either is acceptable; a missing
+          # Flyway log line is the failure mode this guards against.
+          flyway_applied=$(printf '%s' "$logs" | grep -Eo 'Successfully applied [0-9]+ migrations?' | grep -Eo '[0-9]+' | tail -n1 || true)
+          flyway_uptodate=$(printf '%s' "$logs" | grep -E 'Schema .* is up to date|No migration necessary' || true)
+          if [[ -z "$flyway_applied" && -z "$flyway_uptodate" ]]; then
+            echo "::error::Flyway migration log line missing — schema readiness cannot be confirmed."
+            exit 1
+          fi
+          if [[ -n "$flyway_applied" ]]; then
+            echo "Flyway applied $flyway_applied migrations."
+            if (( flyway_applied < 8 )); then
+              echo "::error::Expected >=8 Flyway migrations on a fresh production boot, got $flyway_applied."
+              exit 1
+            fi
+          else
+            echo "Flyway: $flyway_uptodate (idempotent boot)."
+          fi
+
+          # (b) RUNTIME INVARIANT OK — ProductionBootstrapValidator success line.
+          if ! printf '%s' "$logs" | grep -qE 'RUNTIME INVARIANT OK'; then
+            echo "::error::ProductionBootstrapValidator did not emit RUNTIME INVARIANT OK — WKS-API-053 / WKS-API-055 may have failed silently."
+            echo "--- Container logs for diagnosis ---"
+            printf '%s\n' "$logs"
+            echo "--- End container logs ---"
+            exit 1
+          fi
+          echo "RUNTIME INVARIANT OK present in logs."
+
+          # (c) Schema-readiness query against the cases table — a structurally
+          # valid SELECT proves Flyway DDL ran AND the JDBC pool reaches Postgres.
+          if ! docker compose -f docker/docker-compose.prod.yml exec -T postgres \
+                 psql -U wks -d wks -tAc 'SELECT 1 FROM cases LIMIT 1' >/dev/null; then
+            echo "::error::SELECT 1 FROM cases LIMIT 1 failed — cases table absent or pool unreachable."
+            exit 1
+          fi
+          echo "Schema-readiness query OK (cases table queryable)."
+
+      - name: Run runtime ZERO-tenant_id invariant probe
+        # Re-uses Story 14.7's already-shipped probe. AC6.6 + AC8 — extends the
+        # runtime check to the production-profile container without re-implementation.
+        run: ./deploy/probes/check-runtime-no-tenant-id.sh http://localhost:8080
+
+      - name: Tear down (purge volumes)
+        if: always()
+        run: docker compose -f docker/docker-compose.prod.yml down -v
+
+  publish-image:
+    # Manual-dispatch only. Runs after the correctness suites pass in the
+    # same workflow run. Push triggers do not publish.
+    name: Publish image to GHCR
+    needs: [backend-full, production-profile-smoke]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/wkspower/wks-platform:latest
+            ghcr.io/wkspower/wks-platform:2.0.0-prod
+            ghcr.io/wkspower/wks-platform:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/wkspower/wks-platform
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.title=WKS Platform
+            org.opencontainers.image.description=Open-source case management for system integrators
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci-full.yml` to `main` so it surfaces in the GitHub Actions sidebar.
- Workflow is **manual-only** (`workflow_dispatch`); the nightly cron, push-to-main, and PR-to-main triggers from the v2-develop copy are stripped.

## Why workflow_dispatch only
`main` still holds the v1 tree. The jobs in this workflow reference v2 paths that do not exist on v1 (`backend/mvnw`, `-Pfast-it` Maven profile, `docker/docker-compose.prod.yml`, `deploy/probes/check-runtime-no-tenant-id.sh`). Auto-triggers would fail on every fire. Re-enable as part of the v2 merge-back.

## Test plan
- [ ] After merge, "CI (full)" appears in https://github.com/wkspower/wks-platform/actions sidebar.
- [ ] No automatic runs are triggered by this merge or the next push to main.
- [ ] `workflow_dispatch` button is visible on the workflow page (will fail if dispatched against v1 main — expected; intended use is from v2-develop after re-enabling triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)