### PR TITLE
build(versioning): single-source platform version via Maven ${revision} + branch-aware image tags

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -4,9 +4,12 @@
 ## This configures the local docker-compose.yml stack only — not production.
 ## ============================================================================
 
-## Image source (app images are pulled from GHCR by default; `--build` ignores these)
+## Image source (app images are pulled from GHCR by default; `--build` ignores these).
+## WKS_VERSION tracks the branch: `develop` = the floating images CI publishes on every
+## merge to develop (matches this source); pin a release tag (e.g. v1.4.14) to run a
+## specific released build instead.
 WKS_REGISTRY=ghcr.io/wkspower
-WKS_VERSION=v1.4.14
+WKS_VERSION=develop
 
 ## Which profiles start with a bare `docker compose up`.
 ## Default = the FULL stack: all infra (mongodb, keycloak, opa, camunda, storage)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,18 @@ jobs:
           export REACT_APP_NOVU_ENABLED="${{ env.NOVU_ENABLED }}"
           export REACT_APP_NOVU_PUBLISHER_API_URL="${{ env.NOVU_PUBLISHER_API_URL }}"
           yarn --cwd apps/react/case-portal build
+
+  # On develop only: republish the floating :develop image set so `docker compose up`
+  # (default WKS_VERSION=develop) pulls a build that matches develop source. Releases
+  # are pinned via tags (release.yml). maven_revision empty -> jars keep the SNAPSHOT.
+  publish-develop:
+    if: github.ref == 'refs/heads/develop'
+    needs: [build-java, build-react]
+    uses: ./.github/workflows/publish-images.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image_tag: develop
+      maven_revision: ""
+    secrets: inherit

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,223 @@
+name: Publish Images
+
+# Reusable workflow: builds and pushes every service image to GHCR. Called by
+# release.yml (tag -> vX.Y.Z + latest) and build.yml (develop -> develop).
+#
+# Tagging follows docker/metadata-action conventions:
+#   - image_tag: the human/floating tag — `develop` (branch name) or `v1.4.14` (release).
+#   - sha-<short>: an immutable, commit-pinned tag added to EVERY build so a floating
+#     `develop` deploy can still be pinned/rolled back to an exact commit.
+#   - latest: added only when `latest: true` (releases), matching `flavor: latest=auto`
+#     (latest == newest release, never a dev branch).
+#
+# Java service images build their own jars inside the Dockerfile from the reactor
+# root (context: ./apps/java). When `maven_revision` is provided it is passed as the
+# REVISION build-arg so the jar version matches the image tag; left empty the pom's
+# ${revision} default (dev SNAPSHOT) applies.
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        description: "Primary tag for all images (e.g. v1.4.14 or develop)"
+        required: true
+        type: string
+      maven_revision:
+        description: "Maven -Drevision for Java images; empty = pom default (SNAPSHOT)"
+        required: false
+        type: string
+        default: ""
+      latest:
+        description: "Also tag images `latest` (releases only)"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASE: ghcr.io/wkspower
+  KEYCLOAK_URL: http://localhost:8082
+  WKS_API_URL: http://localhost:8081
+  WKS_STORAGE_API_URL: http://localhost:8085
+  WEBSOCKET_ENABLED: false
+  WEBSOCKET_URL: ws://localhost:8484
+  TOPIC_CASE_CREATE: case-create
+  TOPIC_CREATE_HUMAN_TASK: human-task-create
+  NOVU_ENABLED: false
+  NOVU_PUBLISHER_API_URL: http://localhost:3002
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Immutable commit-pinned tag (docker/metadata-action type=sha format: sha-<7>).
+      - name: Compute sha tag
+        id: tags
+        run: echo "sha=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      # The case-portal image's Dockerfile copies a pre-built `dist`, so the portal
+      # must be built here before the image build.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies for case-portal
+        run: yarn --cwd apps/react/case-portal install
+
+      - name: Build for case-portal
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+        run: |
+          export REACT_APP_AUTH_ISSUER_URL="${{ env.KEYCLOAK_URL }}"
+          export REACT_APP_API_URL="${{ env.WKS_API_URL }}"
+          export REACT_APP_STORAGE_URL="${{ env.WKS_STORAGE_API_URL }}"
+          export REACT_APP_WEBSOCKETS_ENABLED="${{ env.WEBSOCKET_ENABLED }}"
+          export REACT_APP_WEBSOCKETS_URL="${{ env.WEBSOCKET_URL }}"
+          export REACT_APP_WEBSOCKETS_CASE_CREATED="${{ env.TOPIC_CASE_CREATE }}"
+          export REACT_APP_WEBSOCKETS_HUMAN_TASK_CREATED="${{ env.TOPIC_CREATE_HUMAN_TASK }}"
+          export REACT_APP_NOVU_ENABLED="${{ env.NOVU_ENABLED }}"
+          export REACT_APP_NOVU_PUBLISHER_API_URL="${{ env.NOVU_PUBLISHER_API_URL }}"
+          yarn --cwd apps/react/case-portal build
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Each image is pushed as: <image_tag> + sha-<short> (+ latest on releases).
+      # The latest line resolves to "" off-release; build-push-action ignores blank tags.
+
+      # --- Java services: build from the reactor root, stamp the version ---
+      - name: Build and push storage-api
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/java
+          file: apps/java/services/storage-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            REVISION=${{ inputs.maven_revision }}
+          tags: |
+            ${{ env.IMAGE_BASE }}/storage-api:${{ inputs.image_tag }}
+            ${{ env.IMAGE_BASE }}/storage-api:${{ steps.tags.outputs.sha }}
+            ${{ inputs.latest && format('{0}/storage-api:latest', env.IMAGE_BASE) || '' }}
+
+      - name: Build and push case-engine-rest-api
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/java
+          file: apps/java/services/case-engine-rest-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            REVISION=${{ inputs.maven_revision }}
+          tags: |
+            ${{ env.IMAGE_BASE }}/case-engine-rest-api:${{ inputs.image_tag }}
+            ${{ env.IMAGE_BASE }}/case-engine-rest-api:${{ steps.tags.outputs.sha }}
+            ${{ inputs.latest && format('{0}/case-engine-rest-api:latest', env.IMAGE_BASE) || '' }}
+
+      - name: Build and push c7-external-tasks
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/java
+          file: apps/java/services/c7-external-tasks/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            REVISION=${{ inputs.maven_revision }}
+          tags: |
+            ${{ env.IMAGE_BASE }}/c7-external-tasks:${{ inputs.image_tag }}
+            ${{ env.IMAGE_BASE }}/c7-external-tasks:${{ steps.tags.outputs.sha }}
+            ${{ inputs.latest && format('{0}/c7-external-tasks:latest', env.IMAGE_BASE) || '' }}
+
+      - name: Build and push demo-data-loader
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/java
+          file: apps/java/services/demo-data-loader/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            REVISION=${{ inputs.maven_revision }}
+          tags: |
+            ${{ env.IMAGE_BASE }}/demo-data-loader:${{ inputs.image_tag }}
+            ${{ env.IMAGE_BASE }}/demo-data-loader:${{ steps.tags.outputs.sha }}
+            ${{ inputs.latest && format('{0}/demo-data-loader:latest', env.IMAGE_BASE) || '' }}
+
+      # --- OPA policy bundle ---
+      - name: Build and push opa
+        uses: docker/build-push-action@v6
+        with:
+          context: ./opa
+          file: opa/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_BASE }}/opa:${{ inputs.image_tag }}
+            ${{ env.IMAGE_BASE }}/opa:${{ steps.tags.outputs.sha }}
+            ${{ inputs.latest && format('{0}/opa:latest', env.IMAGE_BASE) || '' }}
+
+      # --- React portal (dist built above) ---
+      - name: Build and push case-portal
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/react/case-portal
+          file: apps/react/case-portal/deployments/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_BASE }}/case-portal:${{ inputs.image_tag }}
+            ${{ env.IMAGE_BASE }}/case-portal:${{ steps.tags.outputs.sha }}
+            ${{ inputs.latest && format('{0}/case-portal:latest', env.IMAGE_BASE) || '' }}
+
+      # --- Node services ---
+      - name: Build and push websocket-publisher
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/node/websocket-publisher
+          file: apps/node/websocket-publisher/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_BASE }}/websocket-publisher:${{ inputs.image_tag }}
+            ${{ env.IMAGE_BASE }}/websocket-publisher:${{ steps.tags.outputs.sha }}
+            ${{ inputs.latest && format('{0}/websocket-publisher:latest', env.IMAGE_BASE) || '' }}
+
+      - name: Build and push novu-publisher
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/node/novu-publisher
+          file: apps/node/novu-publisher/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_BASE }}/novu-publisher:${{ inputs.image_tag }}
+            ${{ env.IMAGE_BASE }}/novu-publisher:${{ steps.tags.outputs.sha }}
+            ${{ inputs.latest && format('{0}/novu-publisher:latest', env.IMAGE_BASE) || '' }}
+
+      - name: Build and push email-sender
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apps/node/email-sender
+          file: apps/node/email-sender/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_BASE }}/email-sender:${{ inputs.image_tag }}
+            ${{ env.IMAGE_BASE }}/email-sender:${{ steps.tags.outputs.sha }}
+            ${{ inputs.latest && format('{0}/email-sender:latest', env.IMAGE_BASE) || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,155 +6,25 @@ on:
       - "**"
   workflow_dispatch:
 
-env:
-  REGISTRY: ghcr.io
-  REPOSITORY_OWNER: wkspower
-  KEYCLOAK_URL: http://localhost:8082
-  WKS_API_URL: http://localhost:8081
-  WKS_STORAGE_API_URL: http://localhost:8085
-  WEBSOCKET_ENABLED: false
-  WEBSOCKET_URL: ws://localhost:8484
-  TOPIC_CASE_CREATE: case-create
-  TOPIC_CREATE_HUMAN_TASK: human-task-create
-  NOVU_ENABLED: false
-  NOVU_PUBLISHER_API_URL: http://localhost:3002
-
 jobs:
-  build:
+  # Derive the Maven revision from the tag (strip a leading "v": v1.4.14 -> 1.4.14)
+  # so the released jar version matches the image tag.
+  vars:
     runs-on: ubuntu-latest
+    outputs:
+      revision: ${{ steps.v.outputs.revision }}
+    steps:
+      - id: v
+        run: echo "revision=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: vars
+    uses: ./.github/workflows/publish-images.yml
     permissions:
       contents: read
       packages: write
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up jdk 18
-        uses: actions/setup-java@v3
-        with:
-          java-version: "21"
-          distribution: "temurin"
-
-      - name: Set up maven
-        uses: stCarolas/setup-maven@v4.5
-        with:
-          maven-version: 3.8.2
-
-      - name: Build all for backend api
-        run: mvn -B package --file apps/java/pom.xml
-
-      - name: Install dependencies for case-portal
-        run: yarn --cwd apps/react/case-portal install
-
-      - name: Build for case-portal
-        env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
-        run: |
-          export REACT_APP_AUTH_ISSUER_URL="${{ env.KEYCLOAK_URL }}"
-          export REACT_APP_API_URL="${{ env.WKS_API_URL }}"
-          export REACT_APP_STORAGE_URL="${{ env.WKS_STORAGE_API_URL }}"
-          export REACT_APP_WEBSOCKETS_ENABLED="${{ env.WEBSOCKET_ENABLED }}"
-          export REACT_APP_WEBSOCKETS_URL="${{ env.WEBSOCKET_URL }}"
-          export REACT_APP_WEBSOCKETS_CASE_CREATED="${{ env.TOPIC_CASE_CREATE }}"
-          export REACT_APP_WEBSOCKETS_HUMAN_TASK_CREATED="${{ env.TOPIC_CREATE_HUMAN_TASK }}"
-          export REACT_APP_NOVU_ENABLED="${{ env.NOVU_ENABLED }}"
-          export REACT_APP_NOVU_PUBLISHER_API_URL="${{ env.NOVU_PUBLISHER_API_URL }}"
-          yarn --cwd apps/react/case-portal build
-
-      - name: Extract tag name
-        id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/})"
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build and push Docker image for storage-api
-        uses: docker/build-push-action@v2
-        with:
-          context: ./apps/java/services/storage-api
-          platforms: linux/amd64,linux/arm64
-          file: apps/java/services/storage-api/Dockerfile
-          push: true
-          tags: "${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/storage-api:${{ steps.extract_tag.outputs.tag }}"
-
-      - name: Build and push Docker image for opa
-        uses: docker/build-push-action@v2
-        with:
-          context: ./opa
-          platforms: linux/amd64,linux/arm64
-          file: opa/Dockerfile
-          push: true
-          tags: "${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/opa:${{ steps.extract_tag.outputs.tag }}"
-
-      - name: Build and push Docker image for c7-external-tasks
-        uses: docker/build-push-action@v2
-        with:
-          context: ./apps/java/services/c7-external-tasks
-          platforms: linux/amd64,linux/arm64
-          file: apps/java/services/c7-external-tasks/Dockerfile
-          push: true
-          tags: "${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/c7-external-tasks:${{ steps.extract_tag.outputs.tag }}"
-
-      - name: Build and push Docker image for case-engine-rest-api
-        uses: docker/build-push-action@v2
-        with:
-          context: ./apps/java/services/case-engine-rest-api
-          platforms: linux/amd64,linux/arm64
-          file: apps/java/services/case-engine-rest-api/Dockerfile
-          push: true
-          tags: "${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/case-engine-rest-api:${{ steps.extract_tag.outputs.tag }}"
-
-      - name: Build and push Docker image for demo-data-loader
-        uses: docker/build-push-action@v2
-        with:
-          context: ./apps/java/services/demo-data-loader
-          platforms: linux/amd64,linux/arm64
-          file: apps/java/services/demo-data-loader/Dockerfile
-          push: true
-          tags: "${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/demo-data-loader:${{ steps.extract_tag.outputs.tag }}"
-
-      - name: Build and push Docker image for case-portal
-        uses: docker/build-push-action@v2
-        with:
-          context: ./apps/react/case-portal
-          platforms: linux/amd64,linux/arm64
-          file: apps/react/case-portal/deployments/Dockerfile
-          push: true
-          tags: "${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/case-portal:${{ steps.extract_tag.outputs.tag }}"
-
-      - name: Build and push Docker image for websocket-publisher
-        uses: docker/build-push-action@v2
-        with:
-          context: ./apps/node/websocket-publisher
-          platforms: linux/amd64,linux/arm64
-          file: apps/node/websocket-publisher/Dockerfile
-          push: true
-          tags: "${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/websocket-publisher:${{ steps.extract_tag.outputs.tag }}"
-
-      - name: Build and push Docker image for novu-publisher
-        uses: docker/build-push-action@v2
-        with:
-          context: ./apps/node/novu-publisher
-          platforms: linux/amd64,linux/arm64
-          file: apps/node/novu-publisher/Dockerfile
-          push: true
-          tags: "${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/novu-publisher:${{ steps.extract_tag.outputs.tag }}"
-
-      - name: Build and push Docker image for email-sender
-        uses: docker/build-push-action@v2
-        with:
-          context: ./apps/node/email-sender
-          platforms: linux/amd64,linux/arm64
-          file: apps/node/email-sender/Dockerfile
-          push: true
-          tags: "${{ env.REGISTRY }}/${{ env.REPOSITORY_OWNER }}/email-sender:${{ steps.extract_tag.outputs.tag }}"
+    with:
+      image_tag: ${{ github.ref_name }}
+      maven_revision: ${{ needs.vars.outputs.revision }}
+      latest: true
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 target
 dist
 
