### PR TITLE
docs(roadmap): document the v1.6.0 line and align develop to 1.6.0-SNAPSHOT

### DIFF
--- a/apps/java/pom.xml
+++ b/apps/java/pom.xml
@@ -14,7 +14,7 @@
              Defaults to the develop dev line; CI overrides it at release time with
              `-Drevision=X.Y.Z` so the same version lands in the jars and the image tag.
              flatten-maven-plugin (below) resolves ${revision} in the installed/published poms. -->
-        <revision>1.5.0-SNAPSHOT</revision>
+        <revision>1.6.0-SNAPSHOT</revision>
 
         <project.javadoc.outputDirectory>website/static/javadoc</project.javadoc.outputDirectory>
 

--- a/apps/react/docs/docs/release-policy.md
+++ b/apps/react/docs/docs/release-policy.md
@@ -59,9 +59,12 @@ positional, so it's easy to reason about without tracking per-version dates:
 
 | Version | Status | Stack | Supported until |
 |---|---|---|---|
+| `1.6.0` | **Next** — in development (Configuration Standard & Document Management) | Spring Boot 4.0.6 · Java 21 · Camunda 7.24 | Not yet released — see the [Roadmap](./roadmap.md) |
 | `1.5.x` | **Current** — the Stabilization release | Spring Boot 4.0.6 · Java 21 · Camunda 7.24 · zero Critical/High vulns | Active |
 | `1.4.x` | **Previous stable** | Java 17 · Spring Boot 3 | `1.6.0` GA + 90-day grace |
 | `< 1.4` | End-of-life | — | Unsupported — please upgrade |
+
+When `1.6.0` reaches GA the window shifts positionally: `1.5.x` becomes the previous stable line and `1.4.x` enters its 90-day migration grace period before EOL.
 
 ---
 

--- a/apps/react/docs/docs/roadmap.md
+++ b/apps/react/docs/docs/roadmap.md
@@ -26,25 +26,39 @@ flowchart LR
         S[Zero Critical Vulns]
     end
 
+    %% v1.6.0: Next release, in development
+    subgraph V16 ["v1.6.0 (Config Standard and Documents) — In Development"]
+        direction TB
+        G1[Config Standard 2.0 — enforced]
+        G2[Structural validation]
+        G3[CI test gate]
+        G4[Portal error resilience]
+        G5[Document Management]
+    end
+
     %% Future: TBD
     subgraph V_FUTURE ["Future Vision"]
         direction TB
-        F1[To be defined]
+        F1[Spring Boot 4.1 + springdoc 3.x]
+        F2[More to come]
     end
 
     %% Logical Flow
     V14 --> V15
-    V15 -.-> V_FUTURE
+    V15 --> V16
+    V16 -.-> V_FUTURE
 
     %% Styling
     classDef completed fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px;
     classDef current fill:#e1f5fe,stroke:#01579b,stroke-width:2px;
+    classDef indev fill:#fff8e1,stroke:#f57f17,stroke-width:2px;
     classDef planned fill:#fff,stroke:#333,stroke-width:1px,stroke-dasharray: 5 5;
-    
+
     class V14 completed;
     class V15 current;
+    class V16 indev;
     class V_FUTURE planned;
