### PR TITLE
fix(case-portal): show ad-hoc task details and add completion notes

### DIFF
--- a/apps/java/libraries/bpm-engine-interface/src/main/java/com/wks/bpm/engine/model/spi/Task.java
+++ b/apps/java/libraries/bpm-engine-interface/src/main/java/com/wks/bpm/engine/model/spi/Task.java
@@ -42,4 +42,6 @@ public class Task {
 	protected String due;
 	protected String followUp;
 
+	protected String completionNotes;
+
 }

--- a/apps/react/case-portal/src/views/taskForm/adHocTaskForm.js
+++ b/apps/react/case-portal/src/views/taskForm/adHocTaskForm.js
@@ -1,0 +1,164 @@
+import CloseIcon from '@mui/icons-material/Close'
+import {
+  AppBar,
+  Box,
+  Button,
+  Dialog,
+  IconButton,
+  Slide,
+  Stack,
+  TextField,
+  Toolbar,
+  Typography,
+} from '@mui/material'
+import MainCard from 'components/MainCard'
+import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { TaskService } from 'services'
+import { useSession } from '../../SessionStoreContext'
+
+const Transition = React.forwardRef(function Transition(props, ref) {
+  return <Slide direction='up' ref={ref} {...props} />
+})
+
+export const AdHocTaskForm = ({ open, handleClose, task }) => {
+  const [claimed, setClaimed] = useState(false)
+  const [assignee, setAssignee] = useState(null)
+  const [completionNotes, setCompletionNotes] = useState('')
+  const { t } = useTranslation()
+  const keycloak = useSession()
+
+  useEffect(() => {
+    setClaimed(task?.assignee != null)
+    setAssignee(task?.assignee ?? null)
+    setCompletionNotes('')
+  }, [open, task])
+
+  const handleClaim = () => {
+    TaskService.claim(keycloak, task.id)
+      .then(() => {
+        setClaimed(true)
+        setAssignee(keycloak.idTokenParsed.given_name)
+      })
+      .catch((err) => console.log(err.message))
+  }
+
+  const handleUnclaim = () => {
+    TaskService.unclaim(keycloak, task.id)
+      .then(() => {
+        setClaimed(false)
+        setAssignee(null)
+      })
+      .catch((err) => console.log(err.message))
+  }
+
+  const handleComplete = () => {
+    const variables = completionNotes
+      ? [
+          {
+            name: 'completionNotes',
+            value: completionNotes,
+            type: 'String',
+          },
+        ]
+      : []
+
+    TaskService.complete(keycloak, task.id, variables)
+      .then(() => handleClose())
+      .catch((err) => console.log(err.message))
+  }
+
+  return (
+    <Dialog
+      fullScreen
+      open={open}
+      onClose={handleClose}
+      TransitionComponent={Transition}
+    >
+      <AppBar sx={{ position: 'relative' }}>
+        <Toolbar>
+          <IconButton
+            edge='start'
+            color='inherit'
+            onClick={handleClose}
+            aria-label='close'
+          >
+            <CloseIcon />
+          </IconButton>
+          <Typography sx={{ ml: 2, flex: 1 }} component='div'>
+            <div>{task?.name}</div>
+            <div style={{ fontSize: '13px' }}>{task?.caseInstanceId}</div>
+            <div style={{ fontSize: '10px' }}>{task?.id}</div>
+          </Typography>
+          {!claimed ? (
+            <Button color='inherit' onClick={handleClaim}>
+              {t('pages.taskform.claim')}
+            </Button>
+          ) : (
+            <Button color='inherit' onClick={handleUnclaim}>
+              <div>
+                {assignee} <sup style={{ fontSize: '10px' }}>x</sup>
+              </div>
+            </Button>
+          )}
+          {claimed && (
+            <Button color='inherit' onClick={handleComplete}>
+              {t('pages.taskform.complete')}
+            </Button>
+          )}
+        </Toolbar>
+      </AppBar>
+
+      <Box sx={{ p: 2 }}>
+        <MainCard>
+          <Stack spacing={2}>
+            <Stack direction='row' spacing={4}>
+              <Box>
+                <Typography variant='caption' color='text.secondary'>
+                  {t('pages.tasklist.datagrid.columns.due')}
+                </Typography>
+                <Typography>{task?.due || '—'}</Typography>
+              </Box>
+              <Box>
+                <Typography variant='caption' color='text.secondary'>
+                  {t('pages.tasklist.datagrid.columns.assignee')}
+                </Typography>
+                <Typography>{assignee || '—'}</Typography>
+              </Box>
+              <Box>
+                <Typography variant='caption' color='text.secondary'>
+                  {t('pages.tasklist.datagrid.columns.created')}
+                </Typography>
+                <Typography>{task?.created || '—'}</Typography>
+              </Box>
+            </Stack>
+
+            <Box>
+              <Typography variant='caption' color='text.secondary'>
+                {t('pages.tasklist.newTask.description')}
+              </Typography>
+              <Typography sx={{ whiteSpace: 'pre-wrap' }}>
+                {task?.description || '—'}
+              </Typography>
+            </Box>
+
+            <TextField
+              label='Completion notes'
+              multiline
+              minRows={4}
+              fullWidth
+              value={completionNotes}
+              onChange={(e) => setCompletionNotes(e.target.value)}
+              disabled={!claimed}
+              helperText={
+                claimed
+                  ? 'Optional. Saved with the task on completion.'
+                  : 'Claim the task to add notes and complete it.'
+              }
+            />
+          </Stack>
+        </MainCard>
+      </Box>
+    </Dialog>
+  )
+}

