### PR TITLE
feat(portal): document storage modes + durable storage reference (DMS slice 2)

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -97,7 +97,13 @@ WKS_CORS_ALLOWED_ORIGINS=http://localhost:3001
 REACT_APP_AUTH_ISSUER_URL=http://localhost:8082
 REACT_APP_API_URL=http://localhost:8081
 REACT_APP_STORAGE_URL=http://localhost:8085
-## Storage flow the portal speaks: minio (presigned, also DigitalOcean) or filesystem (MinIO-free driver)
+## Storage flow the portal speaks (three-leg contract: REACT_APP_STORAGE_MODE ->
+## __SERVER_STORAGE_MODE__ -> window.STORAGE_MODE):
+##   minio      - presigned object storage (also DigitalOcean); needs the `storage` profile
+##   filesystem - MinIO-free local-disk driver; needs the `storage-fs` profile
+##   inline     - NO storage-api at all: bytes ride on the case document as base64. This is the
+##                minimal (app,portal) deployment option — small docs / demos only (base64 is
+##                ~33% larger and not for large files or high volume; use minio for production).
 REACT_APP_STORAGE_MODE=minio
 REACT_APP_WEBSOCKETS_ENABLED=false
 REACT_APP_WEBSOCKETS_URL=ws://localhost:8484

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ docker compose up -d --build
 
 Then open [http://localhost:3001](http://localhost:3001) — you're logged in automatically.
 
+Document upload works in this mode with no storage-api: set `REACT_APP_STORAGE_MODE=inline` and
+attachment bytes are stored base64 on the case document itself (small docs / demos — use `minio`
+or `filesystem` for production). See the [Document Storage Modes docs](https://docs.wkspower.com/docs/Working%20on%20ACM/Case%20Definition/Reference/document-storage).
+
 ---
 
 For every other configuration — per-concern toggles, filesystem storage, notifications, Traefik,

--- a/apps/java/libraries/case-engine-rest-dto/src/main/java/com/wks/api/dto/CaseDocumentDto.java
+++ b/apps/java/libraries/case-engine-rest-dto/src/main/java/com/wks/api/dto/CaseDocumentDto.java
@@ -36,6 +36,12 @@ public class CaseDocumentDto {
 
 	private String base64;
 
+	/** Storage mode: {@code minio} / {@code filesystem} (storage-api) or {@code inline} (bytes in base64). */
+	private String storage;
+
+	/** Directory/prefix within the tenant storage-api bucket; with {@code name} addresses the object. */
+	private String dir;
+
 	/**
 	 * Optional id of the case-definition {@code requiredDocuments} entry this
 	 * document satisfies. Null for a free-form attachment.

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/CaseDocument.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/CaseDocument.java
@@ -32,7 +32,29 @@ public class CaseDocument {
 
 	private String size;
 
+	/**
+	 * Inline document bytes, base64-encoded. Populated only in the {@code inline}
+	 * storage mode (the minimal, no-storage-api deployment); null when the bytes
+	 * live in storage-api (see {@link #storage} / {@link #dir}). The engine never
+	 * reads this — it is a passive metadata bag; the portal decides how to store
+	 * and retrieve the bytes.
+	 */
 	private String base64;
+
+	/**
+	 * Where the document bytes live: {@code minio} or {@code filesystem} (bytes in
+	 * storage-api, addressed by {@link #dir} + {@link #name}) or {@code inline}
+	 * (bytes in {@link #base64}). Null on legacy documents predating this field —
+	 * treated as a storage-api object by the portal for backward compatibility.
+	 */
+	private String storage;
+
+	/**
+	 * Directory/prefix within the tenant's storage-api bucket (e.g. {@code cases}).
+	 * Together with {@link #name} it addresses the stored object for download.
+	 * Unused in {@code inline} mode.
+	 */
+	private String dir;
 
 	/**
 	 * Optional id of the {@code requiredDocuments} entry on the case definition

--- a/apps/react/case-portal/src/consts/index.js
+++ b/apps/react/case-portal/src/consts/index.js
@@ -14,6 +14,10 @@ const Config = {
     window.AUTH_ISSUER_URL,
   ),
   StorageUrl: getEnv(process.env.REACT_APP_STORAGE_URL, window.STORAGE_URL),
+  // How case documents are stored:
+  //   'minio' | 'filesystem' — bytes go to storage-api (needs the storage profile);
+  //   'inline'               — bytes travel on the document as base64, no storage-api
+  //                            (the minimal, no-storage-api deployment).
   StorageMode:
     getEnv(process.env.REACT_APP_STORAGE_MODE, window.STORAGE_MODE) || 'minio',
   WebsocketsEnabled: getEnv(

--- a/apps/react/case-portal/src/services/FileService.js
+++ b/apps/react/case-portal/src/services/FileService.js
@@ -56,6 +56,20 @@ function upload({ dir, file, progress, keycloak }) {
     })
   }
 
+  // Inline mode: the minimal, no-storage-api deployment. The bytes travel with
+  // the case document as base64 — nothing is uploaded to storage-api.
+  if (Config.StorageMode === 'inline') {
+    return readAsBase64(file).then((base64) => ({
+      storage: 'inline',
+      dir: dir,
+      name: file.name,
+      url: file.name,
+      size: file.size,
+      type: file.type,
+      base64: base64,
+    }))
+  }
+
   if (Config.StorageMode === 'filesystem') {
     const bucket = dir || 'files'
     const fd = new FormData()
@@ -94,6 +108,27 @@ function upload({ dir, file, progress, keycloak }) {
 }
 
 function download(file, keycloak) {
+  // Inline document: bytes are carried on the document itself (base64), so there
+  // is no storage-api round-trip. Keyed off the persisted `storage` marker (with
+  // a defensive fallback to a present base64 payload).
+  if (file.storage === 'inline' || (file.base64 && !file.storage)) {
+    const blob = base64ToBlob(file.base64, file.type)
+    const downloadUrl = window.URL.createObjectURL(blob)
+
+    const anchor = document.createElement('a')
+    document.body.appendChild(anchor)
+    anchor.href = downloadUrl
+    anchor.download = file.name
+
+    anchor.click()
+
+    setTimeout(() => {
+      window.URL.revokeObjectURL(downloadUrl)
+      document.body.removeChild(anchor)
+    }, 0)
+    return Promise.resolve()
+  }
+
   if (Config.StorageMode === 'filesystem') {
     const bucket = file.dir || 'files'
     const url = `${Config.StorageUrl}/storage/filesystem/${encodeURIComponent(
@@ -160,4 +195,29 @@ function createHeaders(keycloak) {
       Authorization: `Bearer ${keycloak.token}`,
     },
   }
+}
+
+// Read a File into a bare base64 string (without the `data:...;base64,` prefix)
+// for inline storage mode.
+function readAsBase64(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result || ''
+      const comma = result.indexOf(',')
+      resolve(comma >= 0 ? result.slice(comma + 1) : result)
+    }
+    reader.onerror = () => reject(reader.error || 'Unable to read file')
+    reader.readAsDataURL(file)
+  })
+}
+
+// Decode a bare base64 string back into a Blob for inline-mode download.
+function base64ToBlob(base64, type) {
+  const binary = atob(base64 || '')
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return new Blob([bytes], { type: type || 'application/octet-stream' })
 }

--- a/apps/react/docs/docs/03-Working on ACM/04-Case Definition/02-Reference/05-document-storage.mdx
+++ b/apps/react/docs/docs/03-Working on ACM/04-Case Definition/02-Reference/05-document-storage.mdx
@@ -1,0 +1,65 @@
+---
+id: document-storage
+title: Document Storage Modes
+---
+
+Once a case declares its [required documents](./04-required-documents.mdx), the bytes of an
+uploaded file have to live *somewhere*. The portal picks **where** via a single deployment
+switch — the **storage mode** — and the case-engine records, on each `CaseDocument`, enough
+metadata (`storage` + `dir`) to find those bytes again on download.
+
+The case-engine itself stays a passive metadata bag: it stores *where* a document lives, not
+*how* it got there. Choosing a mode is a **deployment decision**, not a case-definition field.
+
+---
+
+## The three modes
+
+The portal reads the mode from `StorageMode` (env `REACT_APP_STORAGE_MODE`, surfaced to the
+browser as `window.STORAGE_MODE`; default `minio`).
+
+| Mode | Where bytes live | storage-api needed? | Compose profile | Use it for |
+|------|------------------|---------------------|-----------------|------------|
+| `minio` | Object storage via storage-api's MinIO driver (presigned uploads; also works against DigitalOcean Spaces) | ✅ yes | `storage` (storage-api **+** MinIO) | Production / the default full stack |
+| `filesystem` | Local disk via storage-api's filesystem driver (MinIO-free) | ✅ yes | `storage-fs` (storage-api alone) | On-prem / single-host deployments that want files on a mounted volume, no object store |
+| `inline` | Base64 on the `CaseDocument` itself — bytes travel with the document | ❌ no | *(none — omit the storage profile)* | The minimal, no-storage-api deployment; demos and small documents |
+
+Each stored document also carries a `dir` (bucket / path prefix, e.g. `"cases"`) so the mode
+plus the `dir` are enough to locate it at download time.
+
+---
+
+## `inline` — the no-storage-api minimal mode
+
+`inline` is the storage option for the **minimal deployment** (the `app,portal` recipe that
+omits the `storage`/`storage-fs` profile). Instead of shipping bytes to a separate service, the
+file is base64-encoded and persisted **on the case document** — so there is no MinIO, no
+filesystem volume, and no storage-api container to run. Upload still works end to end; the bytes
+just ride along with the document metadata.
+
+:::caution Size caveat — inline is for small documents and demos
+Base64 inflates payloads by ~33% and the encoded bytes are read and written together with the
+case document on every access. That's fine for small attachments and demo data, but it does not
+scale to large files or high volume. For production, or any non-trivial document sizes, use
+`minio` (or `filesystem`), which stream bytes through storage-api instead of embedding them.
+:::
+
+---
+
+## Choosing a mode
+
+- **Full / production stack** → `minio`. It's the default; run the `storage` profile.
+- **On-prem, object-store-free** → `filesystem`. Run the `storage-fs` profile and mount a volume.
+- **Minimal, nothing-but-engine-and-portal** → `inline`. No storage profile, no storage-api;
+  accept the small-document caveat above.
+
+Whichever mode is active, the portal, engine and (where present) storage-api must agree — the
+mode is set once, at the deployment's env layer (`REACT_APP_STORAGE_MODE` →
+`__SERVER_STORAGE_MODE__` → `window.STORAGE_MODE`). See the repo `.env-sample` and the **Minimal
+stack** recipe in the project README for the concrete env values.
+
+:::note Relationship to required documents
+Storage mode is orthogonal to the [required-documents](./04-required-documents.mdx) contract:
+the config declares *what* documents a case should carry; the storage mode decides *where* their
+bytes are kept. Any mode satisfies any requirement.
+:::

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@
 #  (camunda + c7-external-tasks), storage (minio + storage-api), storage-fs
 #  (storage-api alone, MinIO-free). App/aux profiles: app (case-engine-rest-api),
 #  portal, notifications, proxy, demo.
+#  Document storage mode (REACT_APP_STORAGE_MODE, default minio): minio needs the
+#  `storage` profile, filesystem needs `storage-fs`. `inline` needs NEITHER — bytes
+#  ride on the case document as base64 (minimal app,portal deploy; small docs/demos).
 #  Concern env knobs (defaults = full/secure): WKS_AUTH_MODE, WKS_AUTHZ_OPA_ENABLED,
 #  WKS_BPM_ENGINE, WKS_TENANCY_MULTI_TENANT, WKS_SEED_ENABLED, DRIVER_STORAGE_FACTORYCLASS;
 #  WKS_SPRING_PROFILES carries the jpa datasource (db-h2 / db-postgres). Any point on


### PR DESCRIPTION
## Document storage options — Slice 2 of the DMS roadmap

> **Stacked PR.** Base is `feat/dms-doc-requirements` (#533), not `develop`, because this slice edits the same `CaseDocument.java` / `Documents.js` that #533 changes and #533 isn't merged yet. **Retarget this PR's base to `develop` once #533 merges** (`gh pr edit --base develop`).

### Why
Exploration surfaced that `CaseDocument.base64` is effectively vestigial — the portal's `FileService.upload` already sends bytes to **storage-api in both `minio` and `filesystem` modes**, and nothing in `apps/java` reads `base64`. The real defect: the engine kept only `{name,type,size,base64}` and **dropped the `dir`/`storage` fields the portal sends**, so a document reloaded from the backend lost the reference `FileService.download` needs. And the minimal `app,portal` deployment has **no storage-api at all**, so uploads had nowhere to go.

### What
- **Durable storage reference (bug fix):** `CaseDocument` + `CaseDocumentDto` gain `storage` (`minio|filesystem|inline`) and `dir`. Documents now download reliably after reload.
- **New `inline` storage mode:** bytes ride on the document as base64, no storage-api — the minimal-deployment option. `FileService` gained an inline upload branch (base64 in-browser) and an inline download branch (base64 → blob), keyed off the persisted `storage` marker. For small docs / demos (base64 ≈ 33% larger); `minio`/`filesystem` stay for production.
- **Engine unchanged** — a passive metadata bag; the new fields persist via the existing Gson converter (JPA) + Mongo, exactly like slice 1's `requirementId`.
- **Docs/ops:** a storage-modes reference page; `.env-sample` / `docker-compose.yml` / `README.md` note `inline` as the minimal-mode option (comment-only — the `minio` default is unchanged).

### Storage modes
| Mode | Bytes live in | Needs | Use |
|---|---|---|---|
| `minio` (default) | storage-api MinIO driver (presigned) | `storage` profile | production |
| `filesystem` | storage-api local-disk driver | `storage-fs` profile | on-prem/single-host |
| `inline` (new) | base64 on the document | nothing | minimal `app,portal`; small docs/demos |

### Verification — all green
- `mvn -pl libraries/case-engine,libraries/case-engine-rest-dto -am compile`: **SUCCESS**
- Portal build (ESLint + Prettier + webpack): **green**
- Docs build (docusaurus): **green**
- **Backend contract smoke** (engine self-contained: `db-h2,auth-dev,authz-off,bpm-none,single-tenant`, real REST API, JPA path via `CaseDocumentListConverter`): **6/6** — `minio`-doc persists `storage=minio`+`dir=cases` (download reference survives reload), `inline`-doc persists `storage=inline`+`base64`, and slice 1's `requirementId` still round-trips (the stack composes).

### Backward compatibility
Legacy documents without `storage`/`dir` still route through the storage-api download path. No migration.

### Not covered
Portal UI click-through (upload in inline mode, download each mode) — build-verified; a visual pass on the running stacks is worth doing at review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)