+# Maven CI-friendly versions: flatten-maven-plugin output (transient build artifact)
+.flattened-pom.xml
+
 # Created by https://www.toptal.com/developers/gitignore/api/eclipse
 # Edit at https://www.toptal.com/developers/gitignore?templates=eclipse
 

--- a/apps/java/libraries/api-security/pom.xml
+++ b/apps/java/libraries/api-security/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>api-security</artifactId>

--- a/apps/java/libraries/bpm-engine-client/pom.xml
+++ b/apps/java/libraries/bpm-engine-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>bpm-engine-interface</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<!--

--- a/apps/java/libraries/bpm-engine-interface/pom.xml
+++ b/apps/java/libraries/bpm-engine-interface/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/apps/java/libraries/c7-client/pom.xml
+++ b/apps/java/libraries/c7-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -42,13 +42,13 @@
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>api-security</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>bpm-engine-interface</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>

--- a/apps/java/libraries/c7-plugins/pom.xml
+++ b/apps/java/libraries/c7-plugins/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	

--- a/apps/java/libraries/case-engine-rest-client/pom.xml
+++ b/apps/java/libraries/case-engine-rest-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -36,13 +36,13 @@
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>case-engine-rest-dto</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>api-security</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 		
 		<dependency>

--- a/apps/java/libraries/case-engine-rest-dto/pom.xml
+++ b/apps/java/libraries/case-engine-rest-dto/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>bpm-engine-interface</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 		
 		<dependency>

