### PR TITLE
feat(case-engine): beyond-schema structural validation of config

### DIFF
--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/config/validation/ConfigStructuralValidator.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/config/validation/ConfigStructuralValidator.java
@@ -1,0 +1,81 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.config.validation;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.wks.caseengine.cases.definition.CaseDefinition;
+import com.wks.caseengine.cases.definition.CaseStage;
+import com.wks.caseengine.cases.definition.action.CaseAction;
+import com.wks.caseengine.cases.definition.action.CaseStageUpdateAction;
+import com.wks.caseengine.event.ActionHook;
+
+/**
+ * Beyond-schema structural checks — the internal consistency the JSON Schema can't
+ * express. Pure and self-contained (no repository access): it only cross-references
+ * fields within a single document. Repository-backed checks (e.g. does {@code formKey}
+ * reference an existing Form) are intentionally out of scope here to avoid create-order
+ * hazards; those belong at the command layer.
+ */
+@Component
+public class ConfigStructuralValidator {
+
+	/**
+	 * @return structural violations for {@code document} (empty when it is internally
+	 *         consistent). Only applies checks for types that have them today.
+	 */
+	public List<String> validate(ConfigDocType type, Object document) {
+		if (type == ConfigDocType.CASE_DEFINITION && document instanceof CaseDefinition caseDefinition) {
+			return validateCaseDefinition(caseDefinition);
+		}
+		return List.of();
+	}
+
+	private List<String> validateCaseDefinition(CaseDefinition caseDefinition) {
+		List<String> violations = new ArrayList<>();
+
+		Set<String> stageNames = new LinkedHashSet<>();
+		if (caseDefinition.getStages() != null) {
+			for (CaseStage stage : caseDefinition.getStages()) {
+				if (stage != null && stage.getName() != null) {
+					stageNames.add(stage.getName());
+				}
+			}
+		}
+
+		// A CASE_STAGE_UPDATE_ACTION moves a case to a stage BY NAME; that name must be
+		// one of the definition's own stages, or the hook can never transition the case.
+		if (caseDefinition.getCaseHooks() != null) {
+			for (ActionHook hook : caseDefinition.getCaseHooks()) {
+				if (hook == null || hook.getActions() == null) {
+					continue;
+				}
+				for (CaseAction action : hook.getActions()) {
+					if (action instanceof CaseStageUpdateAction stageAction) {
+						String target = stageAction.getNewStage();
+						if (target != null && !stageNames.contains(target)) {
+							violations.add("caseHook action targets stage '" + target
+									+ "' which is not one of the defined stages " + stageNames);
+						}
+					}
+				}
+			}
+		}
+
+		return violations;
+	}
+}

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/config/validation/ConfigValidationService.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/config/validation/ConfigValidationService.java
@@ -47,12 +47,15 @@ public class ConfigValidationService {
 	}
 
 	private final ConfigSchemaValidator validator;
+	private final ConfigStructuralValidator structuralValidator;
 	private final Gson gson;
 	private final Mode mode;
 
