### PR TITLE
fix(db): add required_documents column to case_definition Postgres DDL

### DIFF
--- a/configs/postgres/create_tables.sql
+++ b/configs/postgres/create_tables.sql
@@ -20,7 +20,8 @@ CREATE TABLE case_definition (
     stages_lifecycle_process_key TEXT,
     deployed BOOLEAN NOT NULL DEFAULT FALSE,
     stages text,
-    case_hooks TEXT
+    case_hooks TEXT,
+    required_documents TEXT
 );
 
 CREATE TABLE record_type (


### PR DESCRIPTION
## Missing Postgres column for `requiredDocuments`

DMS slice 1 (#533) added the JPA mapping `CaseDefinitionEntity.requiredDocuments` (`@Column(name="required_documents")` + `DocumentRequirementListConverter`) but did **not** add the column to the static Postgres schema in `configs/postgres/create_tables.sql`.

**Impact:** a deployment that provisions Postgres from this DDL (rather than Hibernate `ddl-auto`) fails to persist a case definition carrying `requiredDocuments` — the column doesn't exist. H2/dev auto-creates it, so the gap only bites the static-DDL Postgres path.

**Fix:** one line — `required_documents TEXT` on the `case_definition` table, matching the entity's column name/type. The `CaseDocument` lifecycle/storage/version fields (slices 2–4) need no DDL change — they are serialized inside the existing `case_instance.documents` TEXT column.

Found while auditing an abandoned pre-slice draft branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)