### PR TITLE
feat(case-portal): runtime-configurable auth realm override (REACT_APP_REALM)

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -95,6 +95,11 @@ WKS_CORS_ALLOWED_ORIGINS=http://localhost:3001
 ## (see apps/react/case-portal/.env-sample). The dockerized portal below is the
 ## Keycloak (full-stack) variant, where REACT_APP_AUTH_ISSUER_URL is the Keycloak base URL.
 REACT_APP_AUTH_ISSUER_URL=http://localhost:8082
+## Explicit auth realm/tenant (optional). Empty = the portal derives the realm
+## from the browser hostname's first DNS label ('localhost' stays 'localhost'),
+## which requires accessing the portal via an FQDN. Set it to serve the portal
+## from an IP address or a dotless hostname.
+# REACT_APP_REALM=
 REACT_APP_API_URL=http://localhost:8081
 REACT_APP_STORAGE_URL=http://localhost:8085
 ## Storage flow the portal speaks (three-leg contract: REACT_APP_STORAGE_MODE ->

--- a/apps/react/case-portal/.env-sample
+++ b/apps/react/case-portal/.env-sample
@@ -4,6 +4,8 @@ REACT_APP_AUTH_MODE= keycloak
 # Auth issuer base URL. In keycloak mode this is the Keycloak base URL.
 # In dev-token mode (REACT_APP_AUTH_MODE=dev-token) use http://localhost:8081/dev-auth
 REACT_APP_AUTH_ISSUER_URL= http://localhost:8082
+# Optional explicit realm/tenant; empty = derived from the hostname's first DNS label
+# REACT_APP_REALM=
 REACT_APP_API_URL= http://localhost:8081
 REACT_APP_STORAGE_URL= http://localhost:8085
 # Storage flow: minio (presigned 2-step; also covers DigitalOcean) or filesystem (one-step served, for the MinIO-free driver)

--- a/apps/react/case-portal/public/index.html
+++ b/apps/react/case-portal/public/index.html
@@ -53,6 +53,7 @@
     <script>
       window.AUTH_MODE = "$__SERVER_AUTH_MODE__";
       window.AUTH_ISSUER_URL = "$__SERVER_AUTH_ISSUER_URL__";
+      window.REALM = "$__SERVER_REALM__";
       window.API_URL = "$__SERVER_API_URL__";
       window.STORAGE_URL = "$__SERVER_STORAGE_URL__";
       window.STORAGE_MODE = "$__SERVER_STORAGE_MODE__";

--- a/apps/react/case-portal/src/consts/index.js
+++ b/apps/react/case-portal/src/consts/index.js
@@ -13,6 +13,10 @@ const Config = {
     process.env.REACT_APP_AUTH_ISSUER_URL,
     window.AUTH_ISSUER_URL,
   ),
+  // Explicit auth realm/tenant. Empty = derive it from the browser hostname's
+  // first DNS label (the historical behavior, which requires an FQDN); set it
+  // to serve the portal from an IP address or a dotless hostname.
+  Realm: optional(getEnv(process.env.REACT_APP_REALM, window.REALM)),
   StorageUrl: getEnv(process.env.REACT_APP_STORAGE_URL, window.STORAGE_URL),
   // How case documents are stored:
   //   'minio' | 'filesystem' — bytes go to storage-api (needs the storage profile);
@@ -78,6 +82,17 @@ function getEnv(key, defaultValue) {
   }
 
   return defaultValue
+}
+
+// For OPTIONAL runtime vars: when index.html hasn't been envsubst'd (yarn
+// start / tests) the window.X value is the raw "$__SERVER_X__" placeholder,
+// which must not be mistaken for a configured value.
+function optional(value) {
+  if (!value || /^\$__.*__$/.test(value)) {
+    return undefined
+  }
+
+  return value
 }
 
 export default Config

--- a/apps/react/case-portal/src/store/session/SessionStore.test.js
+++ b/apps/react/case-portal/src/store/session/SessionStore.test.js
@@ -32,4 +32,36 @@ test('should be initialize default realm when using app dns', () => {
   expect(realm).toEqual('app')
   expect(clientId).toEqual('wks-portal')
 })