--- a/apps/java/libraries/case-engine/pom.xml
+++ b/apps/java/libraries/case-engine/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.wks</groupId>
         <artifactId>platform</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -69,13 +69,13 @@
         <dependency>
             <groupId>com.wks</groupId>
             <artifactId>bpm-engine-client</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${revision}</version>
         </dependency>
 
         <dependency>
             <groupId>com.wks</groupId>
             <artifactId>api-security</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${revision}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/apps/java/libraries/noop-bpm-engine-client/pom.xml
+++ b/apps/java/libraries/noop-bpm-engine-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>bpm-engine-interface</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 	</dependencies>
 

--- a/apps/java/pom.xml
+++ b/apps/java/pom.xml
@@ -4,12 +4,18 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.wks</groupId>
     <artifactId>platform</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <name>wks-platform</name>
 
     <properties>
+        <!-- CI-friendly version: single source of truth for the platform version.
+             Defaults to the develop dev line; CI overrides it at release time with
+             `-Drevision=X.Y.Z` so the same version lands in the jars and the image tag.
+             flatten-maven-plugin (below) resolves ${revision} in the installed/published poms. -->
+        <revision>1.5.0-SNAPSHOT</revision>
+
         <project.javadoc.outputDirectory>website/static/javadoc</project.javadoc.outputDirectory>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -129,6 +135,39 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <!-- Flattens the installed/published pom so consumers get a self-contained
