### PR TITLE
feat(editor): trim Monaco bundle + schema-aware YAML IntelliSense

### DIFF
--- a/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
+++ b/backend/src/main/java/com/wkspower/platform/api/controller/AdminController.java
@@ -300,6 +300,25 @@ public class AdminController {
         .body(record.rawYaml());
   }
 
+  /**
+   * Returns the Draft 2020-12 meta-schema describing the case-type YAML grammar — i.e. what fields
+   * may appear in a case-type file. Static resource served as {@code application/schema+json}.
+   * Powers Monaco YAML IntelliSense in the in-UI editor.
+   */
+  @GetMapping(path = "/case-types/meta-schema", produces = "application/schema+json")
+  @PreAuthorize("hasRole('ADMIN')")
+  @Operation(
+      summary = "JSON Schema describing the case-type YAML grammar (for editor IntelliSense)")
+  public ResponseEntity<byte[]> caseTypeMetaSchema() throws java.io.IOException {
+    try (var in =
+        new org.springframework.core.io.ClassPathResource("schema/case-type.meta-schema.json")
+            .getInputStream()) {
+      return ResponseEntity.ok()
+          .header(HttpHeaders.CACHE_CONTROL, "public, max-age=300")
+          .body(in.readAllBytes());
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Story 3.9 — Rebase endpoints
   // -------------------------------------------------------------------------

--- a/backend/src/main/resources/schema/case-type.meta-schema.json
+++ b/backend/src/main/resources/schema/case-type.meta-schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wks-platform.dev/schema/case-type.meta-schema.json",
+  "title": "WKS Case-Type Configuration",
+  "description": "Meta-schema for a case-type YAML — what may appear in the file edited by the in-UI Case-Type Editor. Drives Monaco YAML IntelliSense (autocomplete, hover, validation).",
+  "type": "object",
+  "required": ["id", "displayName", "fields"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Stable kebab-case identifier. Must be unique across the deployment."
+    },
+    "displayName": {
+      "type": "string",
+      "description": "Human-readable name shown in the case list and headers."
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Author-supplied version. The registry assigns the authoritative version on deploy and overrides this."
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional free-text description shown in admin tooling."
+    },
+    "defaultFieldEditability": {
+      "type": "string",
+      "enum": ["editableByDefault", "lockedByDefault"],
+      "description": "Top-level policy for fields that omit `editableBy`. `editableByDefault` (default) leaves them unrestricted; `lockedByDefault` makes them read-only unless `editableBy` is declared."
+    },
+    "workflow": {
+      "type": "object",
+      "description": "Optional BPMN attachment. When omitted, the case type advances stages manually with no engine involvement.",
+      "additionalProperties": false,
+      "required": ["bpmn"],
+      "properties": {
+        "bpmn": {
+          "type": "string",
+          "description": "Path to the BPMN file, relative to this YAML's parent directory."
+        },
+        "processKey": {
+          "type": "string",
+          "description": "Optional BPMN process key. When omitted the deployer infers it from the BPMN."
+        }
+      }
+    },
+    "roles": {
+      "type": "array",
+      "description": "Roles declared for this case type. Each role enumerates the verbs it can perform.",
+      "items": {
+        "type": "object",
+        "required": ["name", "permissions"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Role identifier (referenced by `editableBy: [role:<name>]`)."
+          },
+          "permissions": {
+            "type": "array",
+            "description": "Allowed verbs for this role.",
+            "items": {
+              "type": "string",
+              "enum": ["view", "create", "edit", "transition", "delete", "comment"]
+            }
+          }
+        }
+      }
+    },
+    "fields": {
+      "type": "array",
+      "description": "Field definitions for the case `data` payload.",
+      "items": { "$ref": "#/$defs/field" }
+    },
+    "statuses": {
+      "type": "array",
+      "description": "Status definitions. When omitted the validator injects [open, closed].",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "description": "Status identifier." },
+          "displayName": { "type": "string" },
+          "color": {
+            "type": "string",
+            "enum": ["gray", "blue", "green", "yellow", "orange", "red", "purple"]
+          },
+          "initial": { "type": "boolean", "description": "True for the starting status." },
+          "terminal": { "type": "boolean", "description": "True for terminal statuses." }
+        }
+      }
+    },
+    "listColumns": {
+      "type": "array",
+      "description": "Field ids surfaced as columns in the case list view.",
+      "items": { "type": "string" }
+    },
+    "stages": {
+      "type": "array",
+      "description": "Stage definitions. Optional — stage-less case types omit this entirely.",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "displayName": { "type": "string" },
+          "initialStatus": { "type": "string", "description": "Optional initial status when entering this stage." },
+          "statuses": {
+            "type": "array",
+            "description": "Stage-scoped status list. Falls back to the top-level statuses when omitted.",
+            "items": { "$ref": "#/properties/statuses/items" }
+          }
+        }
+      }
+    },
+    "forms": {
+      "type": "array",
+      "description": "Form definitions for submit / draft surfaces.",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string" },
+          "displayName": { "type": "string" },
+          "stage": { "type": "string", "description": "Stage id this form is scoped to." },
+          "sections": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string" },
+                "title": { "type": "string" },
+                "fields": {
+                  "type": "array",
+                  "items": { "type": "string", "description": "Field id." }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "field": {
+      "type": "object",
+      "required": ["id", "displayName", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Field identifier — snake_case."
+        },
+        "displayName": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": ["text", "textarea", "email", "number", "date", "select", "checkbox", "file"],
+          "description": "Field kind. Drives the rendered control and the per-case JSON Schema."
+        },
+        "required": { "type": "boolean", "description": "Required on form submit." },
+        "requiredOnCreate": { "type": "boolean", "description": "Required when the create-case dialog asks for it. Defaults to `required`." },
+        "order": { "type": "integer", "minimum": 0, "description": "Sort order on the form." },
+        "minLength": { "type": "integer", "minimum": 0, "description": "text / textarea / email only." },
+        "maxLength": { "type": "integer", "minimum": 1, "description": "text / textarea / email only." },
+        "min": { "type": "number", "description": "number only." },
+        "max": { "type": "number", "description": "number only." },
+        "options": {
+          "type": "array",
+          "description": "select only.",
+          "items": {
+            "type": "object",
+            "required": ["value"],
+            "additionalProperties": false,
+            "properties": {
+              "value": { "type": "string" },
+              "label": { "type": "string" }
+            }
+          }
+        },
+        "editableBy": {
+          "type": "array",
+          "description": "Role allow-list for write authorization. Entries shaped `role:<roleId>`.",
+          "items": { "type": "string", "pattern": "^role:[a-z][a-z0-9_-]*$" }
+        }
+      }
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "cmdk": "^1.0.4",
         "lucide-react": "^0.468.0",
         "monaco-editor": "^0.55.1",
+        "monaco-yaml": "^5.5.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.74.0",
@@ -3668,6 +3669,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5311,6 +5318,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5807,6 +5820,79 @@
         "marked": "14.0.0"
       }
     },