-    class L1,L2,A,B,C,S,F1 text;
+    class L1,L2,A,B,C,S,G1,G2,G3,G4,G5,F1,F2 text;
 ```
 
 ---
@@ -67,7 +81,35 @@ The current release. A stabilization release that hardens the existing platform:
 
 ---
 
-## Planned & Future Vision
-**Theme: TBD**
+## v1.6.0 (Next — In Development)
+**Theme: The Configuration Standard & Document Management**
 
-*To be defined.*
+The next release consolidates the platform's foundations into a governed, versioned, **enforced** configuration contract, and introduces **Document Management** as a first-class, config-driven capability. It builds directly on the v1.5.0 stabilization — same runtime stack (Spring Boot 4.0.6 · Java 21 · Camunda 7.24) — now with stronger guarantees about *what configuration is valid* and *what a case type requires*.
+
+**Pillar 1 — The Configuration Standard & foundations** *(delivered on `develop`)*
+
+*   **A published, versioned Standard**: case-type configuration (Case Definition, Form, Record Type, Queue) is now a documented, versioned set of JSON Schemas — one source of truth shared by the backend, the portal, and tooling.
+*   **Enforced on write**: the API validates configuration on create/update and rejects non-conforming documents, turning the Standard from advisory into a real contract.
+*   **Structural validation**: checks beyond schema shape — e.g. a stage-transition hook can't target a stage the case type doesn't define.
+*   **A real CI safety net**: pull requests are gated on unit + integration tests (previously silently skipped) with coverage reporting, so regressions are caught before merge.
+*   **A resilient portal**: failed API calls surface as clear errors instead of vanishing; a bad payload degrades gracefully instead of white-screening.
+*   **Dependency governance**: grouped, reviewed dependency updates that keep framework upgrades deliberate.
+
+**Pillar 2 — Document Management** *(in progress)*
+
+*   **Config-declared document requirements**: case types declare the documents they require, and each case surfaces a completeness checklist.
+*   **Storage modes & durable references**, **document lifecycle** (verify / reject with server-stamped actors), and **versioning** (re-upload supersedes the prior version) — landing as a stacked series of slices, the first of which is in review.
+
+**Breaking changes**
+
+*   **`kanbanConfig` removed** from the Case Definition contract (Configuration Standard → **2.0**). Kanban board columns now derive from a case type's `stages`; per-card presentation moves to a separate, versioned board-config artifact — see the [`@wkspower/case-config-schema` changelog](https://github.com/wkspower/wks-platform/blob/develop/packages/case-config-schema/CHANGELOG.md). The removed field was deprecated and empty across all shipped case types.
+
+---
+
+## Planned & Future Vision
+**Theme: Deliberate Modernization & Depth**
+
+*   **Complete the Document Management arc** — remaining slices (search / preview, retention, versioning polish) beyond the first Document Management release.
+*   **Spring Boot 4.1 + springdoc-openapi 3.x** — a deliberate, verified framework-minor upgrade. springdoc 2.x is incompatible with Spring Boot 4 (the Swagger UI is affected), so the two move together as one reviewed change rather than an unvetted auto-bump.
+*   **Persisted board-config store** — the board-config schema is published (Standard 2.0); a backing store/endpoint follows when there's a concrete need for per-card presentation.
+*   **Repository-backed configuration checks** — extend structural validation to cross-document integrity (e.g. a Case Definition's `formKey` must reference an existing Form) at the domain command layer.


### PR DESCRIPTION
## Document the v1.6.0 line

v1.5.0 shipped (2026-06-25); since then **16 PRs** merged to `develop` — the next minor's worth of work. This documents it as **v1.6.0** and aligns the version + support policy. Docs-only + a one-line version bump; no application behavior changes.

### Changes
- **`apps/react/docs/docs/roadmap.md`**
  - Adds **v1.6.0** to the Platform Evolution Mermaid diagram (new "in development" node) and a **`## v1.6.0 (Next — In Development)`** section.
  - Theme: **The Configuration Standard & Document Management**, with two pillars:
    - *Configuration Standard & foundations* (delivered on `develop`): versioned + **enforced** JSON-Schema Standard, structural validation, CI test gate, portal error resilience, dependency governance.
    - *Document Management* (in progress): config-declared document requirements, storage, lifecycle, versioning — first slice in review.
  - Calls out the **breaking change** (`kanbanConfig` removed → Standard 2.0; columns derive from `stages`).
  - Replaces the "To be defined" **Planned & Future Vision** stub with real items: remaining DMS slices, the deliberate **Spring Boot 4.1 + springdoc-openapi 3.x** upgrade (springdoc 2.x is incompatible with SB4 — see #541), persisted board-config store, and repository-backed structural checks.
- **`apps/java/pom.xml`** — bump single-source `${revision}` `1.5.0-SNAPSHOT` → `1.6.0-SNAPSHOT`.
- **`release-policy.md`** — add a `1.6.0` (Next — in development) row and note the positional support-window shift on GA.

### Notes
- **SemVer:** the `kanbanConfig` removal is a breaking *config-contract* change, but treated as a platform **minor** (1.6.0) — the field was deprecated and empty in every shipped case type, and the *schema package* already carries its own 2.0.0. The roadmap flags it explicitly.
- **DMS is not merged yet** — presented as *in progress / targeted*, not delivered. If any slice doesn't make the 1.6.0 cut, move it to "Planned" at release time (the section is forward-looking, so it stays accurate).
- Retrospective release notes still auto-generate from PR titles on the GitHub Release (per CONTRIBUTING.md) — this is the narrative roadmap, not a hand-written changelog.

### Verification
- `docusaurus build` → **success** (no MDX/Mermaid errors; internal links resolve — Docusaurus throws on broken links).
- `${revision}` resolves to `1.6.0-SNAPSHOT`; no stray `1.5.0-SNAPSHOT` left in `apps/java`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)