### PR TITLE
fix(case-portal): run nginx unprivileged on 8080 for OpenShift restricted-v2

### DIFF
--- a/apps/react/case-portal/Dockerfile
+++ b/apps/react/case-portal/Dockerfile
@@ -26,13 +26,19 @@ COPY apps/react/case-portal ./
 RUN yarn build
 
 # Stage 2: Create the production image
-FROM nginx:1.15.8-alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 
-COPY --from=build /app/apps/react/case-portal/dist /usr/share/nginx/html
+# uid 101 (nginx) + gid 0, group-writable: startup.sh rewrites index.html at
+# boot, and OpenShift restricted-v2 runs the container as an arbitrary UID
+# whose only guaranteed membership is gid 0.
+COPY --from=build --chown=101:0 /app/apps/react/case-portal/dist /usr/share/nginx/html
+USER root
+RUN chmod -R g=u /usr/share/nginx/html
+USER 101
 COPY --from=build /app/apps/react/case-portal/startup.sh /startup.sh
 COPY --from=build /app/apps/react/case-portal/nginx.conf /etc/nginx/nginx.conf
 
-EXPOSE 80
+EXPOSE 8080
 
 # Start nginx
-CMD ["/bin/sh", "startup.sh"]
+CMD ["/bin/sh", "/startup.sh"]

--- a/apps/react/case-portal/deployments/Dockerfile
+++ b/apps/react/case-portal/deployments/Dockerfile
@@ -1,5 +1,12 @@
-FROM nginx:1.15.8-alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 COPY deployments/nginx.conf /etc/nginx/nginx.conf
-COPY dist /usr/share/nginx/html
+# uid 101 (nginx) + gid 0, group-writable: startup.sh rewrites index.html at
+# boot, and OpenShift restricted-v2 runs the container as an arbitrary UID
+# whose only guaranteed membership is gid 0.
+COPY --chown=101:0 dist /usr/share/nginx/html
+USER root
+RUN chmod -R g=u /usr/share/nginx/html
+USER 101
 COPY deployments/startup.sh /startup.sh
-CMD ["/bin/sh", "startup.sh"]
+EXPOSE 8080
+CMD ["/bin/sh", "/startup.sh"]

--- a/apps/react/case-portal/deployments/nginx.conf
+++ b/apps/react/case-portal/deployments/nginx.conf
@@ -1,8 +1,10 @@
 daemon off;
-user  nginx;
 worker_processes  1;
 error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
+# Unprivileged: pid and temp paths live in /tmp so nginx runs as any non-root
+# UID (OpenShift restricted-v2 assigns an arbitrary one). No `user` directive —
+# the process already starts unprivileged.
+pid        /tmp/nginx.pid;
 
 events {
     worker_connections  1024;
@@ -11,6 +13,11 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
@@ -26,7 +33,7 @@ http {
     index index.html;
 
     server {
-        listen 80 default_server;
+        listen 8080 default_server;
 
         location / {
             if ($request_method = 'OPTIONS') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -285,7 +285,7 @@ services:
             __SERVER_NOVU_ENABLED__: ${REACT_APP_NOVU_ENABLED}
             __SERVER_NOVU_PUBLISHER_API_URL__: ${REACT_APP_NOVU_PUBLISHER_API_URL}
         ports:
-            - 3001:80
+            - 3001:8080
 
     # ------------------------------------------------------ notifications
     # profile: notifications — Kafka event bus + the consumers that act on it.


### PR DESCRIPTION
## Why

The portal image runs nginx as root (`user nginx;`, `listen 80`, base `nginx:1.15.8-alpine`). Under OpenShift's `restricted-v2` SCC containers run as an **arbitrary non-root UID**, so the image fails to start (can't bind :80, can't write `/var/run/nginx.pid`, can't rewrite `index.html`). This blocks the on-prem OpenShift deployment of the platform (wks-deploy OCP program).

## What

- Base image → **`nginxinc/nginx-unprivileged:1.27-alpine`** in both Dockerfiles (the CI publish one in `deployments/` and the compose-build one), also modernizing nginx 1.15.8 → 1.27.
- `nginx.conf`: drop `user nginx;`, `listen 8080`, pid + client/proxy temp paths moved to `/tmp` — runnable by any UID.
- `dist` copied as `101:0` and made group-writable (`g=u`) so `startup.sh`'s envsubst rewrite of `index.html` works when the runtime UID is arbitrary (gid 0 is the only guaranteed membership under restricted-v2).
- `docker-compose.yml`: portal mapping `3001:80` → `3001:8080`; `EXPOSE 8080`.

## Verification

Built the `deployments/Dockerfile` image and ran it as `--user 1000680000:0` (simulating restricted-v2):
- `GET /status` → `alive`
- `index.html` served with the envsubst rewrite applied (proves the write path)
- static assets served (nginx/1.27.5), access log on stdout

## Downstream

The helm chart (wkspower/wks-deploy, slice OCP-1) will adopt the port via a values-driven `containerPort`; Azure stays on its pinned image until it bumps values + re-imports, so nothing deployed changes when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)