### PR TITLE
fix(deps): revert unvetted Spring Boot 4.1 bump; fix malformed scope; hold SB in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,11 @@ updates:
       maven:
         patterns:
           - "*"
+        # Keep Spring Boot out of the grouped bump: a framework minor (e.g. 4.0->4.1)
+        # can change transitive versions and behaviour, so it should arrive as its own
+        # reviewable PR rather than folded into routine minor/patch updates.
+        exclude-patterns:
+          - "org.springframework.boot:*"
         update-types:
           - "minor"
           - "patch"

--- a/apps/java/libraries/case-engine/pom.xml
+++ b/apps/java/libraries/case-engine/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <scope>>42.5.0</scope>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/apps/java/pom.xml
+++ b/apps/java/pom.xml
@@ -26,7 +26,12 @@
 
         <servlet-api.version>2.5</servlet-api.version>
 
-        <spring.boot.version>4.1.0</spring.boot.version>
+        <!-- Pinned to 4.0.6. The 4.1.0 minor arrived unvetted in a grouped
+             Dependabot bump (#531) and regressed the (then-quarantined) embedded-Mongo
+             integration tests via its transitive Mongo-driver change. Dependabot now
+             holds Spring Boot minors out of the group so the 4.1 upgrade can be done
+             deliberately and verified. -->
+        <spring.boot.version>4.0.6</spring.boot.version>
         <!-- Tomcat security fix: CVE-2026-41293/43512/43515 (critical),
              43513/42498/41284 (high), 43514 (low) in tomcat-embed-core.
              The Spring Boot BOM is imported (not inherited), so overriding


### PR DESCRIPTION
## Remediates Dependabot #531 fallout

Dependabot's grouped maven bump **#531** auto-merged a Spring Boot **minor** (4.0.6 → 4.1.0) alongside routine updates. That minor changed the transitive **Mongo driver to 5.8.0**, which regresses the embedded-Mongo integration tests — and it slipped in **invisibly**, because those ITs were quarantined at the time, so #531's own CI never exercised them. (Surfaced when #535 un-quarantines them.)

### Changes
- **Pin `spring.boot.version` back to 4.0.6** — the Mongo driver returns to **5.6.5**, the known-good line. A deliberate, verified 4.1 upgrade can be its own PR later.
- **Fix a malformed dependency** #531 also introduced: `postgresql` `<scope>>42.5.0</scope>` → `runtime` (Maven was warning and silently treating it as compile scope, so the driver was being bundled instead of runtime-only).
- **Dependabot:** exclude `org.springframework.boot` from the grouped minor/patch bump, so framework minors arrive as their own reviewable PR instead of folded into routine updates. Prevents a repeat.

### Verification
`mvn clean verify` → **BUILD SUCCESS**; confirmed the Mongo driver resolves to **5.6.5** again.

Once this lands, I'll rebase **#535** (re-enable the 3 SB4 integration tests) on top — they pass on 4.0.6.

Not a draft — safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)