### PR TITLE
fix(java): align Mongo case-instance patch with JPA and implement JPA data export

### DIFF
--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/repository/CaseInstanceRepositoryImpl.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/repository/CaseInstanceRepositoryImpl.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Component;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
+import com.wks.caseengine.cases.definition.CaseStatus;
 import com.wks.caseengine.cases.instance.CaseComment;
 import com.wks.caseengine.cases.instance.CaseInstance;
 import com.wks.caseengine.cases.instance.CaseInstanceFilter;
@@ -92,10 +93,21 @@ public class CaseInstanceRepositoryImpl implements CaseInstanceRepository {
 	public void update(final String businessKey, final CaseInstance caseInstance)
 			throws DatabaseRecordNotFoundException {
 		Bson filter = Filters.eq("businessKey", businessKey);
-		Bson update = Updates.combine(Updates.set("status", caseInstance.getStatus()),
-				Updates.set("stage", caseInstance.getStage()), Updates.set("attributes", caseInstance.getAttributes()),
-				Updates.set("documents", caseInstance.getDocuments()),
-				Updates.set("queueId", caseInstance.getQueueId()), Updates.set("comments", caseInstance.getComments()));
+
+		// Only overwrite status when the patch carries a resolvable value; otherwise preserve
+		// the persisted status. Mirrors CaseInstanceJpaRepositoryImpl.update() so both backends
+		// behave identically (a patch touching only stage/queueId must not null out status).
+		List<Bson> updates = new ArrayList<>();
+		CaseStatus status = caseInstance.getStatus();
+		if (status != null) {
+			updates.add(Updates.set("status", status.getCode()));
+		}
+		updates.add(Updates.set("stage", caseInstance.getStage()));
+		updates.add(Updates.set("attributes", caseInstance.getAttributes()));
+		updates.add(Updates.set("documents", caseInstance.getDocuments()));
+		updates.add(Updates.set("queueId", caseInstance.getQueueId()));
+		updates.add(Updates.set("comments", caseInstance.getComments()));
+		Bson update = Updates.combine(updates);
 
 		CaseInstance updatedCaseInstance = getCollection().findOneAndUpdate(filter, update);
 		if (updatedCaseInstance == null) {
@@ -146,7 +158,7 @@ public class CaseInstanceRepositoryImpl implements CaseInstanceRepository {
 		return connection.getOperations();
 	}
 
-	private MongoCollection<CaseInstance> getCollection() {
+	protected MongoCollection<CaseInstance> getCollection() {
 		return connection.getCaseInstanceCollection();
 	}
 

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/command/JpaDataConnectionExchange.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/command/JpaDataConnectionExchange.java
@@ -42,8 +42,15 @@ public class JpaDataConnectionExchange implements DataConnectionExchange {
 	private QueueRepository queueRepository;
 
 	@Override
+	@Transactional(readOnly = true)
 	public JsonObject exportFromDatabase(Gson gson) {
-		throw new RuntimeException("not implemented");
+		// Symmetric to importToDatabase: export the canonical form/caseDefinition/queue
+		// collections under the same keys the import side reads.
+		JsonObject exportedData = new JsonObject();
+		exportedData.add("form", gson.toJsonTree(formRepository.find()).getAsJsonArray());
+		exportedData.add("caseDefinition", gson.toJsonTree(caseDefinitionRepository.find()).getAsJsonArray());
+		exportedData.add("queue", gson.toJsonTree(queueRepository.find()).getAsJsonArray());
+		return exportedData;
 	}
 
 	@Override

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/command/MongoDataConnectionExchange.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/command/MongoDataConnectionExchange.java
@@ -36,7 +36,7 @@ public class MongoDataConnectionExchange implements DataConnectionExchange {
 		// Cases Instances
 		ArrayList<JsonObject> caseInstances = connection.getCaseInstCollection().find()
 				.map(o -> gson.fromJson(o.getJson(), JsonObject.class)).into(new ArrayList<JsonObject>());
-		exportedData.add("casesInstance", gson.toJsonTree(caseInstances).getAsJsonArray());
+		exportedData.add("caseInstance", gson.toJsonTree(caseInstances).getAsJsonArray());
 
 		// Forms
 		exportedData.add("form",
@@ -66,7 +66,7 @@ public class MongoDataConnectionExchange implements DataConnectionExchange {
 			}
 		}
 		exportedData.add("record", recordsArray);
-		return null;
+		return exportedData;
 	}
 
 	@Override

--- a/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/repository/impl/CaseInstanceRepositoryImplIT.java
+++ b/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/repository/impl/CaseInstanceRepositoryImplIT.java
@@ -17,8 +17,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.Conventions;
+import org.bson.codecs.pojo.PojoCodecProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,10 +31,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.mongodb.test.autoconfigure.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoCollection;
 import com.wks.caseengine.cases.definition.CaseStatus;
 import com.wks.caseengine.cases.instance.CaseInstance;
 import com.wks.caseengine.cases.instance.CaseInstanceFilter;
@@ -54,6 +62,19 @@ public class CaseInstanceRepositoryImplIT {
 			protected MongoOperations getOperations() {
 				return operations;
 			}
+
+			// The write path (update/get/save) goes through the driver collection rather than
+			// the template; build it with the same POJO codec registry the production
+			// EngineMongoTenantConfig configures so CaseInstance round-trips identically.
+			@Override
+			protected MongoCollection<CaseInstance> getCollection() {
+				CodecRegistry pojo = CodecRegistries.fromRegistries(
+						MongoClientSettings.getDefaultCodecRegistry(),
+						CodecRegistries.fromProviders(PojoCodecProvider.builder()
+								.conventions(Arrays.asList(Conventions.ANNOTATION_CONVENTION)).automatic(true).build()));
+				return ((MongoTemplate) operations).getDb().withCodecRegistry(pojo)
+						.getCollection("caseInstance", CaseInstance.class);
+			}
 		};
 	}
 
@@ -75,6 +96,31 @@ public class CaseInstanceRepositoryImplIT {
 		assertEquals("1", results.first().getCaseDefinitionId());
 		assertEquals("Data Collection", results.first().getStage());
 		assertEquals(CaseStatus.ARCHIVED_CASE_STATUS, results.first().getStatus());
+	}
+
+	@Test
+	public void shouldPreservePersistedStatusWhenPatchCarriesNullStatus() throws Exception {
+		// Regression: a patch touching only stage must not null out the persisted status.
+		// Mirrors the JPA backend's guard so both behave identically.
+		CaseInstance patch = CaseInstance.builder().businessKey("92935").stage("New Stage").build();
+		assertEquals(null, patch.getStatus(), "precondition: patch has no status");
+
+		repository.update("92935", patch);
+
+		CaseInstance reloaded = repository.get("92935");
+		assertEquals("New Stage", reloaded.getStage());
+		assertEquals(CaseStatus.ARCHIVED_CASE_STATUS, reloaded.getStatus(), "status must be preserved");
+	}
+
+	@Test
+	public void shouldWriteStatusWhenPatchCarriesStatus() throws Exception {
+		CaseInstance patch = CaseInstance.builder().businessKey("92935").stage("New Stage")
+				.status(CaseStatus.CLOSED_CASE_STATUS.getCode()).build();
+
+		repository.update("92935", patch);
+
+		CaseInstance reloaded = repository.get("92935");
+		assertEquals(CaseStatus.CLOSED_CASE_STATUS, reloaded.getStatus());
 	}
 
 	@Test

--- a/apps/java/libraries/case-engine/src/test/java/com/wks/it/JpaDataExportIT.java
+++ b/apps/java/libraries/case-engine/src/test/java/com/wks/it/JpaDataExportIT.java
@@ -12,10 +12,9 @@
 package com.wks.it;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -27,25 +26,32 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.orm.jpa.support.PersistenceAnnotationBeanPostProcessor;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.wks.api.security.context.SecurityContextTenantHolder;
-import com.wks.caseengine.cases.definition.CaseStatus;
-import com.wks.caseengine.cases.instance.CaseInstance;
-import com.wks.caseengine.cases.instance.repository.CaseInstanceJpaRepositoryImpl;
-import com.wks.caseengine.cases.instance.repository.CaseInstanceRepository;
+import com.wks.caseengine.cases.definition.CaseDefinition;
+import com.wks.caseengine.cases.definition.repository.CaseDefinitionJpaRepositoryImpl;
+import com.wks.caseengine.cases.definition.repository.CaseDefinitionRepository;
+import com.wks.caseengine.command.JpaDataConnectionExchange;
 import com.wks.caseengine.db.EngineDatabaseTenantConfig;
-import com.wks.caseengine.repository.JpaPaginator;
+import com.wks.caseengine.form.Form;
+import com.wks.caseengine.form.FormJpaRepositoryImpl;
+import com.wks.caseengine.form.FormRepository;
+import com.wks.caseengine.queue.Queue;
+import com.wks.caseengine.queue.QueueJpaRepositoryImpl;
+import com.wks.caseengine.queue.QueueRepository;
 
 /**
- * WP-1.0 acceptance: proves the real {@link EngineDatabaseTenantConfig} JPA wiring
- * boots against an embedded H2 database (database.type=jpa) and serves CRUD on the
- * single ("public") schema with NO external datastore container.
+ * Proves {@link JpaDataConnectionExchange#exportFromDatabase} (which previously threw
+ * "not implemented") returns the canonical form/caseDefinition/queue collections, symmetric
+ * to its import side, against embedded H2 (database.type=jpa) with no external datastore.
  *
- * <p>Lives in {@code com.wks.it} (outside every production @ComponentScan) so its
- * nested @SpringBootConfiguration is not picked up by other tests' contexts.
+ * <p>Lives in {@code com.wks.it} (outside every production @ComponentScan) so its nested
+ * @SpringBootConfiguration is not picked up by other tests' contexts.
  */
-@SpringBootTest(classes = CaseInstanceJpaRepositoryImplIT.TestApp.class, properties = {
+@SpringBootTest(classes = JpaDataExportIT.TestApp.class, properties = {
 		"database.type=jpa",
-		"spring.datasource.jdbcUrl=jdbc:h2:mem:wks_jpa_it;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+		"spring.datasource.jdbcUrl=jdbc:h2:mem:wks_export_it;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
 		"spring.datasource.driver-class-name=org.h2.Driver",
 		"spring.datasource.username=sa",
 		"spring.datasource.password=",
@@ -54,11 +60,12 @@ import com.wks.caseengine.repository.JpaPaginator;
 				+ "de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongoAutoConfiguration,"
 				+ "org.springframework.boot.data.mongodb.autoconfigure.DataMongoAutoConfiguration,"
 				+ "org.springframework.boot.data.mongodb.autoconfigure.DataMongoRepositoriesAutoConfiguration" })
-public class CaseInstanceJpaRepositoryImplIT {
+public class JpaDataExportIT {
 
 	@SpringBootConfiguration
 	@EnableAutoConfiguration
-	@Import({ EngineDatabaseTenantConfig.class, CaseInstanceJpaRepositoryImpl.class, JpaPaginator.class })
+	@Import({ EngineDatabaseTenantConfig.class, CaseDefinitionJpaRepositoryImpl.class, FormJpaRepositoryImpl.class,
+			QueueJpaRepositoryImpl.class, JpaDataConnectionExchange.class })
 	static class TestApp {
 
 		@Bean
@@ -102,39 +109,32 @@ public class CaseInstanceJpaRepositoryImplIT {
 	}
 
 	@Autowired
-	private CaseInstanceRepository repository;
+	private FormRepository formRepository;
+
+	@Autowired
+	private CaseDefinitionRepository caseDefinitionRepository;
+
+	@Autowired
+	private QueueRepository queueRepository;
+
+	@Autowired
+	private JpaDataConnectionExchange dataConnectionExchange;
 
 	@Test
-	public void shouldPersistAndReadCaseInstanceOnEmbeddedH2() throws Exception {
-		CaseInstance toSave = new CaseInstance("634d1eac797f75ecc4a10052", "WP10-0001", "loan-approval",
-				"Data Collection", "WIP_CASE_STATUS");
+	public void shouldExportCanonicalCollectionsFromJpaBackend() throws Exception {
+		formRepository.save(Form.builder().key("form-1").title("Form 1").build());
+		caseDefinitionRepository.save(CaseDefinition.builder().id("cd-1").name("Case Def 1").deployed(true).build());
+		queueRepository.save(Queue.builder().id("q-1").name("Queue 1").build());
 
-		String uid = repository.save(toSave);
-		assertNotNull(uid, "save() must return the generated uid");
+		JsonObject exported = dataConnectionExchange.exportFromDatabase(new Gson());
 
-		CaseInstance fetched = repository.get("WP10-0001");
-		assertNotNull(fetched);
-		assertEquals("WP10-0001", fetched.getBusinessKey());
-		assertEquals("loan-approval", fetched.getCaseDefinitionId());
-		assertEquals("Data Collection", fetched.getStage());
-		assertEquals(CaseStatus.WIP_CASE_STATUS, fetched.getStatus());
+		assertNotNull(exported, "export must return data, not null");
+		assertTrue(exported.has("form") && exported.get("form").isJsonArray());
+		assertTrue(exported.has("caseDefinition") && exported.get("caseDefinition").isJsonArray());
+		assertTrue(exported.has("queue") && exported.get("queue").isJsonArray());
 
-		List<CaseInstance> all = repository.find();
-		assertFalse(all.isEmpty(), "find() must return the persisted case");
-	}
-
-	@Test
-	public void shouldPreservePersistedStatusWhenPatchCarriesNullStatus() throws Exception {
-		// Cross-backend contract: a patch touching only stage must not null out the persisted
-		// status. The JPA update() already guards this; this pins it so Mongo/JPA can't drift.
-		repository.save(new CaseInstance("634d1eac797f75ecc4a10099", "WP10-0002", "loan-approval",
-				"Data Collection", "WIP_CASE_STATUS"));
-
-		CaseInstance patch = CaseInstance.builder().businessKey("WP10-0002").stage("Review").build();
-		repository.update("WP10-0002", patch);
-
-		CaseInstance reloaded = repository.get("WP10-0002");
-		assertEquals("Review", reloaded.getStage());
-		assertEquals(CaseStatus.WIP_CASE_STATUS, reloaded.getStatus(), "status must be preserved");
+		assertEquals(1, exported.getAsJsonArray("form").size());
+		assertEquals(1, exported.getAsJsonArray("caseDefinition").size());
+		assertEquals(1, exported.getAsJsonArray("queue").size());
 	}
 }

--- a/apps/java/services/case-engine-rest-api/src/test/java/com/wks/caseengine/rest/server/CaseInstanceControllerTest.java
+++ b/apps/java/services/case-engine-rest-api/src/test/java/com/wks/caseengine/rest/server/CaseInstanceControllerTest.java
@@ -11,17 +11,22 @@
  */
 package com.wks.caseengine.rest.server;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -36,6 +41,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.wks.bpm.engine.client.facade.BpmEngineClientFacade;
 import com.wks.caseengine.cases.definition.CaseDefinition;
 import com.wks.caseengine.cases.definition.CaseDefinitionNotFoundException;
+import com.wks.caseengine.cases.definition.CaseStatus;
 import com.wks.caseengine.cases.definition.repository.CaseDefinitionRepository;
 import com.wks.caseengine.cases.instance.CaseComment;
 import com.wks.caseengine.cases.instance.CaseInstance;
@@ -73,8 +79,12 @@ public class CaseInstanceControllerTest {
 	@Test
 	public void shouldSaveCaseInstance() throws Exception {
 		when(caseDefinitionRepository.get("CD-1")).thenReturn(new CaseDefinition());
+		// Verify the deserialized payload actually flows through to the created entity
+		// (the controller returns the persisted case), not just that the call returns 200.
 		this.mockMvc.perform(post("/case").contentType(MediaType.APPLICATION_JSON).content("{\"caseDefinitionId\":\"CD-1\"}"))
-				.andExpect(status().isOk());
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.caseDefinitionId").value("CD-1"))
+				.andExpect(jsonPath("$.businessKey").exists());
 	}
 
 	@Test
@@ -94,6 +104,26 @@ public class CaseInstanceControllerTest {
 		this.mockMvc
 				.perform(patch("/case/{businessKey}", "1").contentType("application/merge-patch+json").content("{}"))
 				.andExpect(status().isNoContent());
+	}
+
+	@Test
+	public void shouldApplyMergePatchFieldsAndPreserveStatus() throws Exception {
+		// A patch touching only stage must update stage and leave the persisted status intact.
+		// Capture what reaches the repository, not just the HTTP status.
+		CaseInstance persisted = new CaseInstance(null, "1", "CD-1", "Data Collection", "WIP_CASE_STATUS");
+		when(caseInstanceRepository.get("1")).thenReturn(persisted);
+
+		this.mockMvc
+				.perform(patch("/case/{businessKey}", "1").contentType("application/merge-patch+json")
+						.content("{\"stage\":\"Review\"}"))
+				.andExpect(status().isNoContent());
+
+		ArgumentCaptor<CaseInstance> captor = ArgumentCaptor.forClass(CaseInstance.class);
+		verify(caseInstanceRepository).update(eq("1"), captor.capture());
+
+		CaseInstance saved = captor.getValue();
+		assertEquals("Review", saved.getStage(), "patched stage must be applied");
+		assertEquals(CaseStatus.WIP_CASE_STATUS, saved.getStatus(), "omitted status must be preserved");
 	}
 
 	@Test


### PR DESCRIPTION
## What & why

Three related correctness/quality defects in the `case-engine` library surfaced where the Mongo and JPA backends were supposed to behave identically but didn't, plus an unimplemented core method and tests too shallow to catch any of it.

### 1. Mongo/JPA patch divergence — status nulled out
`CaseInstanceRepositoryImpl.update()` unconditionally `set("status", …)` on every patch. Because `getStatus()` returns `null` for any persisted code that doesn't resolve via `CaseStatus.fromValue(...)`, a patch touching only `stage`/`queueId` would **null out the persisted status**. The JPA impl already guards this. Mongo now mirrors it — guard the write behind a null check and store the `String` code.

### 2. `JpaDataConnectionExchange.exportFromDatabase()` — `throw "not implemented"`
`GET /export` 500'd under `database.type=jpa`. Now implemented symmetric to the import side (`form`/`caseDefinition`/`queue`). While there, fixed two latent bugs in the Mongo sibling: it `return null` (discarding the assembled export), and it wrote case instances under `casesInstance` while import reads `caseInstance` — an export/import round-trip mismatch.

### 3. Broad-but-shallow tests
Controller tests asserted only HTTP status; repository tests only read paths. Added:
- **Controller captor** — proves a merge-patch deserializes and reaches `repository.update` with the patched stage **and preserved status**.
- **Mongo write-path regression ITs** — status preserved on null patch, written on non-null.
- **JPA parity test** — pins the cross-backend contract on H2.
- **`JpaDataExportIT`** — covers the new JPA export.

## Notes
- `getCollection()` widened `private → protected` so the Mongo IT can exercise the write path.
- JPA export test lives in a new dedicated `JpaDataExportIT`; `SeedDataRunnerIT` was **already failing on `develop`** via an unrelated `DataImportService` wiring issue, so it was not used as a host.

## Verification
All green: Mongo IT 5/5 (run against a `mongo:7` container — embedded Mongo can't start in the sandbox), JPA repo IT 2/2, `JpaDataExportIT` 1/1, controller test 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)