### PR TITLE
feat(case-engine): document versioning — re-upload supersedes prior version (DMS slice 4)

### DIFF
--- a/apps/java/libraries/case-engine-rest-dto/src/main/java/com/wks/api/dto/CaseDocumentDto.java
+++ b/apps/java/libraries/case-engine-rest-dto/src/main/java/com/wks/api/dto/CaseDocumentDto.java
@@ -60,4 +60,13 @@ public class CaseDocumentDto {
 	/** User id that verified/rejected the document (server-stamped). */
 	private String validatedBy;
 
+	/** Version number within the requirement's document history (1-based). */
+	private Integer version;
+
+	/** Whether this is the current version for its requirement. */
+	private Boolean current;
+
+	/** Id of the document version this one superseded (history chain). */
+	private String supersedesId;
+
 }

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/CaseDocument.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/CaseDocument.java
@@ -91,4 +91,25 @@ public class CaseDocument {
 
 	/** User id (JWT {@code sub}) that verified/rejected the document, stamped server-side. */
 	private String validatedBy;
+
+	/**
+	 * Version number within a requirement's document history (1-based). A re-upload
+	 * for the same {@code requirementId} increments this. Null on legacy documents
+	 * (treated as version 1).
+	 */
+	private Integer version;
+
+	/**
+	 * Whether this is the current version for its requirement. A re-upload marks the
+	 * previous current document {@code false} and the new one {@code true}. Null on
+	 * legacy documents is treated as current for backward compatibility.
+	 */
+	private Boolean current;
+
+	/**
+	 * Id of the document this version superseded (the previous current version for
+	 * the same requirement), forming the history chain. Null for the first version
+	 * and for free-form attachments.
+	 */
+	private String supersedesId;
 }

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/command/CreateCaseInstanceDocumentCmd.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/instance/command/CreateCaseInstanceDocumentCmd.java
@@ -11,6 +11,8 @@
  */
 package com.wks.caseengine.cases.instance.command;
 
+import java.util.List;
+
 import org.bson.types.ObjectId;
 
 import com.wks.caseengine.cases.instance.CaseDocument;
@@ -49,6 +51,8 @@ public class CreateCaseInstanceDocumentCmd implements Command<CaseDocument> {
 		document.setStatus(CaseDocument.STATUS_RECEIVED);
 		commandContext.getSecurityContextTenantHolder().getUserId().ifPresent(document::setUploadedBy);
 
+		applyVersioning(caseInstance, document);
+
 		caseInstance.addDocument(document);
 
 		try {
@@ -58,6 +62,35 @@ public class CreateCaseInstanceDocumentCmd implements Command<CaseDocument> {
 		}
 
 		return document;
+	}
+
+	/**
+	 * Version the incoming document within its requirement's history. A document tied
+	 * to a {@code requirementId} that already has a current document supersedes it:
+	 * the previous current version is marked non-current and the new one takes the
+	 * next version number, linking back via {@code supersedesId}. The first document
+	 * for a requirement (and every free-form attachment) is version 1 and current.
+	 */
+	private void applyVersioning(final CaseInstance caseInstance, final CaseDocument incoming) {
+		incoming.setCurrent(Boolean.TRUE);
+
+		String requirementId = incoming.getRequirementId();
+		List<CaseDocument> existing = caseInstance.getDocuments();
+		CaseDocument previousCurrent = (requirementId == null || existing == null) ? null
+				: existing.stream()
+						.filter(d -> requirementId.equals(d.getRequirementId()))
+						.filter(d -> !Boolean.FALSE.equals(d.getCurrent()))
+						.reduce((first, second) -> second) // the latest current, if any
+						.orElse(null);
+
+		if (previousCurrent == null) {
+			incoming.setVersion(1);
+		} else {
+			previousCurrent.setCurrent(Boolean.FALSE);
+			int previousVersion = previousCurrent.getVersion() == null ? 1 : previousCurrent.getVersion();
+			incoming.setVersion(previousVersion + 1);
+			incoming.setSupersedesId(previousCurrent.getId());
+		}
 	}
 
 }

--- a/apps/react/case-portal/src/views/caseForm/Documents.js
+++ b/apps/react/case-portal/src/views/caseForm/Documents.js
@@ -10,6 +10,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
+import Collapse from '@mui/material/Collapse'
 import Fade from '@mui/material/Fade'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