+
+// Config is evaluated at module load, so the runtime-override cases re-import
+// the store with window.REALM already in place.
+async function bootstrapFresh() {
+  jest.resetModules()
+  const { default: freshStore } = await import('./index')
+  return freshStore.bootstrap()
+}
+
+test('explicit realm overrides hostname derivation (IP access)', async () => {
+  window.location.assign('http://10.10.10.210:3001/')
+  window.REALM = 'wks'
+
+  const { keycloak, realm, clientId } = await bootstrapFresh()
+
+  expect(keycloak).not.toBeNull()
+  expect(realm).toEqual('wks')
+  expect(clientId).toEqual('wks-portal')
+
+  delete window.REALM
+})
+
+test('unresolved envsubst placeholder falls back to hostname derivation', async () => {
+  window.location.assign('http://marketshare.wkspower.local/')
+  window.REALM = '$__SERVER_REALM__'
+
+  const { realm } = await bootstrapFresh()
+
+  expect(realm).toEqual('marketshare')
+
+  delete window.REALM
+})
 /* eslint-disable no-undef */

--- a/apps/react/case-portal/src/store/session/index.js
+++ b/apps/react/case-portal/src/store/session/index.js
@@ -7,7 +7,11 @@ function bootstrap() {
   const clientId = 'wks-portal'
   const hostname = window.location.hostname
 
-  if (hostname !== 'localhost') {
+  // Explicit realm wins; the hostname derivation below requires a
+  // fully-qualified DNS name (an IP or dotless hostname yields a bogus realm).
+  if (Config.Realm) {
+    realm = Config.Realm
+  } else if (hostname !== 'localhost') {
     realm = hostname.substring(0, hostname.indexOf('.'))
   } else {
     realm = hostname

--- a/apps/react/case-portal/test/__mocks__/constsMock.js
+++ b/apps/react/case-portal/test/__mocks__/constsMock.js
@@ -6,6 +6,14 @@ const Config = {
   CaseEngineUrl: 'http://localhost:8081',
   AuthMode: 'keycloak',
   AuthIssuerUrl: 'http://localhost:8082',
+  // Mirrors the real module's optional Realm override (window.REALM, with the
+  // unresolved-envsubst-placeholder guard) so realm-derivation tests are live.
+  Realm:
+    typeof window !== 'undefined' &&
+    window.REALM &&
+    !/^\$__.*__$/.test(window.REALM)
+      ? window.REALM
+      : undefined,
   StorageUrl: 'http://localhost:8085',
   StorageMode: 'minio',
   WebsocketsEnabled: 'false',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,6 +275,7 @@ services:
         environment:
             __SERVER_AUTH_MODE__: ${REACT_APP_AUTH_MODE:-keycloak}
             __SERVER_AUTH_ISSUER_URL__: ${REACT_APP_AUTH_ISSUER_URL:-}
+            __SERVER_REALM__: ${REACT_APP_REALM:-}
             __SERVER_API_URL__: ${REACT_APP_API_URL}
             __SERVER_STORAGE_URL__: ${REACT_APP_STORAGE_URL}
             __SERVER_STORAGE_MODE__: ${REACT_APP_STORAGE_MODE:-minio}


### PR DESCRIPTION
## Why

The portal derives the Keycloak realm from the browser hostname's first DNS label (`src/store/session/index.js`), with `localhost` as the only exception. That forces every deployment to be reached via an FQDN: a bare IP yields realm `"10"` and a dotless hostname an empty realm — both unloginable. Single-server customer installs shouldn't have to mint a DNS record just to satisfy the realm heuristic.

## What

Adds an optional explicit realm override through the standard three-leg runtime-config contract (see the CASE PORTAL block in `.env-sample`):

- `REACT_APP_REALM` (.env, build-time) → `__SERVER_REALM__` (docker-compose env) → `window.REALM` (public/index.html, envsubst at container start)
- `session/index.js`: an explicit `Config.Realm` wins; otherwise the existing hostname derivation applies unchanged.
- New `optional()` guard in `consts`: an unresolved `$__SERVER_REALM__` placeholder (`yarn start`/tests, where envsubst never runs) is treated as unset instead of leaking in as a bogus realm.
- `test/__mocks__/constsMock.js` mirrors the override so the realm-derivation tests exercise it.

Default behavior is fully unchanged — the variable is opt-in and empty everywhere by default.

## Verification

- `yarn test`: 51 passing, including two new cases (explicit realm wins under IP access; unresolved placeholder falls back to hostname derivation). `lint:check` + `format:check` clean.
- Container build from this branch: with `__SERVER_REALM__=wks` the served page carries `window.REALM = "wks"`; with the var unset it carries `""` (falsy → derivation), confirming envsubst end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)