+                 artifact: ${revision} is resolved to a concrete version EVERYWHERE,
+                 including inter-module (com.wks) dependency versions, and the BOM-managed
+                 versions are inlined. `oss` mode (vs resolveCiFriendliesOnly) is required
+                 here because resolveCiFriendliesOnly leaves sibling-dep versions as the
+                 literal ${revision}, which breaks anyone consuming the pom outside the
+                 reactor (e.g. the published case-engine-rest-client). Inherited by every
+                 module; matches the GitHub Packages target in <distributionManagement>. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>oss</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/apps/java/services/c7-external-tasks/Dockerfile
+++ b/apps/java/services/c7-external-tasks/Dockerfile
@@ -7,8 +7,11 @@
 FROM maven:3.9-amazoncorretto-21 AS build
 WORKDIR /build
 COPY . .
+# Optional release stamp: CI passes --build-arg REVISION=X.Y.Z so the jar version
+# matches the image tag. Unset (dev/local builds) = the pom's ${revision} default.
+ARG REVISION=
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B -q clean package -pl services/c7-external-tasks -am -DskipTests
+    mvn -B -q clean package -pl services/c7-external-tasks -am -DskipTests ${REVISION:+-Drevision=$REVISION}
 
 # Stage 2: runtime image (matches the jar's Java 21 target).
 FROM amazoncorretto:21