@@ -32,8 +33,18 @@ function Documents({ aCase, initialValue, requiredDocuments = [] }) {
   const [percent, setPercent] = useState(0)
   const [messageError, setMessageError] = useState(null)
   const [filesUploaded, setFilesUploaded] = useState(initialValue)
+  const [expandedHistory, setExpandedHistory] = useState({})
 
   const isManager = accountStore.isManagerUser(keycloak)
+
+  // Re-read the authoritative document list from the engine so server-computed
+  // fields (version / current / supersedesId / status / id) are reflected after an
+  // upload or a status change — the client's own object doesn't carry them.
+  const refreshDocuments = () => {
+    return CaseService.getCaseById(keycloak, aCase.businessKey)
+      .then((caseData) => setFilesUploaded(caseData?.documents || []))
+      .catch((e) => console.log(e))
+  }
 
   const handleUpdateStatus = (documentId, status) => {
     CaseService.updateDocumentStatus(
@@ -42,17 +53,18 @@ function Documents({ aCase, initialValue, requiredDocuments = [] }) {
       documentId,
       status,
     )
-      .then(() => {
-        setFilesUploaded((current) =>
-          current.map((file) =>
-            file.id === documentId ? { ...file, status } : file,
-          ),
-        )
-      })
+      .then(() => refreshDocuments())
       .catch((e) => {
         console.log(e)
         setMessageError(e)
       })
+  }
+
+  const toggleHistory = (documentId) => {
+    setExpandedHistory((current) => ({
+      ...current,
+      [documentId]: !current[documentId],
+    }))
   }
 
   const handleChange = (files, requirementId) => {
@@ -68,9 +80,7 @@ function Documents({ aCase, initialValue, requiredDocuments = [] }) {
         )
 
     uploadPromise
-      .then((data) => {
-        setFilesUploaded([...filesUploaded, ...data])
-      })
+      .then(() => refreshDocuments())
       .catch((e) => {
         console.log(e)
         setMessageError(e)
@@ -131,6 +141,54 @@ function Documents({ aCase, initialValue, requiredDocuments = [] }) {
   const satisfiedMandatoryCount = mandatoryRequirements.filter(
     isRequirementSatisfied,
   ).length
+
+  // Versioning: show only the current version of each document at the top level;
+  // superseded versions are reachable via the per-document history chain.
+  const documentsById = Object.fromEntries(
+    (filesUploaded || []).map((doc) => [doc.id, doc]),
+  )
+  const currentDocuments = (filesUploaded || []).filter(
+    (doc) => doc.current !== false,
+  )
+  const historyOf = (doc) => {
+    const chain = []
+    let previousId = doc.supersedesId
+    while (previousId && documentsById[previousId]) {
+      const previous = documentsById[previousId]
+      chain.push(previous)
+      previousId = previous.supersedesId
+    }
+    return chain
+  }
+
+  const documentAvatar = (file) => {
+    if (file.type === 'application/pdf') {
+      return (
+        <Avatar style={{ backgroundColor: 'red' }}>
+          <FilePdfOutlined />
+        </Avatar>
+      )
+    }
+    if (file.type === 'application/xls') {
+      return (
+        <Avatar style={{ backgroundColor: 'green' }}>
+          <FileExcelOutlined />
+        </Avatar>
+      )
+    }
+    if (file.type && file.type.includes('image/')) {
+      return (
+        <Avatar style={{ backgroundColor: 'lightblue' }}>
+          <FileImageOutlined />
+        </Avatar>
+      )
+    }
+    return (
+      <Avatar style={{ backgroundColor: 'grey' }}>
+        <FileOutlined />
+      </Avatar>
+    )
+  }
 
   const handleError = (error) => {
     console.log('error code ' + error.code + ': ' + error.message)
@@ -300,79 +358,102 @@ function Documents({ aCase, initialValue, requiredDocuments = [] }) {
         </Grid>
       </Box>
 
-      {filesUploaded && filesUploaded.length > 0 && (
+      {currentDocuments.length > 0 && (
         <List sx={{ border: '1px dashed #d9d9d9' }}>
-          {filesUploaded.map((file, index) => {
+          {currentDocuments.map((file) => {
+            const history = historyOf(file)
+            const expanded = !!expandedHistory[file.id]
             return (
-              <ListItem
-                key={index}
-                onClick={() => downloadFile(file, keycloak)}
-              >
-                <ListItemAvatar>
-                  {file.type === 'application/pdf' && (
-                    <Avatar style={{ backgroundColor: 'red' }}>
-                      <FilePdfOutlined />
-                    </Avatar>
-                  )}
-
-                  {file.type === 'application/xls' && (
-                    <Avatar style={{ backgroundColor: 'green' }}>
-                      <FileExcelOutlined />
-                    </Avatar>
-                  )}
-
-                  {file.type && file.type.includes('image/') && (
-                    <Avatar style={{ backgroundColor: 'lightblue' }}>
-                      <FileImageOutlined />
-                    </Avatar>
-                  )}
-
-                  {file.type !== 'application/xls' &&
-                    file.type !== 'application/pdf' &&
-                    file.type &&
-                    !file.type.includes('image/') && (
-                      <Avatar style={{ backgroundColor: 'grey' }}>
-                        <FileOutlined />
-                      </Avatar>
-                    )}
-                </ListItemAvatar>
-                <ListItemText
-                  primary={file.name}
-                  secondary={file.size + 'KB'}
-                  style={{ maxWidth: '80%' }}
-                />
-                <ListItemSecondaryAction>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <DocumentStatusChip status={file.status || 'received'} />
-                    {isManager && file.id && (
-                      <>
+              <React.Fragment key={file.id || file.name}>
+                <ListItem onClick={() => downloadFile(file, keycloak)}>
+                  <ListItemAvatar>{documentAvatar(file)}</ListItemAvatar>
+                  <ListItemText
+                    primary={file.name}
+                    secondary={file.size + 'KB'}
+                    style={{ maxWidth: '80%' }}
+                  />
+                  <ListItemSecondaryAction>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      {file.version > 1 && (
+                        <Chip
+                          size='small'
+                          variant='outlined'
+                          label={`v${file.version}`}
+                        />
+                      )}
+                      {history.length > 0 && (
                         <Button
                           size='small'
-                          color='success'
-                          variant='outlined'
                           onClick={(event) => {
                             event.stopPropagation()
-                            handleUpdateStatus(file.id, 'verified')
+                            toggleHistory(file.id)
                           }}
                         >
-                          Verify
+                          {expanded
+                            ? 'Hide history'
+                            : `History (${history.length})`}
                         </Button>
-                        <Button
-                          size='small'
-                          color='error'
-                          variant='outlined'
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            handleUpdateStatus(file.id, 'rejected')
-                          }}
+                      )}
+                      <DocumentStatusChip status={file.status || 'received'} />
+                      {isManager && file.id && (
+                        <>
+                          <Button
+                            size='small'
+                            color='success'
+                            variant='outlined'
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              handleUpdateStatus(file.id, 'verified')
+                            }}
+                          >
+                            Verify
+                          </Button>
+                          <Button
+                            size='small'
+                            color='error'
+                            variant='outlined'
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              handleUpdateStatus(file.id, 'rejected')
+                            }}
+                          >
+                            Reject
+                          </Button>
+                        </>
+                      )}
+                    </Box>
+                  </ListItemSecondaryAction>
+                </ListItem>
+                {history.length > 0 && (
+                  <Collapse in={expanded} timeout='auto' unmountOnExit>
+                    <List disablePadding sx={{ pl: 4 }}>
+                      {history.map((old) => (
+                        <ListItem
+                          key={old.id}
+                          onClick={() => downloadFile(old, keycloak)}
+                          sx={{ opacity: 0.7 }}
                         >
-                          Reject
-                        </Button>
-                      </>
-                    )}
-                  </Box>
-                </ListItemSecondaryAction>
-              </ListItem>
+                          <ListItemAvatar>{documentAvatar(old)}</ListItemAvatar>
+                          <ListItemText
+                            primary={old.name}
+                            secondary={`v${old.version || 1}${
+                              old.status ? ' · ' + old.status : ''
+                            }`}
+                            style={{ maxWidth: '80%' }}
+                          />
+                          <ListItemSecondaryAction>
+                            <Chip
+                              size='small'
+                              variant='outlined'
+                              label={`v${old.version || 1}`}
+                            />
+                          </ListItemSecondaryAction>
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Collapse>
+                )}
+              </React.Fragment>
             )
           })}
         </List>

--- a/apps/react/docs/docs/03-Working on ACM/04-Case Definition/02-Reference/07-document-versioning.mdx
+++ b/apps/react/docs/docs/03-Working on ACM/04-Case Definition/02-Reference/07-document-versioning.mdx
@@ -1,0 +1,126 @@
+---
+id: document-versioning
+title: Document Versioning
+---
+
+Once a case declares its [required documents](./04-required-documents.mdx), stores their bytes in a
+[storage mode](./05-document-storage.mdx), and tracks each one through its
+[lifecycle status](./06-document-lifecycle.mdx), the natural next question is: what happens when a
+document is **uploaded again**? **Document versioning** answers it. Re-uploading a file for a
+requirement that already has one does not create a duplicate — it creates a **new version**, and the
+previous one is kept as history.
+
+Versioning is done by the case-engine **at upload time**, inside the existing create-document
+command. There is **no new endpoint**: the same upload path that has always accepted documents now
+also decides whether the incoming file is a first upload or a replacement.
+
+---
+
+## What triggers a new version
+
+A new version is created when a document is uploaded for a **requirement that already has a current
+document** — that is, when the incoming upload's `requirementId` matches a requirement that a
+`CaseDocument` already satisfies. On that upload the engine:
+
+- Marks the requirement's existing **current** version as no longer current.
+- Stores the new upload as the **current** version, one higher, and links it back to the version it
+  replaced.
+
+| Upload | Grouped by | Result |
+|--------|-----------|--------|
+| First upload for a requirement | `requirementId` | Version `1`, `current` |
+| Re-upload for the **same** requirement | `requirementId` | New version (`n + 1`), becomes `current`; the prior current version is superseded |
+| Free-form attachment (no `requirementId`) | *not grouped* | Always version `1`, `current` — each is independent |
+
+:::note Free-form attachments are never versioned together
+Versioning is keyed on `requirementId`. Documents with **no** `requirementId` — the free-form
+attachments described in [required documents](./04-required-documents.mdx) — are each their own
+version `1` / `current` and are **not** grouped or superseded, even if you upload several. There is
+nothing tying them together to form a chain.
+:::
+
+---
+
+## The versioning fields
+
+Versioning adds three fields to the `CaseDocument`, all managed by the engine:
+
+| Field | Type | Set by | Meaning |
+|-------|------|--------|---------|
+| `version` | integer | Engine, at upload | 1-based version number. The first document for a requirement is `1`; each re-upload increments it. |
+| `current` | boolean | Engine, at upload | Whether this is the **latest** version for its requirement. Exactly one version per requirement is `current` at a time. |
+| `supersedesId` | string | Engine, at upload | The `id` of the version this one replaced. Following `supersedesId` from the current version walks back through the history chain. `null` / absent on version `1`. |
+
+- The **first** upload for a requirement is `version` `1`, `current` `true`, and has **no**
+  `supersedesId` — there is nothing before it.
+- Each re-upload gets the next `version`, becomes the `current` one, and its `supersedesId` points
+  at the version it just replaced. The replaced version keeps its own fields but flips to
+  `current` `false`.
+
+The chain is single-linked from newest to oldest: current → its `supersedesId` → and so on back to
+version `1`.
+
+---
+
+## Current-vs-history in the portal
+
+The Documents tab shows only the **current** version of each requirement's document, so the list
+stays one row per requirement rather than growing with every re-upload:
+
+- When a requirement has more than one version, its current row carries a **`v{n}`** badge (e.g.
+  `v3`) showing how many versions exist.
+- Superseded versions are reached through a per-document **History** expander. Expanding it lists the
+  prior versions, newest first, following the `supersedesId` chain.
+- Every superseded version **remains downloadable** — its bytes are retained in whatever
+  [storage mode](./05-document-storage.mdx) the deployment uses. History is read-only, not archived
+  away.
+
+:::note History is retained — there is no prune or delete
+This slice keeps **all** versions. Superseded documents are not deleted, expired, or pruned; the
+full chain stays queryable and downloadable. There is no retention window and no "delete old
+versions" action here.
+:::
+
+---
+
+## Versioning and the lifecycle status
+
+Each version is a `CaseDocument` in its own right, so each carries its **own**
+[lifecycle status](./06-document-lifecycle.mdx). Versioning and status are independent:
+
+- A **new version starts at `received`** — the same default the engine stamps on any upload. It does
+  **not** inherit the status of the version it replaced.
+- Verifying or rejecting one version does not change any other. A superseded version keeps the
+  status it had when it was replaced (e.g. a `rejected` version stays `rejected` in history), and the
+  new current version is reviewed on its own.
+- Because the status endpoint targets a specific `documentId`, a validator always acts on one exact
+  version — including, if needed, a superseded one still visible in history.
+
+:::caution A re-upload does not "fix" a rejected version
+Rejecting a document and re-uploading a corrected file produces a **new** current version at
+`received`, awaiting its own review — the old `rejected` version stays in the history chain. The
+rejection is not overwritten; it is superseded.
+:::
+
+---
+
+## Versioning and completeness
+
+The completeness checklist from [required documents](./04-required-documents.mdx) is unchanged: a
+requirement counts as satisfied when a document is **present** for it. Because every re-upload keeps
+the requirement's `current` document present, versioning never regresses completeness — replacing a
+document leaves the requirement satisfied throughout. Completeness looks only at the current version;
+history does not affect it.
+
+---
+
+## Relationship to the other document layers
+
+- [Required documents](./04-required-documents.mdx) declare *what* a case should carry and provide
+  the `requirementId` that versions are grouped by. Free-form attachments (no `requirementId`) are
+  never grouped into a version chain.
+- [Storage mode](./05-document-storage.mdx) decides *where* each version's bytes live. Every
+  version — current or superseded — retains its bytes in the active mode, which is why history stays
+  downloadable.
+- [Document lifecycle](./06-document-lifecycle.mdx) tracks *where each version stands* in review.
+  Each version has its own status, and a new version always starts at `received`.


### PR DESCRIPTION
## Document versioning — Slice 4 of the DMS roadmap

> **Stacked PR (4-deep).** Base is `feat/dms-doc-lifecycle` (#542) → `feat/dms-doc-storage` (#536) → `feat/dms-doc-requirements` (#533) → `develop`. **Retarget down the chain as each parent merges.**

Re-uploading a document for the same required-document creates a **new version** instead of a duplicate, keeping the history.

### Engine
- `CaseDocument` + `CaseDocumentDto` gain `version` (1-based), `current` (the latest version for a requirement), `supersedesId` (id of the replaced version — the history chain).
- `CreateCaseInstanceDocumentCmd` versions the incoming document: a document targeting a `requirementId` that already has a current document marks that one non-current and takes the next version, linking back via `supersedesId`. The first document for a requirement — and every free-form attachment — is version 1 / current. Engine stays a passive metadata bag; new fields persist via the existing converter / Mongo. **No new endpoint** — the existing `POST /case/{businessKey}/document` handles it.

### Portal
- The documents list shows only the **current** version of each document (with a `v{n}` badge), plus a per-document **History** expander for superseded versions, which remain downloadable.
- After an upload or status change the list is **re-fetched** from the engine so server-computed `version`/`current`/`status` are authoritative — this also fixes an earlier optimistic-append gap where a re-added document lacked its `id`/`status`.

### Grouping
| Upload | Result |
|---|---|
| First for a requirement | v1, current |
| Re-upload for the same requirement | v(n+1), current; prior → non-current, linked via `supersedesId` |
| Free-form (no `requirementId`) | v1, current; not grouped |

### Scope boundary
Retention/expiry and custom metadata (the other Slice 4 concerns) are **deferred** to later slices. There is **no delete/prune** of old versions — history is retained.

### Verification — all green
- Backend compile (case-engine + dto): **SUCCESS**
- Portal build (ESLint + Prettier + webpack): **green**
- Docs build (docusaurus): **green**
- **Backend contract smoke** (engine self-contained on the JPA/H2 path): re-upload for the same `requirementId` → 2 versions retained, v1 `current=false`, v2 `current=true` + `supersedesId`→v1, v2 status `received`; free-form doc = v1/current. **7/7**.

### Backward compatibility
Legacy documents without `version`/`current` still render (a null `current` is treated as current).

### Not covered
Portal UI click-through (re-upload → v2 + history expander) — build-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)