### PR TITLE
ci(deps): tame Dependabot to prevent PR floods

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,46 +1,76 @@
-# Dependabot keeps dependencies patched across the repo's three ecosystems.
-# Weekly to keep noise manageable; grouped minor/patch bumps so routine updates
-# land as a single reviewable PR instead of a flood.
+# Dependabot config, tuned for low noise.
+#
+# Policy: keep dependencies patched with as few PRs as possible.
+#  - Minor + patch bumps are grouped into ONE PR per ecosystem per week — safe,
+#    mergeable in a batch.
+#  - Major bumps are ignored here (no per-dependency PR nag). They are breaking
+#    by definition and are handled as deliberate, tested upgrade slices rather
+#    than a pile of standing PRs. Security-critical majors still surface through
+#    Dependabot security updates, which this `ignore` does not suppress.
+#  - Low open-PR limits so the queue can never flood again.
 version: 2
 updates:
-  # Java / Maven — the reactor is rooted at apps/java (parent pom).
+  # Java / Maven — reactor rooted at apps/java.
   - package-ecosystem: "maven"
     directory: "/apps/java"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     groups:
-      maven-minor-patch:
+      maven:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   # Portal (React) — yarn workspace.
   - package-ecosystem: "npm"
     directory: "/apps/react/case-portal"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     groups:
-      npm-minor-patch:
+      npm:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   # The published config Standard package.
   - package-ecosystem: "npm"
     directory: "/packages/case-config-schema"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     groups:
-      npm-minor-patch:
+      npm:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
-  # Keep the GitHub Actions themselves current.
+  # Keep the GitHub Actions current — grouped, low volume.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Fixes the 22-PR flood from Dependabot's first run (backlog dumped all at once, majors as individual PRs).

**Retune for low noise:**
- Group minor + patch into **one PR per ecosystem per week** (safe, batch-mergeable).
- **Ignore major** version-update PRs — breaking by definition; handle them as deliberate, tested upgrade slices instead of a standing PR pile. Dependabot **security** updates are *not* suppressed by this, so critical majors still surface.
- Low `open-pull-requests-limit` per ecosystem so the queue can't flood again.

The 22 backlog PRs (#506–#527) have been closed. Once this merges, Dependabot regenerates at most a handful of tidy grouped PRs.

Not a draft — safe to merge whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)