### PR TITLE
build(keycloak): upgrade Keycloak 20→26 LTS (server, admin client, keycloak-js) + healthcheck/bootstrap fixes

### DIFF
--- a/apps/java/services/demo-data-loader/pom.xml
+++ b/apps/java/services/demo-data-loader/pom.xml
@@ -14,8 +14,10 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.keycloak</groupId>
+			<!-- The standalone admin client tracks its own patch line (26.0.x),
+			     decoupled from the server version; compatible across 26.x. -->
 			<artifactId>keycloak-admin-client</artifactId>
-			<version>20.0.0</version>
+			<version>26.0.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/apps/react/case-portal/package.json
+++ b/apps/react/case-portal/package.json
@@ -23,7 +23,7 @@
     "formiojs": "^4.21.7",
     "framer-motion": "^11.0.28",
     "i18next": "^23.11.1",
-    "keycloak-js": "^24.0.2",
+    "keycloak-js": "^26.0.0",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
     "prop-types": "^15.8.1",

--- a/apps/react/case-portal/yarn.lock
+++ b/apps/react/case-portal/yarn.lock
@@ -5389,11 +5389,6 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-js-sha256@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.1.tgz#712262e8fc9569d6f7f6eea72c0d8e5ccc7c976c"
-  integrity sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5541,18 +5536,10 @@ jwt-decode@^3.1.2:
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
   integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
 
-jwt-decode@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
-  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
-
-keycloak-js@^24.0.2:
-  version "24.0.5"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-24.0.5.tgz#e392d7f233f896efd331349d8e2eb3251cc7a380"
-  integrity sha512-VQOSn3j13DPB6OuavKAq+sRjDERhIKrXgBzekoHRstifPuyULILguugX6yxRUYFSpn3OMYUXmSX++tkdCupOjA==
-  dependencies:
-    js-sha256 "^0.11.0"
-    jwt-decode "^4.0.0"
+keycloak-js@^26.0.0:
+  version "26.2.4"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-26.2.4.tgz#b96ff33ed08ff6fd8d1e09d9e5055c7b3f2fa918"
+  integrity sha512-PnXpR3ubETGOt0B/Qt2lxmPbkZr5bc3vlQsOqDoTPPQsZRp7JjhTKxlJ187uWh8qJhvBab6Gsjb06a8ayOPfuw==
 
 keyv@^4.5.3:
   version "4.5.4"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,15 +99,24 @@ services:
             - ./opa:/etc/rules:ro
 
     keycloak:
-        image: quay.io/keycloak/keycloak:20.0.3
+        image: quay.io/keycloak/keycloak:26.6.1
         profiles: [keycloak]
         command: start-dev
         environment:
             KC_HEALTH_ENABLED: "true"
-            KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
-            KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+            # KC 26 renamed the bootstrap-admin vars; the old KEYCLOAK_ADMIN[_PASSWORD]
+            # still work but log a deprecation warning.
+            KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN}
+            KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+        # KC 25+ serves health/metrics on a dedicated management port (9000), not
+        # the main HTTP port. The 26.x image also ships no curl/wget, so probe the
+        # readiness endpoint over bash's /dev/tcp instead.
         healthcheck:
-            test: curl --fail http://localhost:8080/health/ready || exit 1
+            test:
+                - CMD
+                - bash
+                - -c
+                - 'exec 3<>/dev/tcp/localhost/9000 && printf "GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3 && grep -q "200 OK" <&3'
             interval: 10s
             retries: 10
             start_period: 5s


### PR DESCRIPTION
## What & why

Upgrades Keycloak from **20.0.3 → 26.6.1 LTS** across the dev/demo stack, with the
matching client-side bumps and the 26.x operational fixes.

| Component | From | To |
|---|---|---|
| Keycloak server image | `quay.io/keycloak/keycloak:20.0.3` | `26.6.1` |
| `keycloak-admin-client` (demo-data-loader) | `20.0.0` | `26.0.9` |
| `keycloak-js` (case-portal) | `^24` | `^26` (resolves `26.2.4`) |

### 26.x operational fixes folded in
- **Healthcheck rewritten** for the 26.x image: health/metrics moved to the dedicated
  management port **9000**, and the image ships no `curl`/`wget`, so the probe is now a
  curl-free **bash `/dev/tcp`** request to `/health/ready` on 9000.
- **Bootstrap env switched** to `KC_BOOTSTRAP_ADMIN_USERNAME` / `KC_BOOTSTRAP_ADMIN_PASSWORD`
  (the deprecated `KEYCLOAK_ADMIN[_PASSWORD]` names log `KC-SERVICES0110` on 26.x); values
  still come from the same `${KEYCLOAK_ADMIN[_PASSWORD]}`.
- The admin client `26.0.9` brings its own JAX-RS stack (resteasy-client 6.2.15 +
  jakarta.ws.rs-api 4.0.0) — no extra deps and **no source changes** in
  `KeycloakDataImportCommandRunner` (all admin APIs stable 20→26).

> Note: the admin client has its own patch stream (`26.0.x`) decoupled from the server's
> `26.6.x`; `26.0.9` is the latest on Maven Central and is compatible across 26.x. There is
> no `26.6.1` admin-client artifact.

**Scope:** dev/demo stack only (`docker-compose.yml`). The license-gated SSO stack
(`docker-compose.sso.yml`) and prod hostname config are untouched.

## Verification (end-to-end, full default stack)

1. **Build** — all 4 images build clean (case-engine-rest-api, case-portal,
   demo-data-loader, c7-external-tasks). Keycloak 26.6.1 reaches **healthy** (no curl;
   deprecation warnings gone).
2. **Seed** — `demo-data-loader` reaches "End of data importing"; the admin client (26.0.9)
   authenticates against KC 26 and creates realm `localhost`, clients
   `wks-portal`/`wks-external-tasks`/`wks-email-to-case`, and the `demo` user — **no
   ClassNotFound / JAX-RS errors**.
3. **Login** — portal `:3001` → **302 to KC 26 login** (`wks-portal`, authorization-code +
   **PKCE S256**); `demo`/`demo` → token endpoint **200**, lands in the portal. keycloak-js 26
   drives the full OIDC flow; issuer/redirect URLs consistent (hostname-v2 OK).
4. **Authorized API** — Cases view issues **GET 200 `/case-definition`** to case-engine, which
   validates the KC26-issued JWT via JWKS unchanged; the seeded case definitions render.

## Upgrade note (existing local volumes)

KC 26's `KC_BOOTSTRAP_ADMIN_*` only creates the master admin when the master realm is
initialised **fresh**. If you previously ran the KC20 stack, the persistent
`wks-platform_keycloak` volume already has a master realm, so bootstrap is skipped and the
admin login fails (`invalid_grant` / `user_not_found`). Clear it once on upgrade:
`docker compose down -v` (or remove the `keycloak` volume), then `up`. Fresh clones are
unaffected.
