### PR TITLE
fix(case-engine): persist requiredDocuments on case definition update

### DIFF
--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/definition/repository/CaseDefinitionJpaRepositoryImpl.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/definition/repository/CaseDefinitionJpaRepositoryImpl.java
@@ -69,6 +69,7 @@ public class CaseDefinitionJpaRepositoryImpl implements CaseDefinitionRepository
         existingEntity.setDeployed(caseDefinition.getDeployed());
         existingEntity.setStages(caseDefinition.getStages());
         existingEntity.setCaseHooks(caseDefinition.getCaseHooks());
+        existingEntity.setRequiredDocuments(caseDefinition.getRequiredDocuments());
 
         entityManager.merge(existingEntity);
     }

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/definition/repository/CaseDefinitionRepositoryImpl.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/definition/repository/CaseDefinitionRepositoryImpl.java
@@ -91,7 +91,8 @@ public class CaseDefinitionRepositoryImpl implements CaseDefinitionRepository {
 				Updates.set("formKey", caseDefinition.getFormKey()), Updates.set("name", caseDefinition.getName()),
 				Updates.set("stagesLifecycleProcessKey", caseDefinition.getStagesLifecycleProcessKey()),
 				Updates.set("deployed", caseDefinition.getDeployed()),
-				Updates.set("caseHooks", caseDefinition.getCaseHooks()));
+				Updates.set("caseHooks", caseDefinition.getCaseHooks()),
+				Updates.set("requiredDocuments", caseDefinition.getRequiredDocuments()));
 
 		JsonObject jsonObject = getCollection().findOneAndUpdate(filter, update);
 		if (jsonObject == null) {


### PR DESCRIPTION
## `requiredDocuments` lost when saving an edited case definition

**Symptom:** add document requirements in the Case Builder's Documents tab, hit Save — they don't persist.

**Root cause:** `CaseDefinition.update()` copies fields onto the existing record one at a time, on **both** persistence paths, and neither copied `requiredDocuments`:

- `CaseDefinitionJpaRepositoryImpl.update()` — sets name/formKey/stages/caseHooks/… but not `requiredDocuments`.
- `CaseDefinitionRepositoryImpl.update()` (Mongo) — `Updates.combine(...)` for the same fields, missing `requiredDocuments`.

The Case Builder's Save on an existing definition is `PUT /case-definition/{id}` → `update()`, so the requirements were silently dropped. Create was unaffected (both `save()` paths serialize the whole object) — which is why it only fails on edit-then-save. This was the one spot slice 1 (#533) wired the *converter* for but missed in the manual update copies.

**Fix:** add `requiredDocuments` to both `update()` methods, mirroring the existing `stages`/`caseHooks` handling. Two lines.

**Verified** on the JPA/H2 path (the `db-h2` minimal stack): create a def without `requiredDocuments` → `PUT` it with two requirements → `GET` returns both, field values intact (`required:false` preserved). Before the fix the array came back empty.

**Follow-up (not in this PR):** a repo-level regression test (H2 IT) asserting update round-trips `requiredDocuments` would prevent this class of "field added to the model but not the manual update copy" bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)