--- a/apps/java/services/c7-external-tasks/pom.xml
+++ b/apps/java/services/c7-external-tasks/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>c7-external-tasks</artifactId>
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>case-engine-rest-client</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>		
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>

--- a/apps/java/services/case-engine-rest-api/Dockerfile
+++ b/apps/java/services/case-engine-rest-api/Dockerfile
@@ -7,8 +7,11 @@
 FROM maven:3.9-amazoncorretto-21 AS build
 WORKDIR /build
 COPY . .
+# Optional release stamp: CI passes --build-arg REVISION=X.Y.Z so the jar version
+# matches the image tag. Unset (dev/local builds) = the pom's ${revision} default.
+ARG REVISION=
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B -q clean package -pl services/case-engine-rest-api -am -DskipTests
+    mvn -B -q clean package -pl services/case-engine-rest-api -am -DskipTests ${REVISION:+-Drevision=$REVISION}
 
 # Stage 2: runtime image (matches the jar's Java 21 target).
 FROM amazoncorretto:21

--- a/apps/java/services/case-engine-rest-api/pom.xml
+++ b/apps/java/services/case-engine-rest-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>case-engine</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<!-- BPM engine modules this service supports. bpm-engine-client no longer
@@ -80,25 +80,25 @@
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>c7-client</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>noop-bpm-engine-client</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>api-security</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>case-engine-rest-dto</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>

