### PR TITLE
fix(storage-api): resolve NoClassDefFoundError on okhttp3/RequestBody

### DIFF
--- a/apps/java/services/storage-api/pom.xml
+++ b/apps/java/services/storage-api/pom.xml
@@ -22,7 +22,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>4.12.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Summary:
 Resolves a startup failure in the storage-api service where the MinIO client was unable to find okhttp3 classes at runtime.

 Changes:
  - apps/java/services/storage-api/pom.xml: Removed the 'provided' scope from spring-boot-starter-web to ensure transitive dependencies are bundled.
  - apps/java/services/storage-api/pom.xml: Explicitly added okhttp 4.12.0 to ensure the MinIO client has its required networking library at runtime. 

This fix enables the storage-api to start correctly on port 8085, allowing   12 file uploads to work in the case portal.
