### PR TITLE
build(compose): add SPRINGDOC toggles so the engine boots under Spring Boot 4 (#541 mitigation)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,6 +204,11 @@ services:
             - WKS_BPM_ENGINE=${WKS_BPM_ENGINE:-camunda7}
             - WKS_TENANCY_MULTI_TENANT=${WKS_TENANCY_MULTI_TENANT:-true}
             - WKS_SEED_ENABLED=${WKS_SEED_ENABLED:-false}
+            # Swagger/OpenAPI toggles. springdoc-openapi is incompatible with Spring
+            # Boot 4 and crashes context startup (issue #541); set these to false to
+            # boot the engine without the API docs until the springdoc fix lands.
+            - SPRINGDOC_API_DOCS_ENABLED=${SPRINGDOC_API_DOCS_ENABLED:-true}
+            - SPRINGDOC_SWAGGER_UI_ENABLED=${SPRINGDOC_SWAGGER_UI_ENABLED:-true}
             # Infra connection coordinates (used by whichever concerns are active).
             - CAMUNDA_VERSION=${CAMUNDA_VERSION:-camunda7}
             - CAMUNDA_BASE_URL=${CAMUNDA_BASE_URL}


### PR DESCRIPTION
## Make the minimal stack bootable again (#541 mitigation)

springdoc-openapi is incompatible with Spring Boot 4: its `org.springdoc.webmvc.ui.SwaggerConfig` references `WebMvcProperties`, a class Spring Boot 4 removed. During auto-config **condition evaluation** this throws `NoClassDefFoundError` → `BeanTypeDeductionException` → the case-engine **context fails to refresh and the app exits(1)**. See #541.

Today this makes even the documented **minimal stack** un-bootable:
```
COMPOSE_PROFILES=app,portal WKS_SPRING_PROFILES=db-h2 WKS_AUTH_MODE=dev-token \
WKS_AUTHZ_OPA_ENABLED=false WKS_BPM_ENGINE=none WKS_TENANCY_MULTI_TENANT=false ...
```
Port 8081 never binds, so the portal's dev-token fetch (`/dev-auth/...`) fails with `ERR_CONNECTION_REFUSED`.

### Change
Expose two overridable toggles on the `case-engine-rest-api` service, **defaulting to `true`** (no change to any existing run):
```yaml
- SPRINGDOC_API_DOCS_ENABLED=${SPRINGDOC_API_DOCS_ENABLED:-true}
- SPRINGDOC_SWAGGER_UI_ENABLED=${SPRINGDOC_SWAGGER_UI_ENABLED:-true}
```
Setting both to `false` skips springdoc's auto-config entirely, so the engine boots and serves the API — only `/swagger-ui` is unavailable — until the springdoc/SB4 fix lands.

### Verified
With `SPRINGDOC_API_DOCS_ENABLED=false SPRINGDOC_SWAGGER_UI_ENABLED=false` added to the minimal-stack command:
- engine starts — `Tomcat started on port 8081`, `Started CaseEngineRestAPIApp`
- `GET /dev-auth/realms/localhost/protocol/openid-connect/token` → **200**
- JWKS `/certs` → **200**
- `GET /case-definition` (dev-token auth, seed data) → **200**
- portal loads at :3001

### Note
This is a **mitigation**, not the fix — the real resolution is upgrading springdoc (or bundling with the deliberate Spring Boot 4.1 upgrade) tracked in #541. This just makes the stack runnable in the meantime, and is a no-op unless the toggles are explicitly set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)