### PR TITLE
fix(java): add PostgreSQL JDBC driver for the db-postgres profile

### DIFF
--- a/apps/java/services/case-engine-rest-api/pom.xml
+++ b/apps/java/services/case-engine-rest-api/pom.xml
@@ -45,7 +45,16 @@
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
         </dependency>
-        		
+
+        <!-- PostgreSQL JDBC driver for the db-postgres datastore profile.
+             Version managed by the spring-boot-dependencies BOM. Runtime scope:
+             only loaded when SPRING_PROFILES_ACTIVE=db-postgres selects the JPA path. -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>


### PR DESCRIPTION
## What

Adds `org.postgresql:postgresql` (runtime scope, version managed by the `spring-boot-dependencies` BOM) to `case-engine-rest-api`.

## Why

The `db-postgres` Spring profile had **no PostgreSQL JDBC driver anywhere in the Maven dependency tree** (only H2, transitively). Selecting it failed at startup with `ClassNotFoundException: org.postgresql.Driver` — the profile could never boot. This surfaced while validating the Postgres datastore path for an Azure AKS deployment.

## Verification

- Rebuilt jar bundles `postgresql-42.7.10.jar`.
- `case-engine-rest-api` boots on Postgres 16 with `SPRING_PROFILES_ACTIVE=db-postgres`, single-tenant.
- Hibernate `ddl-auto=update` provisions the schema (7 tables).
- `POST /case-definition` → 200, row persisted and read back from Postgres.

## Notes / follow-ups (out of scope here)

- Multi-tenant on Postgres still needs Flyway schema-per-tenant provisioning (separate workstream).
- `record-type` create returns 500 (NPE) when `id` is omitted — should be a 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)