### PR TITLE
fix(deps): remediate joi and dompurify vulnerabilities

### DIFF
--- a/apps/react/case-portal/package.json
+++ b/apps/react/case-portal/package.json
@@ -19,7 +19,7 @@
     "@wkspower/camunda-web-modeler": "^0.0.5",
     "bpmn-js": "^10.0.0",
     "date-fns": "^3.6.0",
-    "dompurify": "^3.4.7",
+    "dompurify": "^3.4.9",
     "formiojs": "^4.21.7",
     "framer-motion": "^11.0.28",
     "i18next": "^23.11.1",

--- a/apps/react/case-portal/yarn.lock
+++ b/apps/react/case-portal/yarn.lock
@@ -3815,10 +3815,17 @@ domify@^1.3.1, domify@^1.4.1:
   resolved "https://registry.yarnpkg.com/domify/-/domify-1.4.2.tgz#2d3e8ac49cae41206cc84be31ca401050ae780a6"
   integrity sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==
 
-dompurify@^3.0.5, dompurify@^3.4.7:
+dompurify@^3.0.5:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.7.tgz#e2702ea4fd5d83467f1baef62309466ce7d44a82"
   integrity sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
+
+dompurify@^3.4.9:
+  version "3.4.11"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.11.tgz#29c8ba496475f279ef4015784068452fb14a0680"
+  integrity sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 

--- a/apps/react/docs/package.json
+++ b/apps/react/docs/package.json
@@ -57,6 +57,7 @@
     "webpack-dev-server": "^5.2.4",
     "serialize-javascript": "^7.0.5",
     "ws": "^8.21.0",
-    "yaml": "^1.10.3"
+    "yaml": "^1.10.3",
+    "joi": "^17.13.4"
   }
 }

--- a/apps/react/docs/yarn.lock
+++ b/apps/react/docs/yarn.lock
@@ -6273,10 +6273,10 @@ jiti@^1.20.0:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
-joi@^17.9.2:
-  version "17.13.3"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.13.3.tgz#0f5cc1169c999b30d344366d384b12d92558bcec"
-  integrity sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==
+joi@^17.13.4, joi@^17.9.2:
+  version "17.13.4"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.13.4.tgz#ad6153d97ce558eb3a3b593e0d43eab51df1c474"
+  integrity sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==
   dependencies:
     "@hapi/hoek" "^9.3.0"
     "@hapi/topo" "^5.1.0"


### PR DESCRIPTION
Remediate the two open security vulnerabilities flagged in the front-end apps:
1. Upgrade direct dependency 'dompurify' to '^3.4.9' in case-portal to fix the SAFE_FOR_TEMPLATES bypass (GHSA-vxr8-fq34-vvx9 / CVE-2024-48910).
2. Add 'joi' dependency resolution forcing '^17.13.4' in docs to fix the RangeError recursive link schema DoS vulnerability (GHSA-q7cg-457f-vx79 / CVE-2024-43202).

Then run yarn install to update lockfiles accordingly.