--- a/apps/react/case-portal/src/views/taskForm/taskForm.js
+++ b/apps/react/case-portal/src/views/taskForm/taskForm.js
@@ -33,9 +33,15 @@ export const TaskForm = ({ open, handleClose, task }) => {
     let apiDataVariables = {}
     let apiDataFormComponents = {}
 
-    FormService.getByKey(keycloak, task.formKey)
-      .then((data) => {
-        apiDataFormComponents = data.structure
+    const formPromise = task.formKey
+      ? FormService.getByKey(keycloak, task.formKey).then(
+          (data) => data.structure,
+        )
+      : Promise.resolve(null)
+
+    formPromise
+      .then((structure) => {
+        apiDataFormComponents = structure
 
         apiDataVariables = {
           data: {},

--- a/apps/react/case-portal/src/views/taskList/taskList.js
+++ b/apps/react/case-portal/src/views/taskList/taskList.js
@@ -231,11 +231,7 @@ export const TaskList = ({ businessKey, callback }) => {
         />
       )}
       {open && task && !task.processInstanceId && (
-        <AdHocTaskForm
-          task={task}
-          handleClose={handleClose}
-          open={open}
-        />
+        <AdHocTaskForm task={task} handleClose={handleClose} open={open} />
       )}
     </React.Fragment>
   )

--- a/apps/react/case-portal/src/views/taskList/taskList.js
+++ b/apps/react/case-portal/src/views/taskList/taskList.js
@@ -17,6 +17,7 @@ import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TaskService } from 'services'
 import { useSession } from '../../SessionStoreContext'
+import { AdHocTaskForm } from '../taskForm/adHocTaskForm'
 import { TaskForm } from '../taskForm/taskForm'
 import './taskList.css'
 
@@ -221,12 +222,19 @@ export const TaskList = ({ businessKey, callback }) => {
         </React.Fragment>
       )}
 
-      {open && task && (
+      {open && task && task.processInstanceId && (
         <TaskForm
           task={task}
           handleClose={handleClose}
           open={open}
           keycloak={keycloak}
+        />
+      )}
+      {open && task && !task.processInstanceId && (
+        <AdHocTaskForm
+          task={task}
+          handleClose={handleClose}
+          open={open}
         />
       )}
     </React.Fragment>


### PR DESCRIPTION
## Summary

- Ad-hoc / manual tasks opened from a case no longer reuse the BPMN `TaskForm`. A dedicated `AdHocTaskForm` dialog renders the task name, description, due date, assignee and created date — fields that were previously not shown at all.
- Adds a **Completion notes** textarea, gated on claim. The value is sent as a `completionNotes` String variable on complete and persisted as a task-local variable in Camunda history.
- Resolves three regressions previously visible when opening an ad-hoc task:
  - `GET /form/undefined` (FormService called with `task.formKey`)
  - `bpmn-js` "missing start tag" while parsing `/process-definition/undefined/xml`
  - Description / due / assignee blank in the dialog
- Backend: adds `completionNotes` to `com.wks.bpm.engine.model.spi.Task` so the contract is explicit and history can be surfaced later.

## Reported by

Essway (Akshay Patil) — point 4 of the deviation document: "the task body/description field is not visible when opening the task."

## Test plan

- [ ] Open a case, create a new (ad-hoc) task with name + description + assignee.
- [ ] Click the play icon — the new ad-hoc dialog opens with name, description, due, assignee, created visible.
- [ ] Claim → Completion notes field becomes editable.
- [ ] Add notes → Complete → task disappears from the list; notes are present in Camunda task history as a `completionNotes` variable.
- [ ] Regression: open a regular BPMN user task — `TaskForm` still renders, form + diagram intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)