### PR TITLE
fix(platform): correct portal runtime config and harden service wiring

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -73,7 +73,20 @@ KEYCLOAK_DEFAULT_USER_EMAIL=demo@demo.com
 ## OPA
 OPA_URL=http://opa:8181/v1/data/wks/authz/allow
 
+## CORS — comma-separated origin allow-list the backends accept browser calls
+## from. Default is the local portal origin; widen this when the portal is
+## served from another host. (Replaces the previous wildcard CORS.)
+WKS_CORS_ALLOWED_ORIGINS=http://localhost:3001
+
 ## CASE PORTAL
+## These REACT_APP_* vars are the single source of truth for where the portal
+## finds each service. Each one travels through THREE legs that must stay in
+## lockstep — to add or rename a portal-facing service URL, update all three:
+##   1. REACT_APP_X here (build-time default, read by webpack Dotenv on `yarn start`)
+##   2. docker-compose.yml case-portal env:  __SERVER_X__: ${REACT_APP_X}
+##   3. public/index.html:  window.X = "$__SERVER_X__"  (envsubst'd at nginx startup)
+## consts/index.js then resolves build-vs-runtime via getEnv(REACT_APP_X, window.X).
+##
 ## For the MINIMAL (dev-token) backend, run the portal via `yarn start` with
 ## REACT_APP_AUTH_MODE=dev-token and REACT_APP_AUTH_ISSUER_URL=http://localhost:8081/dev-auth
 ## (see apps/react/case-portal/.env-sample). The dockerized portal below is the