-	public ConfigValidationService(ConfigSchemaValidator validator, GsonBuilder gsonBuilder,
+	public ConfigValidationService(ConfigSchemaValidator validator,
+			ConfigStructuralValidator structuralValidator, GsonBuilder gsonBuilder,
 			@Value("${wks.config.validation.mode:enforce}") String mode) {
 		this.validator = validator;
+		this.structuralValidator = structuralValidator;
 		this.gson = gsonBuilder.create();
 		this.mode = parseMode(mode);
 		log.info("Config Standard validation mode: {}", this.mode);
@@ -81,7 +84,12 @@ public class ConfigValidationService {
 			return;
 		}
 
+		// Schema conformance first; only run the beyond-schema structural checks when the
+		// document is schema-valid (they assume well-formed input).
 		List<String> violations = validator.validate(type, toJsonNode(type, documentId, document));
+		if (violations.isEmpty()) {
+			violations = structuralValidator.validate(type, document);
+		}
 		if (violations.isEmpty()) {
 			return;
 		}

--- a/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/config/validation/CaseDefinitionServiceEnforcementTest.java
+++ b/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/config/validation/CaseDefinitionServiceEnforcementTest.java
@@ -42,7 +42,7 @@ class CaseDefinitionServiceEnforcementTest {
 	void setup() {
 		commandExecutor = mock(CommandExecutor.class);
 		ConfigValidationService validation = new ConfigValidationService(new ConfigSchemaValidator(),
-				new GsonBuilderFactory().getGsonBuilder(), "enforce");
+				new ConfigStructuralValidator(), new GsonBuilderFactory().getGsonBuilder(), "enforce");
 
 		service = new CaseDefinitionServiceImpl();
 		ReflectionTestUtils.setField(service, "commandExecutor", commandExecutor);

--- a/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/config/validation/ConfigStructuralValidatorTest.java
+++ b/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/config/validation/ConfigStructuralValidatorTest.java
@@ -1,0 +1,64 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.config.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.wks.caseengine.cases.definition.CaseDefinition;
+import com.wks.caseengine.cases.definition.CaseStage;
+import com.wks.caseengine.cases.definition.action.CaseStageUpdateAction;
+import com.wks.caseengine.tasks.event.complete.TaskCompleteHook;
+
+class ConfigStructuralValidatorTest {
+
+	private final ConfigStructuralValidator validator = new ConfigStructuralValidator();
+
+	private CaseDefinition caseDefWithHookTargeting(String targetStage) {
+		return CaseDefinition.builder()
+				.id("customer-support")
+				.name("Customer Support")
+				.formKey("cs-form")
+				.stages(List.of(
+						CaseStage.builder().id("0").index(0).name("Intake").build(),
+						CaseStage.builder().id("1").index(1).name("Resolution").build()))
+				.caseHooks(List.of(TaskCompleteHook.builder()
+						.actions(List.of(CaseStageUpdateAction.builder().newStage(targetStage).build()))
+						.build()))
+				.build();
+	}
+
+	@Test
+	void hookTargetingAnExistingStage_isValid() {
+		List<String> violations = validator.validate(ConfigDocType.CASE_DEFINITION,
+				caseDefWithHookTargeting("Resolution"));
+		assertTrue(violations.isEmpty(), () -> "expected no violations but got " + violations);
+	}
+
+	@Test
+	void hookTargetingAnUndefinedStage_isReported() {
+		List<String> violations = validator.validate(ConfigDocType.CASE_DEFINITION,
+				caseDefWithHookTargeting("Nonexistent"));
+		assertEquals(1, violations.size(), () -> "expected one violation but got " + violations);
+		assertTrue(violations.get(0).contains("Nonexistent"));
+	}
+
+	@Test
+	void otherDocTypes_haveNoStructuralChecks() {
+		assertTrue(validator.validate(ConfigDocType.FORM, new Object()).isEmpty());
+		assertTrue(validator.validate(ConfigDocType.CASE_DEFINITION, null).isEmpty());
+	}
+}

--- a/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/config/validation/ConfigValidationServiceTest.java
+++ b/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/config/validation/ConfigValidationServiceTest.java
@@ -31,7 +31,7 @@ import com.wks.caseengine.record.type.RecordType;
 class ConfigValidationServiceTest {
 
 	private ConfigValidationService service(String mode) {
-		return new ConfigValidationService(new ConfigSchemaValidator(),
+		return new ConfigValidationService(new ConfigSchemaValidator(), new ConfigStructuralValidator(),
 				new GsonBuilderFactory().getGsonBuilder(), mode);
 	}
 


### PR DESCRIPTION
## Follow-up (from Slice 3): structural validation

Adds the internal-consistency checks JSON Schema can't express, wired into the existing `ConfigValidationService` right after schema validation — same `enforce`/`warn`/`disabled` policy, same 400 path.

### First check: dangling stage references
A `CaseDefinition` `caseHook` with a `CASE_STAGE_UPDATE_ACTION` must target a stage **name** that exists in the definition's own `stages`. A hook pointing at a non-existent stage can never transition the case, so it's now rejected (e.g. `caseHook action targets stage 'Nonexistent' which is not one of the defined stages [Intake, Resolution]`).

### Design
- `ConfigStructuralValidator` is **pure / self-contained** — it only cross-references fields *within* one document, no repository access.
- **Deliberately not** doing repository-backed checks here (e.g. does `formKey` reference an existing Form). Those introduce create-order hazards (the seeder loads case-defs before forms) and belong at the command layer with `CommandContext` — kept as the remaining follow-up.

### Tests
- `ConfigStructuralValidatorTest` — valid target, dangling target, other doc types / null.
- Existing `ConfigValidationServiceTest` + `CaseDefinitionServiceEnforcementTest` updated for the new constructor and still green.

### Verification
`mvn clean verify` (full reactor) → **BUILD SUCCESS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)