### PR TITLE
fix(case-portal): fix add task button and Material UI imports

### DIFF
--- a/apps/react/case-portal/src/views/taskList/taskList.js
+++ b/apps/react/case-portal/src/views/taskList/taskList.js
@@ -2,11 +2,9 @@ import { AddCircleOutline, PlayCircle } from '@mui/icons-material'
 import { Box } from '@mui/material'
 import Button from '@mui/material/Button'
 import List from '@mui/material/List'
-import {
-  default as IconButton,
-  default as ListItem,
-} from '@mui/material/ListItem'
-import { default as ListItemSecondaryAction } from '@mui/material/ListItemIcon'
+import IconButton from '@mui/material/IconButton'
+import ListItem from '@mui/material/ListItem'
+import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction'
 import ListSubheader from '@mui/material/ListSubheader'
 import Modal from '@mui/material/Modal'
 import TextField from '@mui/material/TextField'
@@ -92,135 +90,131 @@ export const TaskList = ({ businessKey, callback }) => {
         {t('pages.caseform.actions.newTask')}
       </Button>
       {tasks && tasks.length > 0 && (
-        <React.Fragment>
-          <List
-            component='nav'
-            aria-labelledby='task-list'
-            subheader={
-              <ListSubheader component='div' id='nested-list-subheader'>
-                {t('pages.tasklist.upcoming')}
-              </ListSubheader>
-            }
-          >
-            {tasks.map((task) => (
-              <ListItem
-                key={task.id}
-                disablePadding
-                sx={{
-                  borderRadius: '5px',
-                  mb: 1,
-                  boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)', // Adding box shadow for differentiation
-                  backgroundColor: 'rgba(255, 255, 255, 0.5)', // Adding background color for differentiation
-                }}
-              >
-                <Box sx={{ p: 2, flex: 1 }}>
-                  <Typography variant='subtitle1'>{task.name}</Typography>
-                  {task.assignee && (
-                    <Typography variant='body2'>
-                      {t('pages.tasklist.datagrid.columns.assignee')}:{' '}
-                      {task.assignee}
-                    </Typography>
-                  )}
-                  {task.created && (
-                    <Typography variant='body2'>
-                      {t('pages.tasklist.datagrid.columns.created')}:{' '}
-                      {task.created}
-                    </Typography>
-                  )}
-                  {task.due && (
-                    <Typography variant='body2'>
-                      {t('pages.tasklist.datagrid.columns.due')}: {task.due}
-                    </Typography>
-                  )}
-                  {task.followUp && (
-                    <Typography variant='body2'>
-                      {t('pages.tasklist.datagrid.columns.followup')}:{' '}
-                      {task.followUp}
-                    </Typography>
-                  )}
-                </Box>
-                <ListItemSecondaryAction>
-                  <IconButton
-                    edge='end'
-                    aria-label='complete'
-                    onClick={() => {
-                      setTask(task)
-                      setOpen(true)
-                    }}
-                  >
-                    <PlayCircle color='primary' />
-                  </IconButton>
-                </ListItemSecondaryAction>
-              </ListItem>
-            ))}
-          </List>
-
-          <Modal open={isModalOpen} onClose={() => setModalOpen(false)}>
-            <Box
+        <List
+          component='nav'
+          aria-labelledby='task-list'
+          subheader={
+            <ListSubheader component='div' id='nested-list-subheader'>
+              {t('pages.tasklist.upcoming')}
+            </ListSubheader>
+          }
+        >
+          {tasks.map((task) => (
+            <ListItem
+              key={task.id}
+              disablePadding
               sx={{
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                transform: 'translate(-50%, -50%)',
-                bgcolor: 'background.paper',
-                boxShadow: 24,
-                p: 4,
-                minWidth: 400,
-                maxWidth: 600,
+                borderRadius: '5px',
+                mb: 1,
+                boxShadow: '0px 2px 4px rgba(0, 0, 0, 0.1)', // Adding box shadow for differentiation
+                backgroundColor: 'rgba(255, 255, 255, 0.5)', // Adding background color for differentiation
               }}
             >
-              <Typography variant='h6' component='h2' gutterBottom>
-                {t('pages.caseform.actions.newTask')}
-              </Typography>
-              <Box
-                sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
-              >
-                <TextField
-                  label={t('pages.tasklist.newTask.name')}
-                  value={newTaskData.name}
-                  onChange={(e) =>
-                    setNewTaskData({ ...newTaskData, name: e.target.value })
-                  }
-                />
-                <TextField
-                  label={t('pages.tasklist.newTask.description')}
-                  value={newTaskData.description}
-                  onChange={(e) =>
-                    setNewTaskData({
-                      ...newTaskData,
-                      description: e.target.value,
-                    })
-                  }
-                />
-                {/* <TextField
-                                    label={t('pages.tasklist.newTask.dueDate')}
-                                    value={newTaskData.due}
-                                    onChange={(e) =>
-                                        setNewTaskData({ ...newTaskData, due: e.target.value })
-                                    }
-                                /> */}
-                <TextField
-                  label={t('pages.tasklist.newTask.assignee')}
-                  value={newTaskData.assignee}
-                  onChange={(e) =>
-                    setNewTaskData({
-                      ...newTaskData,
-                      assignee: e.target.value,
-                    })
-                  }
-                />
-                <Button
-                  type='submit'
-                  variant='contained'
-                  onClick={handleNewTaskSubmit}
-                >
-                  Submit
-                </Button>
+              <Box sx={{ p: 2, flex: 1 }}>
+                <Typography variant='subtitle1'>{task.name}</Typography>
+                {task.assignee && (
+                  <Typography variant='body2'>
+                    {t('pages.tasklist.datagrid.columns.assignee')}:{' '}
+                    {task.assignee}
+                  </Typography>
+                )}
+                {task.created && (
+                  <Typography variant='body2'>
+                    {t('pages.tasklist.datagrid.columns.created')}:{' '}
+                    {task.created}
+                  </Typography>
+                )}
+                {task.due && (
+                  <Typography variant='body2'>
+                    {t('pages.tasklist.datagrid.columns.due')}: {task.due}
+                  </Typography>
+                )}
+                {task.followUp && (
+                  <Typography variant='body2'>
+                    {t('pages.tasklist.datagrid.columns.followup')}:{' '}
+                    {task.followUp}
+                  </Typography>
+                )}
               </Box>
-            </Box>
-          </Modal>
-        </React.Fragment>
+              <ListItemSecondaryAction>
+                <IconButton
+                  edge='end'
+                  aria-label='complete'
+                  onClick={() => {
+                    setTask(task)
+                    setOpen(true)
+                  }}
+                >
+                  <PlayCircle color='primary' />
+                </IconButton>
+              </ListItemSecondaryAction>
+            </ListItem>
+          ))}
+        </List>
       )}