--- a/apps/java/libraries/api-security/src/main/resources/api-security-defaults.properties
+++ b/apps/java/libraries/api-security/src/main/resources/api-security-defaults.properties
@@ -35,3 +35,8 @@ wks.tenancy.claim-name=${WKS_TENANCY_CLAIM_NAME:org}
 # Dev-token issuer defaults (only consumed when wks.auth.mode=dev-token).
 wks.auth.devtoken.roles=${WKS_DEVTOKEN_ROLES:mgmt_case_def,mgmt_record_type,mgmt_form,client_case,client_task,client_record}
 wks.auth.devtoken.allowed-origins=${WKS_DEVTOKEN_ALLOWED_ORIGINS:http://localhost:3001}
+
+# Browser CORS origin allow-list the REST + storage APIs accept (comma-separated).
+# Replaces the previous wildcard CORS; widen via WKS_CORS_ALLOWED_ORIGINS when the
+# portal is served from another host.
+wks.cors.allowed-origins=${WKS_CORS_ALLOWED_ORIGINS:http://localhost:3001}

--- a/apps/java/services/c7-external-tasks/application.yml
+++ b/apps/java/services/c7-external-tasks/application.yml
@@ -24,7 +24,7 @@ camunda.bpm.client:
     password: ${CAMUNDA_PASSWORD:demo}
 
 wks-case-api.base.url: ${WKS_CASE_API_URL:http://localhost:8081}
-wks-case-api.auth.url: ${KEYCLOAK_URL:http://localhost:8082/realms/localhost/protocol/openid-connect/token}
+wks-case-api.auth.url: ${KEYCLOAK_TOKEN_URL:http://localhost:8082/realms/localhost/protocol/openid-connect/token}
 wks-case-api.auth.client_id: ${WKS_CLIENT_ID:wks-external-tasks}
 wks-case-api.auth.client_secret: ${WKS_CLIENT_SECRET:replaceme}
 wks-case-api.auth.grant_type: client_credentials

--- a/apps/java/services/case-engine-rest-api/src/main/java/com/wks/caseengine/rest/config/WebConfig.java
+++ b/apps/java/services/case-engine-rest-api/src/main/java/com/wks/caseengine/rest/config/WebConfig.java
@@ -26,9 +26,10 @@ public class WebConfig implements WebMvcConfigurer {
 	@Autowired
 	private InjectorTenantHandlerInterceptor tenantHandler;
 
-	// Comma-separated origin allow-list for the case portal. Defaults to the
-	// local portal origin; override via WKS_CORS_ALLOWED_ORIGINS per environment.
-	@Value("${WKS_CORS_ALLOWED_ORIGINS:http://localhost:3001}")
+	// Comma-separated origin allow-list for the case portal. The default lives in
+	// the api-security library's api-security-defaults.properties (env-overridable
+	// via WKS_CORS_ALLOWED_ORIGINS), so it isn't hardcoded here.
+	@Value("${wks.cors.allowed-origins}")
 	private String[] allowedOrigins;
 
 	@Override

--- a/apps/java/services/case-engine-rest-api/src/main/java/com/wks/caseengine/rest/config/WebConfig.java
+++ b/apps/java/services/case-engine-rest-api/src/main/java/com/wks/caseengine/rest/config/WebConfig.java
@@ -12,6 +12,7 @@
 package com.wks.caseengine.rest.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -25,9 +26,17 @@ public class WebConfig implements WebMvcConfigurer {
 	@Autowired
 	private InjectorTenantHandlerInterceptor tenantHandler;
 
+	// Comma-separated origin allow-list for the case portal. Defaults to the
+	// local portal origin; override via WKS_CORS_ALLOWED_ORIGINS per environment.
+	@Value("${WKS_CORS_ALLOWED_ORIGINS:http://localhost:3001}")
+	private String[] allowedOrigins;
+
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/**").allowedHeaders("*").allowedMethods("*");
+		registry.addMapping("/**")
+				.allowedOrigins(allowedOrigins)
+				.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+				.allowedHeaders("*");
 	}
 
 	@Override

--- a/apps/java/services/storage-api/src/main/java/com/wks/storage/config/WebConfig.java
+++ b/apps/java/services/storage-api/src/main/java/com/wks/storage/config/WebConfig.java
@@ -26,9 +26,10 @@ public class WebConfig implements WebMvcConfigurer {
 	@Autowired
 	private InjectorTenantHandlerInterceptor tenantHandler;
 
-	// Comma-separated origin allow-list for the case portal. Defaults to the
-	// local portal origin; override via WKS_CORS_ALLOWED_ORIGINS per environment.
-	@Value("${WKS_CORS_ALLOWED_ORIGINS:http://localhost:3001}")
+	// Comma-separated origin allow-list for the case portal. The default lives in
+	// the api-security library's api-security-defaults.properties (env-overridable
+	// via WKS_CORS_ALLOWED_ORIGINS), so it isn't hardcoded here.
+	@Value("${wks.cors.allowed-origins}")
 	private String[] allowedOrigins;
 
 	@Override

--- a/apps/java/services/storage-api/src/main/java/com/wks/storage/config/WebConfig.java
+++ b/apps/java/services/storage-api/src/main/java/com/wks/storage/config/WebConfig.java
@@ -12,6 +12,7 @@
 package com.wks.storage.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -25,9 +26,17 @@ public class WebConfig implements WebMvcConfigurer {
 	@Autowired
 	private InjectorTenantHandlerInterceptor tenantHandler;
 
+	// Comma-separated origin allow-list for the case portal. Defaults to the
+	// local portal origin; override via WKS_CORS_ALLOWED_ORIGINS per environment.
+	@Value("${WKS_CORS_ALLOWED_ORIGINS:http://localhost:3001}")
+	private String[] allowedOrigins;
+
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/**").allowedHeaders("*").allowedMethods("*");
+		registry.addMapping("/**")
+				.allowedOrigins(allowedOrigins)
+				.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+				.allowedHeaders("*");
 	}
 
 	@Override

--- a/apps/react/case-portal/src/consts/index.js
+++ b/apps/react/case-portal/src/consts/index.js
@@ -1,5 +1,10 @@
 console.log(process.env.NODE_ENV)
 
+// Each service location is configured via a three-leg contract that must stay
+// in lockstep (see the CASE PORTAL block in the root .env for the canonical list):
+//   REACT_APP_X  (build-time, .env)  <->  __SERVER_X__ (docker-compose env)  <->  window.X (public/index.html)
+// getEnv() picks the build-time value in dev and the runtime window.* value in
+// a built bundle. To add a service URL, add all three legs AND an entry here.
 const Config = {
   CaseEngineUrl: getEnv(process.env.REACT_APP_API_URL, window.API_URL),
   AuthMode:
@@ -25,7 +30,7 @@ const Config = {
   ),
   WebsocketsTopicHumanTaskCreated: getEnv(
     process.env.REACT_APP_WEBSOCKETS_HUMAN_TASK_CREATED,
-    window.HUMAN_TASK_CREATED,
+    window.WEBSOCKETS_HUMAN_TASK_CREATED,
   ),
   NovuEnabled: getEnv(process.env.REACT_APP_NOVU_ENABLED, window.NOVU_ENABLED),
   NovuPublisherApiUrl: getEnv(
@@ -40,7 +45,10 @@ const Config = {
 
 async function fetchNovuAppId() {
   try {
-    const host = getEnv(process.env.REACT_APP_NOVU_PUBLISHER_API_URL)
+    const host = getEnv(
+      process.env.REACT_APP_NOVU_PUBLISHER_API_URL,
+      window.NOVU_PUBLISHER_API_URL,
+    )
 
     const apiUrl = `${host}/novu-app-id`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,7 @@ services:
             # storage-api reaches the issuing engine over the Docker network (used
             # only when WKS_AUTH_MODE=dev-token; ignored in keycloak mode).
             - WKS_DEVTOKEN_ISSUER_URL=${WKS_DEVTOKEN_ISSUER_URL:-http://case-engine-rest-api:8081/dev-auth}
+            - WKS_CORS_ALLOWED_ORIGINS=${WKS_CORS_ALLOWED_ORIGINS}
             - MINIO_HOST_INTERNAL=${MINIO_HOST_INTERNAL}
             - MINIO_HOST_EXTERNAL=${MINIO_HOST_EXTERNAL}
             - MINIO_ROOT_USER=${MINIO_ROOT_USER}
@@ -201,6 +202,7 @@ services:
             # same from any container (used only when WKS_AUTH_MODE=dev-token).
             - WKS_DEVTOKEN_ISSUER_URL=${WKS_DEVTOKEN_ISSUER_URL:-http://case-engine-rest-api:8081/dev-auth}
             - OPA_URL=${OPA_URL}
+            - WKS_CORS_ALLOWED_ORIGINS=${WKS_CORS_ALLOWED_ORIGINS}
             # The pre-built v1.4.14 image bundles a Camunda 8 / Zeebe client that
             # can't reach a broker in Camunda 7 mode and reports health DOWN. The
             # client is mandatory in that image (can't be removed), so we just drop
@@ -225,7 +227,7 @@ services:
             - CAMUNDA_BASE_URL=${CAMUNDA_BASE_URL}
             - CAMUNDA_USERNAME=${CAMUNDA_USERNAME}
             - CAMUNDA_PASSWORD=${CAMUNDA_PASSWORD}
-            - KEYCLOAK_URL=${KEYCLOAK_TOKEN_URL}
+            - KEYCLOAK_TOKEN_URL=${KEYCLOAK_TOKEN_URL}
             - WKS_CASE_API_URL=${WKS_CASE_API_URL}
             - WEBSOCKET_ENABLED=${WEBSOCKET_ENABLED}
             - DISABLE_BACKOFF_STRATEGY=${DISABLE_BACKOFF_STRATEGY}


### PR DESCRIPTION
## What & why

Tightens how the platform's HTTP services locate and trust one another, and fixes two portal runtime-config defects surfaced while reviewing it. Follows up the orthogonal-core work now on `develop`; defaults are unchanged.

## Changes

- **case-portal runtime-config fixes**
  - Read `window.WEBSOCKETS_HUMAN_TASK_CREATED` (was the never-set `window.HUMAN_TASK_CREATED`), so the human-task websocket topic resolves in built bundles.
  - Fall back to the runtime `window.NOVU_PUBLISHER_API_URL` when fetching the Novu app id, instead of requesting `undefined/novu-app-id` in production.
- **Backend CORS hardening** — `case-engine-rest-api` and `storage-api` replace wildcard CORS with an env-driven origin allow-list (`WKS_CORS_ALLOWED_ORIGINS`, default `http://localhost:3001`) and scoped methods. Wired through `.env-sample` and both service blocks in `docker-compose.yml`. Service-to-service auth is untouched.
- **Env-var naming** — `c7-external-tasks` reads the case-engine auth endpoint from `KEYCLOAK_TOKEN_URL`, matching its meaning (a token URL), instead of a var misleadingly named `KEYCLOAK_URL`.
- **Docs** — document the three-leg portal config contract (`REACT_APP_X` ↔ `__SERVER_X__` ↔ `window.X`) in `consts/index.js` and `.env-sample`.

## Verification

- `mvn compile` passes for `case-engine-rest-api` and `storage-api`.
- `consts/index.js` passes Prettier; the two fixes previously passed ESLint in the develop checkout.
- Not yet exercised end-to-end against the merged `StorageMode`/`storage-fs` flow — reviewer note: confirm the CORS allow-list is compatible with the dev-token/`storage-fs` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
