### PR TITLE
docs(roadmap): rebrand v1.5.0 as the Stabilization release

### DIFF
--- a/apps/react/docs/docs/roadmap.md
+++ b/apps/react/docs/docs/roadmap.md
@@ -18,7 +18,7 @@ flowchart LR
     end
 
     %% v1.5.0: Next Release
-    subgraph V15 ["v1.5.0 (The Modernization)"]
+    subgraph V15 ["v1.5.0 (The Stabilization)"]
         direction TB
         A[Spring Boot 4.0.6]
         B[Java 21 Support]
@@ -57,9 +57,9 @@ The current production version supporting Java 17 and Spring Boot 3.x. This vers
 ---
 
 ## v1.5.0 (Next Release - In Progress)
-**Theme: The Modernization Release**
+**Theme: The Stabilization Release**
 
-A major architectural leap combining core infrastructure upgrades with a comprehensive security overhaul.
+A stabilization release that hardens the existing platform: upgrading core dependencies to current LTS/supported versions and clearing High and Critical vulnerabilities, without changing the application's capabilities.
 
 *   **Zero-Vulnerability Baseline**: Elimination of all High and Critical CVEs across the platform.
 *   **Java 21 & Spring Boot 4**: Transition to the latest LTS and next-gen framework standards.


### PR DESCRIPTION
Rebrands the v1.5.0 roadmap entry from **"The Modernization"** to **"The Stabilization"** release. v1.5.0 hardens the existing stack (Spring Boot 4, Java 21, Camunda 7.24, zero High/Critical CVEs) rather than adding new capability, so "Stabilization" frames it accurately.

Pre-step for cutting `release/1.5` / `v1.5.0-rc.1` — the rename must be on `develop` before the release branch is cut so the RC carries the corrected framing.

- `apps/react/docs/docs/roadmap.md`: mermaid node + theme heading + intro sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)