### PR TITLE
docs: document Docker Compose v2.20+ prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Spring Boot, React and Camunda.
 > The Docker Compose stack in this repo is for **local development only** — it is not
 > production-hardened.
 
+## Prerequisites
+
+- **Docker Compose v2.20.0 or newer** (check with `docker compose version`). The stack uses the
+  `required:` field in `depends_on`, which older versions reject with
+  `Additional property required is not allowed`. On Windows/macOS, update Docker Desktop; make sure
+  you invoke `docker compose` (the v2 plugin) rather than the legacy `docker-compose` v1 command.
+
 ## Quick start (full stack)
 
 Brings up the full stack — backend, case portal, and a demo seed — with images pulled from the


### PR DESCRIPTION
## What

Adds a **Prerequisites** section to the README calling out a minimum Docker Compose version.

## Why

The Compose stack uses the `required:` field inside `depends_on` (`docker-compose.yml:162-164`), added in the Compose spec **v2.20.0**. Older Docker Compose rejects it during validation with:

```
services.storage-api.depends_on.minio Additional property required is not allowed
```

This trips up users on older Docker Desktop (commonly Windows) following the install steps — it reads like a broken compose file, but it's just a version gap. The new section documents the minimum version, the `docker compose version` check, the exact error string (so it's searchable), and the `docker compose` v2-plugin vs legacy `docker-compose` v1 distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)