### PR TITLE
ci(full): build multi-arch image (linux/amd64 + linux/arm64)

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -211,6 +211,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
@@ -226,6 +228,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/wkspower/wks-platform:latest
             ghcr.io/wkspower/wks-platform:2.0.0-prod


### PR DESCRIPTION
## Summary
Cherry-picks the multi-arch publish fix from v2-develop (`2d2193fcf`) onto `develop` so the workflow file stays in sync across the default branch.

Adds `docker/setup-qemu-action` and `platforms: linux/amd64,linux/arm64` to the `Publish image to GHCR` step. Fixes `no matching manifest for linux/arm64/v8` on Apple Silicon when pulling `ghcr.io/wkspower/wks-platform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)