+    "node_modules/monaco-languageserver-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.4.0.tgz",
+      "integrity": "sha512-QQ3BZiU5LYkJElGncSNb5AKoJ/LCs6YBMCJMAz9EA7v+JaOdn3kx2cXpPTcZfKA5AEsR0vc97sAw+5mdNhVBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0",
+        "vscode-languageserver-protocol": "^3.0.0",
+        "vscode-uri": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-marker-data-provider": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/monaco-marker-data-provider/-/monaco-marker-data-provider-1.2.5.tgz",
+      "integrity": "sha512-5ZdcYukhPwgYMCvlZ9H5uWs5jc23BQ8fFF5AhSIdrz5mvYLsqGZ58ZLxTv8rCX6+AxdJ8+vxg1HVSk+F2bLosg==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-types": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/monaco-types/-/monaco-types-0.1.2.tgz",
+      "integrity": "sha512-8LwfrlWXsedHwAL41xhXyqzPibS8IqPuIXr9NdORhonS495c2/wky+sI1PRLvMCuiI0nqC2NH1six9hdiRY4Xg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-worker-manager": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/monaco-worker-manager/-/monaco-worker-manager-2.0.1.tgz",
+      "integrity": "sha512-kdPL0yvg5qjhKPNVjJoym331PY/5JC11aPJXtCZNwWRvBr6jhkIamvYAyiY5P1AWFmNOy0aRDRoMdZfa71h8kg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.30.0"
+      }
+    },
+    "node_modules/monaco-yaml": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-5.5.0.tgz",
+      "integrity": "sha512-FEJezTYwzL3VFCWnA98mPp0AmPERoiQNN54ycllF0LorUeTXPN2YzJzu9jfzwVn2CxX1qajEornAr4CrZffuMQ==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "jsonc-parser": "^3.0.0",
+        "monaco-languageserver-types": "^0.4.0",
+        "monaco-marker-data-provider": "^1.0.0",
+        "monaco-types": "^0.1.0",
+        "monaco-worker-manager": "^2.0.0",
+        "path-browserify": "^1.0.0",
+        "prettier": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.0",
+        "vscode-languageserver-types": "^3.0.0",
+        "vscode-uri": "^3.0.0",
+        "yaml": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">=0.36"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5937,6 +6023,12 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6061,7 +6153,6 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -8133,6 +8224,43 @@
         }
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -8367,6 +8495,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "cmdk": "^1.0.4",
     "lucide-react": "^0.468.0",
     "monaco-editor": "^0.55.1",