--- a/apps/java/services/demo-data-loader/Dockerfile
+++ b/apps/java/services/demo-data-loader/Dockerfile
@@ -7,8 +7,11 @@
 FROM maven:3.9-amazoncorretto-21 AS build
 WORKDIR /build
 COPY . .
+# Optional release stamp: CI passes --build-arg REVISION=X.Y.Z so the jar version
+# matches the image tag. Unset (dev/local builds) = the pom's ${revision} default.
+ARG REVISION=
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B -q clean package -pl services/demo-data-loader -am -DskipTests
+    mvn -B -q clean package -pl services/demo-data-loader -am -DskipTests ${REVISION:+-Drevision=$REVISION}
 
 # Stage 2: runtime image (matches the jar's Java 21 target).
 FROM amazoncorretto:21

--- a/apps/java/services/demo-data-loader/pom.xml
+++ b/apps/java/services/demo-data-loader/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>demo-data-loader</artifactId>

--- a/apps/java/services/storage-api/Dockerfile
+++ b/apps/java/services/storage-api/Dockerfile
@@ -7,8 +7,11 @@
 FROM maven:3.9-amazoncorretto-21 AS build
 WORKDIR /build
 COPY . .
+# Optional release stamp: CI passes --build-arg REVISION=X.Y.Z so the jar version
+# matches the image tag. Unset (dev/local builds) = the pom's ${revision} default.
+ARG REVISION=
 RUN --mount=type=cache,target=/root/.m2 \
-    mvn -B -q clean package -pl services/storage-api -am -DskipTests
+    mvn -B -q clean package -pl services/storage-api -am -DskipTests ${REVISION:+-Drevision=$REVISION}
 
 # Stage 2: runtime image (matches the jar's Java 21 target).
 FROM amazoncorretto:21

--- a/apps/java/services/storage-api/pom.xml
+++ b/apps/java/services/storage-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.wks</groupId>
 		<artifactId>platform</artifactId>
