### PR TITLE
fix(java): set backend keycloak clients to confidential mode

### DIFF
--- a/apps/java/services/demo-data-loader/src/main/java/com/wks/caseengine/loader/runner/KeycloakDataImportCommandRunner.java
+++ b/apps/java/services/demo-data-loader/src/main/java/com/wks/caseengine/loader/runner/KeycloakDataImportCommandRunner.java
@@ -123,7 +123,7 @@ public class KeycloakDataImportCommandRunner implements CommandLineRunner {
 		ClientRepresentation externalTasksClient = new ClientRepresentation();
 		externalTasksClient.setClientId(externalTasksClientId);
 		externalTasksClient.setSecret(externalTasksSecret);
-		externalTasksClient.setPublicClient(true);
+		externalTasksClient.setPublicClient(false);
 		externalTasksClient.setProtocol("openid-connect");
 		externalTasksClient.setDirectAccessGrantsEnabled(true);
 		externalTasksClient.setStandardFlowEnabled(true);
@@ -140,7 +140,7 @@ public class KeycloakDataImportCommandRunner implements CommandLineRunner {
 		ClientRepresentation emailToCaseClient = new ClientRepresentation();
 		emailToCaseClient.setClientId(emailToCaseClientId);
 		emailToCaseClient.setSecret(emailToCaseSecret);
-		emailToCaseClient.setPublicClient(true);
+		emailToCaseClient.setPublicClient(false);
 		emailToCaseClient.setProtocol("openid-connect");
 		emailToCaseClient.setDirectAccessGrantsEnabled(true);
 		emailToCaseClient.setStandardFlowEnabled(true);


### PR DESCRIPTION
 This PR modifies the KeycloakDataImportCommandRunner in the demo-data-loader service to register backend clients (wks-external-tasks and wks-email-to-case) as confidential (non-public).

  Why
  Recent updates to the external task worker (c7-external-tasks) introduced mandatory token caching using the client_credentials grant type. In Keycloak, a client cannot be "public" and simultaneously use a client secret or service
  accounts. Because the loader was marking them as public, Keycloak rejected authentication requests with a 401 Unauthorized (unauthorized_client).

  Setting these to confidential allows them to correctly use their secrets and service account roles.

  How to verify
   1. Stop the stack: docker compose down
   2. Remove the existing Keycloak volume to trigger a fresh bootstrap: docker volume rm wks-platform_keycloak
   3. Rebuild and start: docker compose up -d --build demo-data-loader c7-external-tasks
   4. Check logs for c7-external-tasks: It should now successfully fetch a token and poll for tasks without authentication errors.

  Related Issues
  Fixes the 401 Unauthorized error reported during application startup.