### PR TITLE
fix(compose): default SPRINGDOC toggles off so the engine boots by default (#541)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,10 +205,11 @@ services:
             - WKS_TENANCY_MULTI_TENANT=${WKS_TENANCY_MULTI_TENANT:-true}
             - WKS_SEED_ENABLED=${WKS_SEED_ENABLED:-false}
             # Swagger/OpenAPI toggles. springdoc-openapi is incompatible with Spring
-            # Boot 4 and crashes context startup (issue #541); set these to false to
-            # boot the engine without the API docs until the springdoc fix lands.
-            - SPRINGDOC_API_DOCS_ENABLED=${SPRINGDOC_API_DOCS_ENABLED:-true}
-            - SPRINGDOC_SWAGGER_UI_ENABLED=${SPRINGDOC_SWAGGER_UI_ENABLED:-true}
+            # Boot 4 and CRASHES context startup (issue #541), so the API docs are
+            # disabled by default to keep the engine bootable. Set these to true once
+            # the springdoc/SB4 fix lands to restore Swagger UI.
+            - SPRINGDOC_API_DOCS_ENABLED=${SPRINGDOC_API_DOCS_ENABLED:-false}
+            - SPRINGDOC_SWAGGER_UI_ENABLED=${SPRINGDOC_SWAGGER_UI_ENABLED:-false}
             # Infra connection coordinates (used by whichever concerns are active).
             - CAMUNDA_VERSION=${CAMUNDA_VERSION:-camunda7}
             - CAMUNDA_BASE_URL=${CAMUNDA_BASE_URL}


### PR DESCRIPTION
## Make the engine bootable out of the box

Follow-up to #546. That PR made the Swagger toggles *overridable* but left them defaulting to `true`, so a plain `docker compose up -d` (no env prefix) still crashes the case-engine on the springdoc × Spring Boot 4 incompatibility (#541) — `SwaggerConfig` references the removed `WebMvcProperties`, the context fails to refresh, the app exits(1).

Since springdoc **doesn't work under SB4 at all**, defaulting the docs **off** loses no working functionality and lets the engine start without the env prefix:

```diff
- SPRINGDOC_API_DOCS_ENABLED=${SPRINGDOC_API_DOCS_ENABLED:-true}
- SPRINGDOC_SWAGGER_UI_ENABLED=${SPRINGDOC_SWAGGER_UI_ENABLED:-true}
+ SPRINGDOC_API_DOCS_ENABLED=${SPRINGDOC_API_DOCS_ENABLED:-false}
+ SPRINGDOC_SWAGGER_UI_ENABLED=${SPRINGDOC_SWAGGER_UI_ENABLED:-false}
```

Still overridable (`SPRINGDOC_*_ENABLED=true`) — flip back to `true` once the real springdoc/SB4 fix (#541) lands to restore Swagger UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)