### PR TITLE
fix(java): cut external-task pickup latency, fix worker startup

### DIFF
--- a/apps/java/libraries/api-security/src/main/java/com/wks/api/security/config/KeycloakAuthnConfig.java
+++ b/apps/java/libraries/api-security/src/main/java/com/wks/api/security/config/KeycloakAuthnConfig.java
@@ -12,6 +12,7 @@
 package com.wks.api.security.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,6 +42,11 @@ import jakarta.servlet.http.HttpServletRequest;
  * @author wks
  */
 @Configuration
+// spring-security is a {@code provided}-scope dependency of this library, so consumers that do
+// not bundle it (e.g. the headless c7-external-tasks worker, which only needs the tenant holder)
+// must not load this config. {@code @ConditionalOnClass} is read from bytecode metadata, so it
+// skips the class without triggering NoClassDefFoundError on AuthenticationManagerResolver.
+@ConditionalOnClass(AuthenticationManagerResolver.class)
 @ConditionalOnProperty(name = "wks.auth.mode", havingValue = "keycloak", matchIfMissing = true)
 public class KeycloakAuthnConfig {
 

--- a/apps/java/libraries/api-security/src/main/java/com/wks/api/security/config/OpaAuthorizationManagerConfig.java
+++ b/apps/java/libraries/api-security/src/main/java/com/wks/api/security/config/OpaAuthorizationManagerConfig.java
@@ -12,6 +12,7 @@
 package com.wks.api.security.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +36,10 @@ import com.wks.api.security.OpenPolicyAuthzEnforcerConfig;
  * @author wks
  */
 @Configuration
+// Requires spring-security, a {@code provided}-scope dependency of this library. Consumers that
+// do not bundle it (e.g. the headless c7-external-tasks worker) must skip this config; the
+// condition is read from bytecode metadata so it never loads AuthorizationManager directly.
+@ConditionalOnClass(AuthorizationManager.class)
 @ConditionalOnProperty(name = "wks.authz.opa.enabled", havingValue = "true", matchIfMissing = true)
 public class OpaAuthorizationManagerConfig {
 

--- a/apps/java/libraries/api-security/src/main/java/com/wks/api/security/config/PermitAuthenticatedAuthorizationManagerConfig.java
+++ b/apps/java/libraries/api-security/src/main/java/com/wks/api/security/config/PermitAuthenticatedAuthorizationManagerConfig.java
@@ -12,6 +12,7 @@
 package com.wks.api.security.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +35,10 @@ import com.wks.api.security.PermitAuthenticatedAuthorizationManager;
  * @author wks
  */
 @Configuration
+// Requires spring-security, a {@code provided}-scope dependency of this library; consumers that
+// do not bundle it (e.g. the headless c7-external-tasks worker) must skip this config. The
+// condition is read from bytecode metadata so it never loads AuthorizationManager directly.
+@ConditionalOnClass(AuthorizationManager.class)
 @ConditionalOnProperty(name = "wks.authz.opa.enabled", havingValue = "false")
 public class PermitAuthenticatedAuthorizationManagerConfig {
 

--- a/apps/java/libraries/api-security/src/main/java/com/wks/api/security/devtoken/DevTokenSecurityConfig.java
+++ b/apps/java/libraries/api-security/src/main/java/com/wks/api/security/devtoken/DevTokenSecurityConfig.java
@@ -12,6 +12,7 @@
 package com.wks.api.security.devtoken;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -36,6 +37,10 @@ import jakarta.servlet.http.HttpServletRequest;
  * @author wks
  */
 @Configuration
+// Requires spring-security-web, a {@code provided}-scope dependency of this library; consumers
+// that do not bundle it (e.g. the headless c7-external-tasks worker) must skip this config. The
+// condition is read from bytecode metadata so it never loads SecurityFilterChain directly.
+@ConditionalOnClass(SecurityFilterChain.class)
 @ConditionalOnProperty(name = "wks.auth.mode", havingValue = "dev-token")
 public class DevTokenSecurityConfig {
 

--- a/apps/java/libraries/case-engine-rest-client/src/main/java/com/wks/api/client/gateway/AuthInterceptor.java
+++ b/apps/java/libraries/case-engine-rest-client/src/main/java/com/wks/api/client/gateway/AuthInterceptor.java
@@ -1,18 +1,26 @@
 /*
  * WKS Platform - Open-Source Project
- * 
+ *
  * This file is part of the WKS Platform, an open-source project developed by WKS Power.
- * 
+ *
  * WKS Platform is licensed under the MIT License.
- * 
+ *
  * © 2021 WKS Power. All rights reserved.
- * 
+ *
  * For licensing information, see the LICENSE file in the root directory of the project.
  */
 package com.wks.api.client.gateway;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -23,19 +31,38 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 /**
- * @author victor.franca
+ * Adds a Keycloak bearer token to every outbound case-api request.
+ * <p>
+ * The token is cached and reused until shortly before it expires, instead of being re-fetched
+ * on every request. This removes a full Keycloak round-trip from each external-task execution
+ * (the original implementation POSTed to the token endpoint on every call with a fresh, unpooled
+ * {@link RestTemplate}). The token endpoint itself is now called through a pooled HTTP client
+ * with explicit timeouts, so a slow/stale Keycloak connection cannot hang a worker indefinitely.
  *
+ * @author victor.franca
  */
 @Component
 public class AuthInterceptor implements ClientHttpRequestInterceptor {
+
+	private static final int TOKEN_CONNECT_TIMEOUT_MS = 2000;
+	private static final int TOKEN_CONNECTION_REQUEST_TIMEOUT_MS = 2000;
+	private static final int TOKEN_SOCKET_TIMEOUT_MS = 5000;
+
+	/** Refresh the token this many ms before it actually expires, to absorb clock skew / in-flight calls. */
+	private static final long TOKEN_EXPIRY_SKEW_MS = 30_000L;
+
+	/** Fallback TTL when the token response has no {@code expires_in}. */
+	private static final long DEFAULT_TOKEN_TTL_MS = 60_000L;
 
 	@Value("${wks-case-api.auth.url}")
 	private String authUrl;
@@ -49,15 +76,42 @@ public class AuthInterceptor implements ClientHttpRequestInterceptor {
 	@Value("${wks-case-api.auth.grant_type}")
 	private String grantType;
 
+	/** Dedicated, pooled client for the token endpoint (separate from the case-api RestTemplate). */
+	private final RestTemplate tokenRestTemplate = createTokenRestTemplate();
+
+	private final Object tokenLock = new Object();
+	private volatile String cachedToken;
+	private volatile long tokenExpiresAtMillis = 0L;
+
 	@Override
 	public ClientHttpResponse intercept(final HttpRequest request, final byte[] body,
 			final ClientHttpRequestExecution execution) throws IOException {
-		HttpHeaders headers = request.getHeaders();
-		headers.add("Authorization", "Bearer " + getBearerToken());
+		request.getHeaders().set(HttpHeaders.AUTHORIZATION, "Bearer " + getBearerToken());
 		return execution.execute(request, body);
 	}
 
+	/**
+	 * Eagerly fetch and cache a token. Intended to be called at application startup so the first
+	 * real request does not pay the cold-start cost (TLS handshake + token fetch against Keycloak).
+	 */
+	public void prefetchToken() {
+		getBearerToken();
+	}
+
 	private String getBearerToken() {
+		String token = cachedToken;
+		if (token != null && System.currentTimeMillis() < tokenExpiresAtMillis) {
+			return token;
+		}
+		synchronized (tokenLock) {
+			if (cachedToken != null && System.currentTimeMillis() < tokenExpiresAtMillis) {
+				return cachedToken;
+			}
+			return fetchAndCacheToken();
+		}
+	}
+
+	private String fetchAndCacheToken() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
@@ -68,18 +122,43 @@ public class AuthInterceptor implements ClientHttpRequestInterceptor {
 
 		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(requestBody, headers);
 
-		RestTemplate restTemplate = new RestTemplate();
+		ResponseEntity<String> responseEntity = tokenRestTemplate.postForEntity(authUrl, request, String.class);
 
-		ResponseEntity<String> responseEntity = restTemplate.postForEntity(authUrl, request, String.class);
-
-		if (responseEntity.getStatusCode() == HttpStatus.OK) {
-			String responseBody = responseEntity.getBody();
-			String accessToken = JsonParser.parseString(responseBody).getAsJsonObject().get("access_token")
-					.getAsString();
-			return accessToken;
-		} else {
+		if (responseEntity.getStatusCode() != HttpStatus.OK) {
 			throw new RuntimeException("Failed to retrieve token");
 		}
+
+		JsonObject json = JsonParser.parseString(responseEntity.getBody()).getAsJsonObject();
+		String accessToken = json.get("access_token").getAsString();
+
+		long ttlMs = json.has("expires_in") ? json.get("expires_in").getAsLong() * 1000L : DEFAULT_TOKEN_TTL_MS;
+		long effectiveTtlMs = Math.max(ttlMs - TOKEN_EXPIRY_SKEW_MS, 0L);
+
+		cachedToken = accessToken;
+		tokenExpiresAtMillis = System.currentTimeMillis() + effectiveTtlMs;
+		return accessToken;
+	}
+
+	private static RestTemplate createTokenRestTemplate() {
+		ConnectionConfig connectionConfig = ConnectionConfig.custom()
+				.setConnectTimeout(Timeout.of(TOKEN_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+				.setSocketTimeout(Timeout.of(TOKEN_SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+				.build();
+
+		PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+				.setDefaultConnectionConfig(connectionConfig)
+				.build();
+
+		RequestConfig requestConfig = RequestConfig.custom()
+				.setConnectionRequestTimeout(Timeout.of(TOKEN_CONNECTION_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+				.build();
+
+		CloseableHttpClient httpClient = HttpClients.custom()
+				.setConnectionManager(connectionManager)
+				.setDefaultRequestConfig(requestConfig)
+				.build();
+
+		return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
 	}
 
 }

--- a/apps/java/libraries/case-engine-rest-client/src/main/java/com/wks/api/client/gateway/RestTemplateConfig.java
+++ b/apps/java/libraries/case-engine-rest-client/src/main/java/com/wks/api/client/gateway/RestTemplateConfig.java
@@ -1,18 +1,26 @@
 /*
  * WKS Platform - Open-Source Project
- * 
+ *
  * This file is part of the WKS Platform, an open-source project developed by WKS Power.
- * 
+ *
  * WKS Platform is licensed under the MIT License.
- * 
+ *
  * © 2021 WKS Power. All rights reserved.
- * 
+ *
  * For licensing information, see the LICENSE file in the root directory of the project.
  */
 package com.wks.api.client.gateway;
 
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,18 +28,44 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 /**
+ * Builds the case-api {@link RestTemplate} backed by a pooled HTTP client with explicit
+ * connect/socket timeouts. Connection pooling avoids per-call connection warmup (notably on the
+ * cold first request), and the socket timeout prevents a stale/hung case-api connection from
+ * blocking a worker indefinitely.
+ *
  * @author victor.franca
  */
 @Configuration
 public class RestTemplateConfig {
-	
+
+	private static final int CONNECT_TIMEOUT_MS = 5000;
+	private static final int CONNECTION_REQUEST_TIMEOUT_MS = 5000;
+	private static final int SOCKET_TIMEOUT_MS = 30000;
+
 	@Autowired
 	AuthInterceptor authInterceptor;
 
 	@Bean
 	public RestTemplate getRestTemplate() {
-		RestTemplate restTemplate = new RestTemplate();
-		restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+		ConnectionConfig connectionConfig = ConnectionConfig.custom()
+				.setConnectTimeout(Timeout.of(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+				.setSocketTimeout(Timeout.of(SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+				.build();
+
+		PoolingHttpClientConnectionManager connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+				.setDefaultConnectionConfig(connectionConfig)
+				.build();
+
+		RequestConfig requestConfig = RequestConfig.custom()
+				.setConnectionRequestTimeout(Timeout.of(CONNECTION_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+				.build();
+
+		CloseableHttpClient httpClient = HttpClients.custom()
+				.setConnectionManager(connectionManager)
+				.setDefaultRequestConfig(requestConfig)
+				.build();
+
+		RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
 		restTemplate.setInterceptors(Collections.singletonList(authInterceptor));
 		return restTemplate;
 	}

--- a/apps/java/services/c7-external-tasks/application.yml
+++ b/apps/java/services/c7-external-tasks/application.yml
@@ -17,8 +17,15 @@ camunda.bpm.client:
   base-url: ${CAMUNDA_BASE_URL:http://localhost:8080/engine-rest}
   disable-backoff-strategy: ${DISABLE_BACKOFF_STRATEGY:true}
   max-tasks: 1
-  async-response-timeout: 120000
-  lock-duration: 500
+  # Long-poll hold time. Caps the worst-case pickup latency if the engine's fetch-and-lock
+  # request is not woken for a newly-created task (or the long-poll connection goes stale):
+  # the client re-polls at most every async-response-timeout. Keep low (10s) so a missed
+  # notification costs seconds, not minutes, and stale connections recycle quickly.
+  async-response-timeout: ${CAMUNDA_ASYNC_RESPONSE_TIMEOUT:10000}
+  # Time a fetched task stays locked while the worker runs. Must exceed real worker execution
+  # (Keycloak token + case-api HTTP round-trips, slow on a cold first call). 500ms was far too
+  # short, causing the lock to expire mid-execution -> complete() fails -> retry loop.
+  lock-duration: ${CAMUNDA_LOCK_DURATION:60000}
   basic-auth:
     username: ${CAMUNDA_USERNAME:demo}
     password: ${CAMUNDA_PASSWORD:demo}

--- a/apps/java/services/c7-external-tasks/src/main/java/com/wks/bpm/externaltask/CaseApiClientWarmUp.java
+++ b/apps/java/services/c7-external-tasks/src/main/java/com/wks/bpm/externaltask/CaseApiClientWarmUp.java
@@ -1,0 +1,47 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.bpm.externaltask;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.wks.api.client.gateway.AuthInterceptor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Pre-fetches the case-api Keycloak token at startup so the first external task does not pay the
+ * cold-start cost (JVM warmup + TLS handshake + token fetch) while holding its lock. Failure here
+ * is non-fatal: the first real request will fetch a token on demand.
+ *
+ * @author victor.franca
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CaseApiClientWarmUp {
+
+	private final AuthInterceptor authInterceptor;
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void warmUp() {
+		try {
+			authInterceptor.prefetchToken();
+			log.info("Pre-fetched case-api auth token at startup");
+		} catch (Exception e) {
+			log.warn("Startup case-api token pre-fetch failed; first task will fetch on demand", e);
+		}
+	}
+
+}


### PR DESCRIPTION
## Why

The first Camunda external task after an idle period took **minutes** to be picked up and completed — sometimes long enough that operators had to restart Camunda **and** the c7-external-tasks worker, after which tasks were picked up instantly. While investigating, the worker was also found to **fail to start** under Spring Boot 4.

## Latency

The worker can only fetch a task that already exists, and pickup is a long-poll. The fixes attack each segment of the path:

- **`application.yml`** — `async-response-timeout` `120000 → 10000`: caps worst-case pickup when an in-flight fetch-and-lock isn't woken for a newly-created task (or the long-poll connection has gone stale), which matches the "few minutes, restart fixes it" symptom. `lock-duration` `500 → 60000`: 500ms was shorter than real worker execution (Keycloak token + case-api round-trips), so the lock expired mid-execution → `complete()` failed → retry loop.
- **`AuthInterceptor`** — cache the Keycloak token until shortly before expiry instead of POSTing a fresh token on every request; the token endpoint now uses a pooled client with timeouts.
- **`RestTemplateConfig`** — back the case-api `RestTemplate` with a pooled HTTP client + connect/socket timeouts (mirrors the existing `OpenPolicyAuthzEnforcer`).
- **`CaseApiClientWarmUp`** (new) — pre-fetch a token on `ApplicationReadyEvent` so the first task doesn't pay cold-start while holding its lock.

## Startup fix

The worker failed to boot with `NoClassDefFoundError: AuthenticationManagerResolver` while introspecting `KeycloakAuthnConfig`. `api-security` declares spring-security at `provided` scope, but the worker scans `com.wks.api.security` and pulls in security/authz configs whose `@Bean` types reference spring-security classes it doesn't bundle. The spring-security-requiring configs are now guarded with `@ConditionalOnClass` so non-security consumers skip them cleanly. Secured services (e.g. `case-engine-rest-api`) bundle spring-security, so the conditions still pass and their behaviour is unchanged.

## Verification

- Full reactor compiles (`api-security`, `c7-external-tasks`, `case-engine-rest-api`).
- Dependency tree confirms all `spring-security-*` are `provided` on the worker (absent at runtime) → `@ConditionalOnClass` guards evaluate false → configs skipped → the startup crash cannot recur.
- ⚠️ Not yet exercised end-to-end against a live Camunda + Keycloak; the latency improvement should be confirmed with a Docker run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)