+
+      <Modal open={isModalOpen} onClose={() => setModalOpen(false)}>
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            bgcolor: 'background.paper',
+            boxShadow: 24,
+            p: 4,
+            minWidth: 400,
+            maxWidth: 600,
+          }}
+        >
+          <Typography variant='h6' component='h2' gutterBottom>
+            {t('pages.caseform.actions.newTask')}
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+            <TextField
+              label={t('pages.tasklist.newTask.name')}
+              value={newTaskData.name}
+              onChange={(e) =>
+                setNewTaskData({ ...newTaskData, name: e.target.value })
+              }
+            />
+            <TextField
+              label={t('pages.tasklist.newTask.description')}
+              value={newTaskData.description}
+              onChange={(e) =>
+                setNewTaskData({
+                  ...newTaskData,
+                  description: e.target.value,
+                })
+              }
+            />
+            {/* <TextField
+                                label={t('pages.tasklist.newTask.dueDate')}
+                                value={newTaskData.due}
+                                onChange={(e) =>
+                                    setNewTaskData({ ...newTaskData, due: e.target.value })
+                                }
+                            /> */}
+            <TextField
+              label={t('pages.tasklist.newTask.assignee')}
+              value={newTaskData.assignee}
+              onChange={(e) =>
+                setNewTaskData({
+                  ...newTaskData,
+                  assignee: e.target.value,
+                })
+              }
+            />
+            <Button
+              type='submit'
+              variant='contained'
+              onClick={handleNewTaskSubmit}
+            >
+              Submit
+            </Button>
+          </Box>
+        </Box>
+      </Modal>
 
       {open && task && task.processInstanceId && (
         <TaskForm


### PR DESCRIPTION
### Description                                                                                                                                                                                                                        
    This PR fixes the issue where clicking the "Add Task" button inside the task tab of a case view had no effect if the case had no tasks.

 ### Changes                                                                                                                                                                                                                            
    - Moved the `<Modal>` containing the task form outside the `tasks && tasks.length > 0` condition block in taskList.js.
    - Corrected the import of `IconButton` and `ListItem` from `@mui/material/IconButton` and `@mui/material/ListItem` (they were previously both imported as default exports of `ListItem`).