+    "monaco-yaml": "^5.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.74.0",

--- a/frontend/src/api/caseTypes.ts
+++ b/frontend/src/api/caseTypes.ts
@@ -22,6 +22,16 @@ export async function getCaseTypeSource(id: string): Promise<string> {
   return apiFetchText(`/api/admin/case-types/${encodeURIComponent(id)}/source`);
 }
 
+/**
+ * `GET /api/admin/case-types/meta-schema` — Draft 2020-12 JSON Schema describing the case-type
+ * YAML grammar (what fields may appear in the file). Distinct from the per-case data schema in
+ * `JsonSchemaGenerator`. ADMIN-only. Powers Monaco YAML IntelliSense in the editor.
+ */
+export async function getCaseTypeMetaSchema(): Promise<unknown> {
+  const text = await apiFetchText('/api/admin/case-types/meta-schema');
+  return JSON.parse(text);
+}
+
 export interface DeployResponse {
   caseTypeId: string;
   version: number;

--- a/frontend/src/pages/CaseTypeEditorPage.tsx
+++ b/frontend/src/pages/CaseTypeEditorPage.tsx
@@ -24,7 +24,16 @@ if (typeof self !== 'undefined') {
 loader.config({ monaco });
 
 const META_SCHEMA_URI = 'wks://schema/case-type.meta-schema.json';
-let metaSchemaConfigured = false;
+
+// Register the YAML language and attach monaco-yaml's providers at module load.
+// Schema is plugged in once fetched (see effect). Registering up-front guarantees that
+// when <Editor language="yaml"> mounts, the language id is known and completion providers
+// are already attached — no race between Editor.create and configureMonacoYaml.
+const monacoYaml =
+  typeof window === 'undefined'
+    ? null
+    : configureMonacoYaml(monaco, { validate: true, hover: true, completion: true, schemas: [] });
+let metaSchemaLoaded = false;
 
 interface ValidationError {
   code: string;
@@ -48,18 +57,26 @@ export function CaseTypeEditorPage() {
     setLoading(true);
     Promise.all([
       getCaseTypeSource(caseTypeId),
-      metaSchemaConfigured ? Promise.resolve(null) : getCaseTypeMetaSchema().catch(() => null),
+      metaSchemaLoaded
+        ? Promise.resolve(null)
+        : getCaseTypeMetaSchema().catch((err: unknown) => {
+            // Don't block YAML load on schema failure — log loudly so missing autocomplete
+            // is debuggable from devtools instead of silently degrading.
+            // eslint-disable-next-line no-console
+            console.error('[CaseTypeEditor] meta-schema fetch failed; autocomplete disabled', err);
+            return null;
+          }),
     ])
       .then(([source, schema]) => {
         if (cancelled) return;
-        if (!metaSchemaConfigured && schema) {
-          configureMonacoYaml(monaco, {
+        if (!metaSchemaLoaded && schema && monacoYaml) {
+          monacoYaml.update({
             validate: true,
             hover: true,
             completion: true,
             schemas: [{ uri: META_SCHEMA_URI, fileMatch: ['*'], schema: schema as object }],
           });
-          metaSchemaConfigured = true;
+          metaSchemaLoaded = true;
         }
         setYaml(source);
         setDirty(false);

--- a/frontend/src/pages/CaseTypeEditorPage.tsx
+++ b/frontend/src/pages/CaseTypeEditorPage.tsx
@@ -1,24 +1,30 @@
 import Editor, { loader } from '@monaco-editor/react';
-import * as monaco from 'monaco-editor';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import { configureMonacoYaml } from 'monaco-yaml';
+import yamlWorker from 'monaco-yaml/yaml.worker?worker';
 import { ArrowLeft, Loader2, Save } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { ApiError } from '@/api/client';
-import { deployCaseType, getCaseTypeSource } from '@/api/caseTypes';
+import { deployCaseType, getCaseTypeMetaSchema, getCaseTypeSource } from '@/api/caseTypes';
 import { Button } from '@/components/ui/Button';
 import { Spinner } from '@/components/ui/Spinner';
 import { toast } from '@/components/ui/Toaster';
 
 if (typeof self !== 'undefined') {
   self.MonacoEnvironment = {
-    getWorker() {
+    getWorker(_, label) {
+      if (label === 'yaml') return new yamlWorker();
       return new editorWorker();
     },
   };
 }
 loader.config({ monaco });
+
+const META_SCHEMA_URI = 'wks://schema/case-type.meta-schema.json';
+let metaSchemaConfigured = false;
 
 interface ValidationError {
   code: string;
@@ -40,9 +46,21 @@ export function CaseTypeEditorPage() {
     if (!caseTypeId) return;
     let cancelled = false;
     setLoading(true);
-    getCaseTypeSource(caseTypeId)
-      .then((source) => {
+    Promise.all([
+      getCaseTypeSource(caseTypeId),
+      metaSchemaConfigured ? Promise.resolve(null) : getCaseTypeMetaSchema().catch(() => null),
+    ])
+      .then(([source, schema]) => {
         if (cancelled) return;
+        if (!metaSchemaConfigured && schema) {
+          configureMonacoYaml(monaco, {
+            validate: true,
+            hover: true,
+            completion: true,
+            schemas: [{ uri: META_SCHEMA_URI, fileMatch: ['*'], schema: schema as object }],
+          });
+          metaSchemaConfigured = true;
+        }
         setYaml(source);
         setDirty(false);
         setErrors([]);

--- a/frontend/src/types/monaco-editor-api.d.ts
+++ b/frontend/src/types/monaco-editor-api.d.ts
@@ -1,0 +1,3 @@
+declare module 'monaco-editor/esm/vs/editor/editor.api' {
+  export * from 'monaco-editor';
+}


### PR DESCRIPTION
## Summary

Two deferred follow-ups from the v0.1 MVP editor:

- **Task 1 — Monaco bundle trim.** Runtime entry switched from the basic-languages-auto-loading `monaco-editor` barrel to the language-free `monaco-editor/esm/vs/editor/editor.api` subpath. TS2307 (the original blocker) resolved with an ambient module declaration that re-exports the public monaco types onto the deep path.
- **Task 2 — Schema-aware autocomplete.** `monaco-yaml` drives IntelliSense (autocomplete, hover, validation) from a new admin endpoint `GET /api/admin/case-types/meta-schema` that serves a hand-written Draft 2020-12 meta-schema for the case-type YAML grammar.

### Bundle impact

| Metric | Before | After | Δ |
| --- | --- | --- | --- |
| `CaseTypeEditorPage-*.js` chunk | 3,826 kB | 2,608 kB | **−32%** |
| Total dist JS | 14,212 kB | 4,412 kB | **−69%** |
| Chunk count | 100 | 4 | **−96** |

The chunk-count crash is the 60+ basic-languages contributions (abap, perl, ruby, solidity, ...) that no longer ship.

### Schema endpoint shape

The original surprise: `/api/admin/case-types/{id}/schema` was referenced in `DeployResponseDto.schemaPath` but **never wired** as a controller endpoint, and `JsonSchemaGenerator` produces the per-case *data* schema — wrong shape for autocompleting the case-type file itself. New endpoint serves a static meta-schema resource (`backend/src/main/resources/schema/case-type.meta-schema.json`) describing the YAML grammar.

### Worker routing

`MonacoEnvironment.getWorker(_, label)` dispatches the `yaml` label to `monaco-yaml/yaml.worker` and falls through to the core editor worker for everything else.

## Test plan

- [x] `npm run build` — chunk reduction verified
- [x] `npm test` — 18/18 passing
- [x] `./mvnw -B -ntp verify -Pfast-it` — BUILD SUCCESS
- [ ] Manual: open the editor for `vendor-onboarding`, type at the top level — autocomplete shows `id`, `displayName`, `fields`, `workflow`, ...
- [ ] Manual: inside a `fields[]` entry, `type:` completion offers the seven field-type enum values

🤖 Generated with [Claude Code](https://claude.com/claude-code)