### PR TITLE
fix(case-portal): display friendly message in empty start process dialog

### DIFF
--- a/apps/react/case-portal/src/i18n/en_us.js
+++ b/apps/react/case-portal/src/i18n/en_us.js
@@ -79,6 +79,7 @@ const defs = {
       },
       manualProcesses: {
         title: 'Choose a process to start',
+        noProcesses: 'No manual processes available for this stage',
       },
       validation: {
         pleaseCorrectErrors: 'Please correct the following errors in the form:',

--- a/apps/react/case-portal/src/i18n/pt_br.js
+++ b/apps/react/case-portal/src/i18n/pt_br.js
@@ -79,6 +79,7 @@ const defs = {
       },
       manualProcesses: {
         title: 'Selecione o processo para iniciar',
+        noProcesses: 'Nenhum processo manual disponível para esta etapa',
       },
       validation: {
         pleaseCorrectErrors:

--- a/apps/react/case-portal/src/views/caseForm/caseForm.js
+++ b/apps/react/case-portal/src/views/caseForm/caseForm.js
@@ -433,24 +433,32 @@ export const CaseForm = ({ open, handleClose, aCase, keycloak }) => {
               {t('pages.caseform.manualProcesses.title')}
             </DialogTitle>
             <List>
-              {manualInitProcessDefs.map((process, index) => (
-                <React.Fragment key={process.definitionKey}>
-                  <ListItem
-                    button
-                    onClick={() => startProcess(process.definitionKey)}
-                    sx={{
-                      '&:hover': {
-                        backgroundColor: 'action.hover',
-                      },
-                    }}
-                  >
-                    <ListItemText
-                      primary={process.name || process.definitionKey}
-                    />
-                  </ListItem>
-                  {index !== manualInitProcessDefs.length - 1 && <Divider />}
-                </React.Fragment>
-              ))}
+              {!manualInitProcessDefs || manualInitProcessDefs.length === 0 ? (
+                <ListItem>
+                  <ListItemText
+                    secondary={t('pages.caseform.manualProcesses.noProcesses')}
+                  />
+                </ListItem>
+              ) : (
+                manualInitProcessDefs.map((process, index) => (
+                  <React.Fragment key={process.definitionKey}>
+                    <ListItem
+                      button
+                      onClick={() => startProcess(process.definitionKey)}
+                      sx={{
+                        '&:hover': {
+                          backgroundColor: 'action.hover',
+                        },
+                      }}
+                    >
+                      <ListItemText
+                        primary={process.name || process.definitionKey}
+                      />
+                    </ListItem>
+                    {index !== manualInitProcessDefs.length - 1 && <Divider />}
+                  </React.Fragment>
+                ))
+              )}
             </List>
           </Dialog>
         )}


### PR DESCRIPTION
Show an empty state message in the "Start process" dialog when no manual process definitions are configured for the active stage. Previously, the dialog was rendered completely empty except for the title. Also, add translations for this empty state message in English (en_us) and Portuguese (pt_br).