### PR TITLE
fix(storage-api): pin okhttp to 4.12.0 so minio driver boots

### DIFF
--- a/apps/java/services/storage-api/pom.xml
+++ b/apps/java/services/storage-api/pom.xml
@@ -50,6 +50,18 @@
 			<artifactId>minio</artifactId>
 			<version>8.6.0</version>
 		</dependency>
+
+		<!-- minio 8.6.0 transitively pulls okhttp 5.x, whose JVM classes live in
+		     the okhttp-jvm artifact declared only via Gradle module metadata.
+		     Maven ignores that metadata and resolves only the okhttp stub jar,
+		     so the minio driver fails to boot (NoClassDefFoundError). Pin okhttp
+		     to the last single-jar 4.x, which is Maven-friendly and API-compatible
+		     with minio 8.6.0. -->
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>4.12.0</version>
+		</dependency>
 		
 		<dependency>
 			<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Problem

`storage-api:develop` is broken upstream — the container can't boot because the MinIO driver fails to initialize with a `NoClassDefFoundError`.

## Root cause

`storage-api` depends on minio 8.6.0, which transitively pulls **okhttp 5.1.0**. okhttp 5.x moved to a Kotlin-Multiplatform layout where the actual JVM classes live in the `okhttp-jvm` artifact, declared **only** in okhttp's Gradle module metadata. Maven ignores Gradle metadata, so it resolves just the `okhttp` stub jar (which contains no `OkHttpClient` classes) → the minio driver can't start.

(okio survives the same layout only because okio's POM declares `okio-jvm` as a real Maven dependency; okhttp's does not.)

## Fix

Pin `com.squareup.okhttp3:okhttp` to `4.12.0` — the last single-jar 4.x release, fully Maven-compatible and API-compatible with minio 8.6.0.

## Verification

- Dependency tree resolves to okhttp 4.12.0 / okio 3.6.0
- Resolved jar contains `okhttp3/OkHttpClient.class` (the 5.x stub had none)
- `clean package` compiles and bundles `BOOT-INF/lib/okhttp-4.12.0.jar` into the boot jar

🤖 Generated with [Claude Code](https://claude.com/claude-code)