### PR TITLE
feat(case-engine): document lifecycle — verify/reject with server-stamped actors (DMS slice 3)

### DIFF
--- a/apps/java/libraries/case-engine-rest-dto/src/main/java/com/wks/api/dto/CaseDocumentDto.java
+++ b/apps/java/libraries/case-engine-rest-dto/src/main/java/com/wks/api/dto/CaseDocumentDto.java
@@ -28,6 +28,9 @@ import lombok.Setter;
 @Builder
 public class CaseDocumentDto {
 
+	/** Server-assigned document id; addresses the document for lifecycle transitions. */
+	private String id;
+
 	private String name;
 
 	private String type;
@@ -47,5 +50,14 @@ public class CaseDocumentDto {
 	 * document satisfies. Null for a free-form attachment.
 	 */
 	private String requirementId;
+
+	/** Lifecycle status: received | verified | rejected (pending is portal-computed). */
+	private String status;
+
+	/** User id that uploaded the document (server-stamped). */
+	private String uploadedBy;
+
+	/** User id that verified/rejected the document (server-stamped). */
+	private String validatedBy;
 
 }

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/CaseDocument.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/CaseDocument.java
@@ -26,6 +26,20 @@ import lombok.ToString;
 @NoArgsConstructor
 public class CaseDocument {
 
+	/** Default status stamped when a document is uploaded. */
+	public static final String STATUS_RECEIVED = "received";
+	/** Status set when a validator accepts the document. */
+	public static final String STATUS_VERIFIED = "verified";
+	/** Status set when a validator rejects the document. */
+	public static final String STATUS_REJECTED = "rejected";
+
+	/**
+	 * Server-assigned identifier (assigned on upload). Addresses this document for
+	 * lifecycle transitions (see the document-status endpoint). Null on legacy
+	 * documents predating this field.
+	 */
+	private String id;
+
 	private String name;
 
 	private String type;
@@ -63,4 +77,18 @@ public class CaseDocument {
 	 * a free-form attachment not tied to a declared requirement.
 	 */
 	private String requirementId;
+
+	/**
+	 * Lifecycle status. Stored values: {@code received} (default, stamped on
+	 * upload), {@code verified}, {@code rejected}. ({@code pending} is a
+	 * portal-computed state for a declared-but-unfulfilled requirement — never
+	 * stored here.) Null on legacy documents predating this field.
+	 */
+	private String status;
+
+	/** User id (JWT {@code sub}) that uploaded the document, stamped server-side. */
+	private String uploadedBy;
+
+	/** User id (JWT {@code sub}) that verified/rejected the document, stamped server-side. */
+	private String validatedBy;
 }

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/CaseInstanceDocumentNotFoundException.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/CaseInstanceDocumentNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.cases.instance;
+
+public class CaseInstanceDocumentNotFoundException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final String DEFAULT_MESSAGE = "Case Instance Document not found";
+
+	public CaseInstanceDocumentNotFoundException() {
+		super(DEFAULT_MESSAGE);
+	}
+
+	public CaseInstanceDocumentNotFoundException(final String message) {
+		super(message);
+	}
+
+}

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/command/CreateCaseInstanceDocumentCmd.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/command/CreateCaseInstanceDocumentCmd.java
@@ -11,6 +11,8 @@
  */
 package com.wks.caseengine.cases.instance.command;
 
+import org.bson.types.ObjectId;
+
 import com.wks.caseengine.cases.instance.CaseDocument;
 import com.wks.caseengine.cases.instance.CaseInstance;
 import com.wks.caseengine.cases.instance.CaseInstanceNotFoundException;
@@ -39,6 +41,13 @@ public class CreateCaseInstanceDocumentCmd implements Command<CaseDocument> {
 		} catch (DatabaseRecordNotFoundException e) {
 			throw new CaseInstanceNotFoundException(e.getMessage(), e);
 		}
+
+		// Server-assigned lifecycle metadata: a stable id (so the document can later
+		// be addressed for status transitions), the received status, and the uploader
+		// taken from the security context (never trusted from the client).
+		document.setId(ObjectId.get().toString());
+		document.setStatus(CaseDocument.STATUS_RECEIVED);
+		commandContext.getSecurityContextTenantHolder().getUserId().ifPresent(document::setUploadedBy);
 
 		caseInstance.addDocument(document);
 

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/command/UpdateCaseInstanceDocumentStatusCmd.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/command/UpdateCaseInstanceDocumentStatusCmd.java
@@ -1,0 +1,81 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.cases.instance.command;
+
+import java.util.List;
+import java.util.Set;
+
+import com.wks.caseengine.cases.instance.CaseDocument;
+import com.wks.caseengine.cases.instance.CaseInstance;
+import com.wks.caseengine.cases.instance.CaseInstanceDocumentNotFoundException;
+import com.wks.caseengine.cases.instance.CaseInstanceNotFoundException;
+import com.wks.caseengine.command.Command;
+import com.wks.caseengine.command.CommandContext;
+import com.wks.caseengine.repository.DatabaseRecordNotFoundException;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * Transitions a single case document's lifecycle status (verify / reject) and
+ * stamps {@code validatedBy} from the security context. DB-agnostic: it loads the
+ * case, mutates the document in the embedded list and saves the whole instance, so
+ * it works identically on the Mongo and JPA persistence paths.
+ */
+@AllArgsConstructor
+public class UpdateCaseInstanceDocumentStatusCmd implements Command<Void> {
+
+	/** Statuses a validator may transition a document to via this command. */
+	private static final Set<String> ALLOWED_TARGET_STATUSES =
+			Set.of(CaseDocument.STATUS_VERIFIED, CaseDocument.STATUS_REJECTED);
+
+	private String businessKey;
+	private String documentId;
+	private String status;
+
+	@Override
+	public Void execute(final CommandContext commandContext) {
+		if (status == null || !ALLOWED_TARGET_STATUSES.contains(status)) {
+			throw new IllegalArgumentException(
+					"Unsupported document status '" + status + "'. Allowed: " + ALLOWED_TARGET_STATUSES);
+		}
+
+		CaseInstance caseInstance;
+		try {
+			caseInstance = commandContext.getCaseInstanceRepository().get(businessKey);
+		} catch (DatabaseRecordNotFoundException e) {
+			throw new CaseInstanceNotFoundException(e.getMessage(), e);
+		}
+
+		List<CaseDocument> documents = caseInstance.getDocuments();
+		CaseDocument document = documents == null ? null
+				: documents.stream()
+						.filter(d -> documentId != null && documentId.equals(d.getId()))
+						.findFirst()
+						.orElse(null);
+		if (document == null) {
+			throw new CaseInstanceDocumentNotFoundException(
+					"Document '" + documentId + "' not found on case '" + businessKey + "'");
+		}
+
+		document.setStatus(status);
+		commandContext.getSecurityContextTenantHolder().getUserId().ifPresent(document::setValidatedBy);
+
+		try {
+			commandContext.getCaseInstanceRepository().update(businessKey, caseInstance);
+		} catch (DatabaseRecordNotFoundException e) {
+			throw new CaseInstanceNotFoundException(e.getMessage(), e);
+		}
+
+		return null;
+	}
+
+}

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/service/CaseInstanceService.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/service/CaseInstanceService.java
@@ -33,6 +33,8 @@ public interface CaseInstanceService {
 
 	void saveDocument(final String businessKey, final CaseDocument document);
 
+	void updateDocumentStatus(final String businessKey, final String documentId, final String status);
+
 	void saveComment(final String businessKey, final CaseComment comment);
 
 	void updateComment(final String businessKey, final String commentId, final String body);

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/service/CaseInstanceServiceImpl.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/service/CaseInstanceServiceImpl.java
@@ -29,6 +29,7 @@ import com.wks.caseengine.cases.instance.command.PatchCaseInstanceCmd;
 import com.wks.caseengine.cases.instance.command.SaveCaseInstanceWithValuesCmd;
 import com.wks.caseengine.cases.instance.command.StartCaseInstanceWithValuesCmd;
 import com.wks.caseengine.cases.instance.command.UpdateCaseInstanceCommentCmd;
+import com.wks.caseengine.cases.instance.command.UpdateCaseInstanceDocumentStatusCmd;
 import com.wks.caseengine.command.CommandExecutor;
 import com.wks.caseengine.pagination.PageResult;
 
@@ -76,6 +77,12 @@ public class CaseInstanceServiceImpl implements CaseInstanceService {
 	@Transactional
 	public void saveDocument(final String businessKey, final CaseDocument document) {
 		commandExecutor.execute(new CreateCaseInstanceDocumentCmd(businessKey, document));
+	}
+
+	@Override
+	@Transactional
+	public void updateDocumentStatus(final String businessKey, final String documentId, final String status) {
+		commandExecutor.execute(new UpdateCaseInstanceDocumentStatusCmd(businessKey, documentId, status));
 	}
 
 	@Override

--- a/apps/java/services/case-engine-rest-api/src/main/java/com/wks/caseengine/rest/server/CaseInstanceController.java
+++ b/apps/java/services/case-engine-rest-api/src/main/java/com/wks/caseengine/rest/server/CaseInstanceController.java
@@ -11,8 +11,17 @@
  */
 package com.wks.caseengine.rest.server;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -23,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.google.gson.GsonBuilder;
 import com.wks.caseengine.cases.definition.CaseDefinitionNotFoundException;
@@ -30,6 +40,7 @@ import com.wks.caseengine.cases.instance.CaseComment;
 import com.wks.caseengine.cases.instance.CaseDocument;
 import com.wks.caseengine.cases.instance.CaseInstance;
 import com.wks.caseengine.cases.instance.CaseInstanceCommentNotFoundException;
+import com.wks.caseengine.cases.instance.CaseInstanceDocumentNotFoundException;
 import com.wks.caseengine.cases.instance.CaseInstanceFilter;
 import com.wks.caseengine.cases.instance.CaseInstanceNotFoundException;
 import com.wks.caseengine.cases.instance.service.CaseInstanceService;
@@ -50,6 +61,18 @@ public class CaseInstanceController {
 
 	@Autowired
 	private GsonBuilder gsonBuilder;
+
+	/**
+	 * When authorization is enabled, transitioning a document's status requires one
+	 * of these manager realm roles. When authorization is off (dev/minimal mode)
+	 * the check is skipped, so any authenticated caller may transition — the gate is
+	 * a natural no-op, matching the rest of the orthogonal core.
+	 */
+	private static final Set<String> DOCUMENT_VALIDATOR_ROLES =
+			Set.of("mgmt_case_def", "mgmt_form", "mgmt_record_type");
+
+	@Value("${wks.authz.opa.enabled:true}")
+	private boolean authorizationEnabled;
 
 	@GetMapping
 	public ResponseEntity<Object> find(@RequestParam(required = false) String status,
@@ -129,6 +152,40 @@ public class CaseInstanceController {
 			throw new RestResourceNotFoundException(e.getMessage());
 		}
 		return ResponseEntity.noContent().build();
+	}
+
+	/**
+	 * Transition a document's lifecycle status (verify / reject). The engine stamps
+	 * {@code validatedBy} from the security context; the request body carries only
+	 * the target {@code status}.
+	 */
+	@PatchMapping(value = "/{businessKey}/document/{documentId}/status")
+	public ResponseEntity<Void> updateDocumentStatus(@PathVariable final String businessKey,
+			@PathVariable final String documentId, @RequestBody final CaseDocument statusPatch) {
+
+		if (authorizationEnabled && !callerHasValidatorRole()) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+					"Transitioning a document status requires a manager role");
+		}
+
+		try {
+			caseInstanceService.updateDocumentStatus(businessKey, documentId, statusPatch.getStatus());
+		} catch (CaseInstanceNotFoundException | CaseInstanceDocumentNotFoundException e) {
+			throw new RestResourceNotFoundException(e.getMessage());
+		} catch (IllegalArgumentException e) {
+			throw new RestInvalidArgumentException(e.getMessage(), e);
+		}
+		return ResponseEntity.noContent().build();
+	}
+
+	private boolean callerHasValidatorRole() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+		if (auth instanceof JwtAuthenticationToken token
+				&& token.getToken().getClaim("realm_access") instanceof Map<?, ?> realmAccess
+				&& realmAccess.get("roles") instanceof Collection<?> roles) {
+			return roles.stream().map(String::valueOf).anyMatch(DOCUMENT_VALIDATOR_ROLES::contains);
+		}
+		return false;
 	}
 
 	@PostMapping(value = "/{businessKey}/comment")

--- a/apps/react/case-portal/src/services/CaseService.js
+++ b/apps/react/case-portal/src/services/CaseService.js
@@ -11,6 +11,7 @@ export const CaseService = {
   createCase,
   patch,
   addDocuments,
+  updateDocumentStatus,
   addComment,
   updateComment,
   deleteComment,
@@ -160,6 +161,26 @@ async function addDocuments(keycloak, businessKey, document) {
         Authorization: `Bearer ${keycloak.token}`,
       },
       body: JSON.stringify(document),
+    })
+    return nop(keycloak, resp)
+  } catch (e) {
+    console.log(e)
+    return await Promise.reject(e)
+  }
+}
+
+async function updateDocumentStatus(keycloak, businessKey, documentId, status) {
+  const url = `${Config.CaseEngineUrl}/case/${businessKey}/document/${documentId}/status`
+
+  try {
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${keycloak.token}`,
+      },
+      body: JSON.stringify({ status }),
     })
     return nop(keycloak, resp)
   } catch (e) {

--- a/apps/react/case-portal/src/views/caseForm/DocumentStatusChip.js
+++ b/apps/react/case-portal/src/views/caseForm/DocumentStatusChip.js
@@ -1,0 +1,18 @@
+import Chip from '@mui/material/Chip'
+
+const STATUS_COLORS = {
+  received: 'info',
+  verified: 'success',
+  rejected: 'error',
+  pending: 'warning',
+}
+
+function DocumentStatusChip({ status }) {
+  const value = status || 'received'
+  const color = STATUS_COLORS[value] || 'default'
+  const label = value.charAt(0).toUpperCase() + value.slice(1)
+
+  return <Chip size='small' color={color} label={label} />
+}
+
+export default DocumentStatusChip

--- a/apps/react/case-portal/src/views/caseForm/Documents.js
+++ b/apps/react/case-portal/src/views/caseForm/Documents.js
@@ -14,6 +14,7 @@ import Fade from '@mui/material/Fade'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import ListItemAvatar from '@mui/material/ListItemAvatar'
+import ListItemSecondaryAction from '@mui/material/ListItemSecondaryAction'
 import ListItemText from '@mui/material/ListItemText'
 import Snackbar from '@mui/material/Snackbar'
 import Typography from '@mui/material/Typography'
@@ -21,6 +22,8 @@ import { useSession } from 'SessionStoreContext'
 import React, { useState } from 'react'
 import Files from 'react-files'
 import { CaseService, FileService } from '../../services'
+import { accountStore } from '../../store'
+import DocumentStatusChip from './DocumentStatusChip'
 import CaseStore from './store'
 
 function Documents({ aCase, initialValue, requiredDocuments = [] }) {
@@ -29,6 +32,28 @@ function Documents({ aCase, initialValue, requiredDocuments = [] }) {
   const [percent, setPercent] = useState(0)
   const [messageError, setMessageError] = useState(null)
   const [filesUploaded, setFilesUploaded] = useState(initialValue)
+
+  const isManager = accountStore.isManagerUser(keycloak)
+
+  const handleUpdateStatus = (documentId, status) => {
+    CaseService.updateDocumentStatus(
+      keycloak,
+      aCase.businessKey,
+      documentId,
+      status,
+    )
+      .then(() => {
+        setFilesUploaded((current) =>
+          current.map((file) =>
+            file.id === documentId ? { ...file, status } : file,
+          ),
+        )
+      })
+      .catch((e) => {
+        console.log(e)
+        setMessageError(e)
+      })
+  }
 
   const handleChange = (files, requirementId) => {
     setFetching(true)
@@ -316,6 +341,37 @@ function Documents({ aCase, initialValue, requiredDocuments = [] }) {
                   secondary={file.size + 'KB'}
                   style={{ maxWidth: '80%' }}
                 />
+                <ListItemSecondaryAction>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <DocumentStatusChip status={file.status || 'received'} />
+                    {isManager && file.id && (
+                      <>
+                        <Button
+                          size='small'
+                          color='success'
+                          variant='outlined'
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            handleUpdateStatus(file.id, 'verified')
+                          }}
+                        >
+                          Verify
+                        </Button>
+                        <Button
+                          size='small'
+                          color='error'
+                          variant='outlined'
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            handleUpdateStatus(file.id, 'rejected')
+                          }}
+                        >
+                          Reject
+                        </Button>
+                      </>
+                    )}
+                  </Box>
+                </ListItemSecondaryAction>
               </ListItem>
             )
           })}

--- a/apps/react/docs/docs/03-Working on ACM/04-Case Definition/02-Reference/06-document-lifecycle.mdx
+++ b/apps/react/docs/docs/03-Working on ACM/04-Case Definition/02-Reference/06-document-lifecycle.mdx
@@ -1,0 +1,131 @@
+---
+id: document-lifecycle
+title: Document Lifecycle
+---
+
+Once a case declares its [required documents](./04-required-documents.mdx) and its uploaded bytes
+have a [storage mode](./05-document-storage.mdx) to live in, each document also carries a
+**lifecycle status** — a small, server-controlled state machine that says whether a document has
+merely *arrived* or has been *reviewed*. This lets a case distinguish "we received something" from
+"someone validated it", turning the Documents tab from an attachment list into a review queue.
+
+The status lives on the `CaseDocument` and is managed by the case-engine, not by the config: the
+case definition declares *what* documents a case should carry; the lifecycle tracks *where each one
+stands* in review.
+
+---
+
+## Status values
+
+| Status | Stored? | Set by | Meaning |
+|--------|---------|--------|---------|
+| `received` | ✅ | Engine, at upload | Default. Stamped server-side the moment a file is uploaded. The document exists and is awaiting review. |
+| `verified` | ✅ | Validator, via the status endpoint | A reviewer accepted the document. |
+| `rejected` | ✅ | Validator, via the status endpoint | A reviewer rejected the document (e.g. wrong file, illegible, expired). |
+| `pending` | ❌ | Portal (computed) | **Not a stored status.** A declared [required document](./04-required-documents.mdx) that has *no* upload yet. The portal derives it for display; the engine never persists it. |
+
+:::note `pending` is a view, not a state
+`pending` describes a *gap* — a requirement the case is expected to satisfy but hasn't. Because it
+belongs to a requirement with no document behind it, there is nothing to store it on. The portal
+computes it by comparing the declared `requiredDocuments` against the documents actually present.
+Only `received`, `verified`, and `rejected` ever exist on a stored `CaseDocument`.
+:::
+
+---
+
+## The transition
+
+A stored document moves through a deliberately small state machine:
+
+```
+             ┌──────────► verified
+received ────┤
+             └──────────► rejected
+```
+
+- A document starts at `received` (stamped by the engine at upload — clients cannot set it).
+- A validator transitions it to **either** `verified` **or** `rejected`.
+
+There is no separate "re-open" transition in this slice; the endpoint simply sets the status to one
+of the two review outcomes.
+
+---
+
+## The transition endpoint
+
+```
+PATCH /case/{businessKey}/document/{documentId}/status
+```
+
+```json
+{ "status": "verified" }
+```
+
+| Part | Value |
+|------|-------|
+| Method | `PATCH` |
+| Path | `/case/{businessKey}/document/{documentId}/status` |
+| `documentId` | The server-assigned `id` on the `CaseDocument` (see below). |
+| Body `status` | `"verified"` or `"rejected"`. No other value is accepted. |
+
+The endpoint records the outcome on the document and stamps who made the decision (`validatedBy`,
+below). It does not accept `received` or `pending` — `received` is the engine's job at upload, and
+`pending` is never stored.
+
+---
+
+## Server-stamped identity — `uploadedBy` and `validatedBy`
+
+Two attribution fields are filled in **by the engine from the authenticated user** (the JWT `sub`
+claim), never from the request body:
+
+| Field | Stamped when | Source |
+|-------|--------------|--------|
+| `uploadedBy` | At upload | Authenticated user (JWT `sub`) |
+| `validatedBy` | At verify / reject | Authenticated user (JWT `sub`) |
+
+Documents also gained a server-assigned `id` at upload, which is what `documentId` in the endpoint
+path refers to.
+
+:::caution Integrity — these fields are not client-trusted
+`uploadedBy` and `validatedBy` are set server-side from the token, so a client cannot spoof who
+uploaded or who validated a document by putting a different name in the payload. Any such value in
+the request body is ignored.
+:::
+
+:::caution No audit *trail* — attribution, not history
+The lifecycle records the **current** status and the **latest** actor (`uploadedBy`,
+`validatedBy`) only. It does **not** keep a change history, and **no timestamps are stored** — you
+cannot see prior statuses, when a transition happened, or a sequence of reviewers. A full audit
+trail is out of scope for this slice (it is a separate project). Do not rely on these fields as a
+history log.
+:::
+
+---
+
+## Who can transition — the role gate
+
+Whether a transition requires a privileged role depends on whether authorization is enabled, in
+keeping with the platform's minimal-mode philosophy:
+
+| Authz | Setting | Gate on the status endpoint |
+|-------|---------|-----------------------------|
+| **On** | `wks.authz.opa.enabled=true` (OPA) | Requires a **manager role** — one of `mgmt_case_def`, `mgmt_form`, `mgmt_record_type`. |
+| **Off** | minimal / dev mode | **No-op.** Any authenticated user can transition. |
+
+:::note Same philosophy as the rest of the core
+The gate mirrors the orthogonal-core stance: security is a concern you switch **on** for a real
+deployment and **off** for a minimal/dev stack. With authz off the transition is still restricted
+to *authenticated* users — the no-op removes the *role* check, not authentication.
+:::
+
+---
+
+## Relationship to the other document layers
+
+- [Required documents](./04-required-documents.mdx) declare *what* a case should carry. The
+  lifecycle status describes *where each document stands* in review; a declared requirement with no
+  upload shows as the computed `pending`.
+- [Storage mode](./05-document-storage.mdx) decides *where* a document's bytes live. It is
+  orthogonal to the lifecycle — a document has a status regardless of whether its bytes are in
+  MinIO, on the filesystem, or inline.


### PR DESCRIPTION
## Document lifecycle — Slice 3 of the DMS roadmap

> **Stacked PR (3-deep).** Base is `feat/dms-doc-storage` (#536), which bases on `feat/dms-doc-requirements` (#533), which bases on `develop`. **Retarget down the chain as each parent merges** (`gh pr edit <this> --base feat/dms-doc-storage` → eventually `--base develop`).

Makes document management a real **discipline**: an uploaded document is `received`, and a validator **verifies** or **rejects** it. The acting user is stamped **server-side from the token**, not trusted from the client. This is the first slice with real engine logic (slices 1 & 2 were passive model changes).

### Engine
- `CaseDocument` + `CaseDocumentDto` gain `id`, `status`, `uploadedBy`, `validatedBy`.
- `CreateCaseInstanceDocumentCmd` stamps a server `id`, `status=received`, and `uploadedBy` from the security context (JWT `sub`) at upload.
- New **`PATCH /case/{businessKey}/document/{documentId}/status`** → `UpdateCaseInstanceDocumentStatusCmd`: load case → find document by id → validate target (`verified`|`rejected` only) → set status + stamp `validatedBy` → save. **DB-agnostic** (load/mutate/save), so it works on both the Mongo and JPA persistence paths.
- **Role gate that no-ops when authz is off:** when `wks.authz.opa.enabled=true`, the transition requires a manager realm role (`mgmt_case_def`/`mgmt_form`/`mgmt_record_type`) read from the JWT → else 403; when off (dev/minimal mode), any authenticated caller may transition — matching the orthogonal core.

### Portal
- `DocumentStatusChip` (status → colored chip) and, on each uploaded-file row, **role-gated Verify/Reject** buttons (`accountStore.isManagerUser` — the *same* roles the backend enforces) that call the endpoint and refresh the status.
- `CaseService.updateDocumentStatus` (PATCH) mirrors the existing client pattern.

### Status model
| Status | Meaning |
|---|---|
| `pending` | portal-computed — a declared required document with no upload (never stored) |
| `received` | stored default, stamped at upload |
| `verified` / `rejected` | validator transition via the endpoint |

### Scope boundary
A full **audit trail / change history is out of scope** (separate project) — no timestamps are stored; only current status + latest actor.

### Verification — all green
- Backend compile (case-engine + dto + rest-api): **SUCCESS**
- Portal build (ESLint + Prettier + webpack): **green**
- Docs build (docusaurus): **green**
- **Backend contract smoke** (engine self-contained on the JPA/H2 path, real REST API): upload → `id` assigned + `status=received` + `uploadedBy` stamped; `PATCH verified` → `status=verified` + `validatedBy` stamped; invalid status → **400**; unknown document → **404**; slices 1 & 2 fields (`requirementId`/`storage`/`dir`) intact.

### Caveat for review
The smoke ran with **authz off** (JPA/H2 profile), so the role-gate *code* is verified but its enforcement path (403 for a non-manager when authz is **on**) was not exercised end-to-end — worth a check on an OPA-enabled stack.

### Backward compatibility
Legacy documents without `id`/`status` still render (chip falls back to `received`; no buttons without an id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)