### PR TITLE
docs: add Installation category landing page

### DIFF
--- a/apps/react/docs/docs/02-Installation/index.mdx
+++ b/apps/react/docs/docs/02-Installation/index.mdx
@@ -1,0 +1,18 @@
+---
+id: installation
+title: Installation
+---
+
+WKS Platform can be installed in two ways, depending on whether you want to get
+up and running quickly or set up a full local development environment.
+
+- **[Option 1 — Pre-built Docker Images](</docs/Installation/Option 1 Pre-built Docker Images/>)**: the
+  fastest way to try the platform. Spin everything up from pre-built Docker
+  images with all dependencies and services pre-configured. Recommended for
+  development or test environments.
+- **[Option 2 — Local Development Setup](</docs/Installation/Option 2 Local Development Setup/>)**: build
+  and run the platform locally for development, with full control over the
+  source and configuration.
+
+Pick the option that fits your goal and follow the steps in the corresponding
+guide.


### PR DESCRIPTION
## Problem

The README links to `https://docs.wkspower.com/docs/Installation/`, which returned a **404**. The `02-Installation/` docs folder is a bare category with no `index.mdx` (unlike `01-Introduction/`), so Docusaurus generated no routable page there — only the deeper option pages existed.

## Fix

Add an `index.mdx` landing page to `02-Installation/`, matching the `01-Introduction/` pattern. It briefly introduces and links to the two installation paths (pre-built Docker images / local dev setup).

This makes the README link resolve without changing the README.

## Verification

`yarn build` in `apps/react/docs` passes with **no broken links** (Docusaurus' broken-link check is what surfaced the original issue during development).

🤖 Generated with [Claude Code](https://claude.com/claude-code)