-		<version>1.0-SNAPSHOT</version>
+		<version>${revision}</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>storage-api</artifactId>
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>com.wks</groupId>
 			<artifactId>api-security</artifactId>
-			<version>${project.parent.version}</version>
+			<version>${revision}</version>
 		</dependency>
 
 		<dependency>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ name: wks-platform
 
 # Image/build/port for the single env-driven case-engine-rest-api service.
 x-case-engine-rest-api: &case-engine-rest-api
-    image: ${WKS_REGISTRY:-ghcr.io/wkspower}/case-engine-rest-api:${WKS_VERSION:-v1.4.14}
+    image: ${WKS_REGISTRY:-ghcr.io/wkspower}/case-engine-rest-api:${WKS_VERSION:-develop}
     build:
         context: apps/java
         dockerfile: services/case-engine-rest-api/Dockerfile
@@ -41,7 +41,7 @@ x-case-engine-rest-api: &case-engine-rest-api
 
 # Image/build/port for the single env-driven storage-api service.
 x-storage-api: &storage-api
-    image: ${WKS_REGISTRY:-ghcr.io/wkspower}/storage-api:${WKS_VERSION:-v1.4.14}
+    image: ${WKS_REGISTRY:-ghcr.io/wkspower}/storage-api:${WKS_VERSION:-develop}
     build:
         context: apps/java
         dockerfile: services/storage-api/Dockerfile
@@ -203,10 +203,10 @@ services:
             - WKS_DEVTOKEN_ISSUER_URL=${WKS_DEVTOKEN_ISSUER_URL:-http://case-engine-rest-api:8081/dev-auth}
             - OPA_URL=${OPA_URL}
             - WKS_CORS_ALLOWED_ORIGINS=${WKS_CORS_ALLOWED_ORIGINS}
-            # The pre-built v1.4.14 image bundles a Camunda 8 / Zeebe client that
-            # can't reach a broker in Camunda 7 mode and reports health DOWN. The
-            # client is mandatory in that image (can't be removed), so we just drop
-            # its health contributor. Harmless on source-built images (no Zeebe).
+            # Legacy released images (the Camunda 8 era, e.g. v1.4.x) bundle a
+            # Zeebe client that can't reach a broker in Camunda 7 mode and reports
+            # health DOWN; the client is mandatory there, so we drop its health
+            # contributor. Harmless on develop/source-built images (no Zeebe).
             - MANAGEMENT_HEALTH_ZEEBE_ENABLED=false
         depends_on:
             # Optional: only enforced when the infra profile is also active.
@@ -218,7 +218,7 @@ services:
                 required: false
 
     c7-external-tasks:
-        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/c7-external-tasks:${WKS_VERSION:-v1.4.14}
+        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/c7-external-tasks:${WKS_VERSION:-develop}
         profiles: [camunda]
         build:
             context: apps/java
@@ -245,7 +245,7 @@ services:
     # profile: portal (enabled by default via COMPOSE_PROFILES in .env)
 
     case-portal:
-        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/case-portal:${WKS_VERSION:-v1.4.14}
+        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/case-portal:${WKS_VERSION:-develop}
         profiles: [portal]
         build:
             context: apps/react/case-portal
@@ -296,7 +296,7 @@ services:
             - zookeeper
 
     email-sender:
-        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/email-sender:${WKS_VERSION:-v1.4.14}
+        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/email-sender:${WKS_VERSION:-develop}
         profiles: [notifications]
         build:
             context: apps/node/email-sender
@@ -313,7 +313,7 @@ services:
             - kafka
 
     websocket-publisher:
-        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/websocket-publisher:${WKS_VERSION:-v1.4.14}
+        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/websocket-publisher:${WKS_VERSION:-develop}
         profiles: [notifications]
         build:
             context: apps/node/websocket-publisher
@@ -327,7 +327,7 @@ services:
             - kafka
 
     novu-publisher:
-        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/novu-publisher:${WKS_VERSION:-v1.4.14}
+        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/novu-publisher:${WKS_VERSION:-develop}
         profiles: [notifications]
         build:
             context: apps/node/novu-publisher
@@ -378,7 +378,7 @@ services:
     # but then the portal has no realm/user to log in against.
 
     demo-data-loader:
-        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/demo-data-loader:${WKS_VERSION:-v1.4.14}
+        image: ${WKS_REGISTRY:-ghcr.io/wkspower}/demo-data-loader:${WKS_VERSION:-develop}
         profiles: [demo]
         build:
             context: apps/java

--- a/experimental/camunda8/docker-compose.camunda8.yaml
+++ b/experimental/camunda8/docker-compose.camunda8.yaml
@@ -148,7 +148,7 @@ services:
 
   case-engine-rest-api:
     # Overrides the root service to talk to Camunda 8 instead of 7 (pull-only).
-    image: ${WKS_REGISTRY:-ghcr.io/wkspower}/case-engine-rest-api:${WKS_VERSION:-v1.4.14}
+    image: ${WKS_REGISTRY:-ghcr.io/wkspower}/case-engine-rest-api:${WKS_VERSION:-develop}
     ports:
       - 8081:8081
     environment:
@@ -176,7 +176,7 @@ services:
 
   c8-external-tasks:
     # No source dir / not a Maven module — pull-only (see README).
-    image: ${WKS_REGISTRY:-ghcr.io/wkspower}/c8-external-tasks:${WKS_VERSION:-v1.4.14}
+    image: ${WKS_REGISTRY:-ghcr.io/wkspower}/c8-external-tasks:${WKS_VERSION:-develop}
     environment:
       - CAMUNDA8_ZEEBE_GATEWAY_ADDRESS=${CAMUNDA8_ZEEBE_GATEWAY_ADDRESS}
       - KEYCLOAK_URL=${KEYCLOAK_TOKEN_URL}


### PR DESCRIPTION
## What & why

The repo carried **two disconnected version schemes**: Maven was frozen at `1.0-SNAPSHOT` forever while images were tagged with a release version, so a built jar never reported the version of the image shipping it. And `develop` defaulted `WKS_VERSION` to a *frozen released tag*, so `docker compose up` (no `--build`) pulled stale images that didn't match develop source.

This unifies them so one version concept tracks the branch and feeds both Maven and Docker.

## Changes

- **Maven CI-friendly versions** — parent declares `<revision>1.5.0-SNAPSHOT</revision>` + `flatten-maven-plugin` (`oss` mode, so installed/published poms resolve `${revision}` everywhere, including inter-module deps). All modules derive from the one property; CI overrides it at release with `-Drevision=<tag>` so **jar version == image tag**.
- **Java Dockerfiles** accept an optional `REVISION` build-arg to stamp that version.
- **Branch-aware image tags** — `WKS_VERSION` defaults to `develop` (floating). A reusable `publish-images.yml` is called by `release.yml` (`vX.Y.Z` + `latest`) and `build.yml` (`develop`). Every build also gets an immutable `sha-<short>` tag; `latest` only on releases — following `docker/metadata-action` conventions.
- **Fix** — `release.yml` built the Java images with the *service dir* as context, but the Dockerfiles build from the **reactor root**; corrected to `context: ./apps/java`. (The release workflow was effectively broken for the 4 Java services after the Dockerfile consolidation.)

## Verification (local)

- `mvn clean package` → `*-1.5.0-SNAPSHOT.jar` ×13; `mvn -Drevision=1.4.14 package` → `*-1.4.14.jar`; flattened poms carry concrete versions (no literal `${revision}`).
- `docker build` of a Java service with the corrected reactor-root context + `--build-arg REVISION=1.4.14` succeeds.
- `docker compose config` renders app images as `:develop`.
- All workflow YAML parses; rebuilt green after rebasing onto latest `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)