### PR TITLE
fix(case-portal): make login work in insecure (plain-HTTP) contexts

### DIFF
--- a/apps/react/case-portal/deployments/startup.sh
+++ b/apps/react/case-portal/deployments/startup.sh
@@ -1,7 +1,11 @@
-#!/bin/sh 
+#!/bin/sh
 
 envsubst < /usr/share/nginx/html/index.html > /tmp/index.html
 
-cp /tmp/index.html /usr/share/nginx/html/index.html
+# Overwrite via redirection (owner O_TRUNC), not cp: under the unprivileged
+# image the html directory isn't writable by the runtime UID, so cp's
+# unlink-and-recreate replace fails with "File exists" while an in-place
+# truncate of the (owned, writable) file succeeds.
+cat /tmp/index.html > /usr/share/nginx/html/index.html
 
 nginx

--- a/apps/react/case-portal/src/App.js
+++ b/apps/react/case-portal/src/App.js
@@ -23,25 +23,27 @@ const App = () => {
   const [menu, setMenu] = useState({ items: [] })
 
   useEffect(() => {
-    const { keycloak } = sessionStore.bootstrap()
+    const { keycloak, initOptions } = sessionStore.bootstrap()
     // Held across the async init so the effect's cleanup can actually run it.
     // Previously the cleanup was returned from inside the .then() callback — which
     // React ignores — so the menu subscription leaked on unmount/HMR.
     let unsubscribe
 
-    keycloak.init({ onLoad: 'login-required' }).then((authenticated) => {
-      setKeycloak(keycloak)
-      setAuthenticated(authenticated)
-      buildMenuItems(keycloak)
-      RegisterInjectUserSession(keycloak)
-      RegisteOptions(keycloak)
-      forceLogoutIfUserNoMinimalRoleForSystem(keycloak)
-      registerExtensionModulesFormio()
-
-      unsubscribe = MenuEventService.subscribeToMenuUpdates(() => {
+    keycloak
+      .init({ onLoad: 'login-required', ...initOptions })
+      .then((authenticated) => {
+        setKeycloak(keycloak)
+        setAuthenticated(authenticated)
         buildMenuItems(keycloak)
+        RegisterInjectUserSession(keycloak)
+        RegisteOptions(keycloak)
+        forceLogoutIfUserNoMinimalRoleForSystem(keycloak)
+        registerExtensionModulesFormio()
+
+        unsubscribe = MenuEventService.subscribeToMenuUpdates(() => {
+          buildMenuItems(keycloak)
+        })
       })
-    })
 
     keycloak.onAuthRefreshError = () => {
       window.location.reload()

--- a/apps/react/case-portal/src/store/session/index.js
+++ b/apps/react/case-portal/src/store/session/index.js
@@ -1,6 +1,7 @@
 import Keycloak from 'keycloak-js'
 import Config from '../../consts'
 import { createDevTokenAdapter } from './devTokenAdapter'
+import { insecureContextInitOptions } from './insecureContext'
 
 function bootstrap() {
   let realm = ''
@@ -24,6 +25,7 @@ function bootstrap() {
       keycloak: kc,
       realm,
       clientId,
+      initOptions: {},
     }
   }
 
@@ -37,6 +39,9 @@ function bootstrap() {
     keycloak: kc,
     realm,
     clientId,
+    // Extra keycloak.init() options — non-empty only in insecure (plain-HTTP)
+    // contexts, where Web Crypto is restricted; see insecureContext.js.
+    initOptions: insecureContextInitOptions(),
   }
 }
 

--- a/apps/react/case-portal/src/store/session/insecureContext.js
+++ b/apps/react/case-portal/src/store/session/insecureContext.js
@@ -1,0 +1,56 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+
+// keycloak-js 26 requires crypto.randomUUID (login state/nonce) and, for PKCE,
+// crypto.subtle — browsers expose both ONLY in secure contexts (HTTPS or
+// localhost), so a portal served over plain HTTP on a remote host fails login
+// with "Web Crypto API is not available". crypto.getRandomValues IS available
+// in insecure contexts: back-fill randomUUID from it (same CSPRNG, RFC 4122
+// v4) and disable PKCE, whose SHA-256 digest cannot be polyfilled without
+// crypto.subtle. Secure contexts are left completely untouched.
+export function insecureContextInitOptions() {
+  if (window.isSecureContext) {
+    return {}
+  }
+
+  console.warn(
+    '[wks] Portal is served over plain HTTP (insecure context): ' +
+      'polyfilling crypto.randomUUID and disabling PKCE for login. ' +
+      'Serve the portal over HTTPS to restore full Web Crypto support.',
+  )
+
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'undefined' &&
+    typeof crypto.getRandomValues === 'function'
+  ) {
+    crypto.randomUUID = function randomUUID() {
+      const bytes = crypto.getRandomValues(new Uint8Array(16))
+      bytes[6] = (bytes[6] & 0x0f) | 0x40
+      bytes[8] = (bytes[8] & 0x3f) | 0x80
+      const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0'))
+      return (
+        hex.slice(0, 4).join('') +
+        '-' +
+        hex.slice(4, 6).join('') +
+        '-' +
+        hex.slice(6, 8).join('') +
+        '-' +
+        hex.slice(8, 10).join('') +
+        '-' +
+        hex.slice(10, 16).join('')
+      )
+    }
+  }
+
+  return { pkceMethod: false }
+}

--- a/apps/react/case-portal/src/store/session/insecureContext.test.js
+++ b/apps/react/case-portal/src/store/session/insecureContext.test.js
@@ -1,0 +1,64 @@
+/* eslint-disable no-undef */
+import { insecureContextInitOptions } from './insecureContext'
+
+const originalDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  'isSecureContext',
+)
+
+function setSecureContext(value) {
+  Object.defineProperty(window, 'isSecureContext', {
+    value,
+    configurable: true,
+  })
+}
+
+afterEach(() => {
+  if (originalDescriptor) {
+    Object.defineProperty(window, 'isSecureContext', originalDescriptor)
+  } else {
+    delete window.isSecureContext
+  }
+  delete crypto.randomUUID
+  jest.restoreAllMocks()
+})
+
+test('secure context: no init overrides, crypto untouched', () => {
+  setSecureContext(true)
+
+  expect(insecureContextInitOptions()).toEqual({})
+  expect(crypto.randomUUID).toBeUndefined()
+})
+
+test('insecure context: disables PKCE and warns', () => {
+  setSecureContext(false)
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+  expect(insecureContextInitOptions()).toEqual({ pkceMethod: false })
+  expect(warn).toHaveBeenCalled()
+})
+
+test('insecure context: polyfills a valid RFC 4122 v4 randomUUID', () => {
+  setSecureContext(false)
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+  insecureContextInitOptions()
+
+  expect(typeof crypto.randomUUID).toBe('function')
+  const uuid = crypto.randomUUID()
+  expect(uuid).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  )
+  expect(crypto.randomUUID()).not.toEqual(uuid)
+})
+
+test('insecure context: an existing native randomUUID is not replaced', () => {
+  setSecureContext(false)
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+  const native = () => 'native'
+  crypto.randomUUID = native
+
+  insecureContextInitOptions()
+
+  expect(crypto.randomUUID).toBe(native)
+})


### PR DESCRIPTION
## Why

A portal served over **plain HTTP on a remote host or IP** cannot log in: keycloak-js 26 throws `Web Crypto API is not available` (reported by a customer deployment). Browsers restrict `crypto.randomUUID` (used for the login state/nonce, `keycloak.js:1624`) and `crypto.subtle` (PKCE S256 digest) to **secure contexts** — HTTPS or localhost — so any HTTP deployment beyond localhost fails at `keycloak.init()`.

## What

**1. Insecure-context login support** (`src/store/session/insecureContext.js`):
- `crypto.getRandomValues` *is* available in insecure contexts → back-fill `crypto.randomUUID` from it (same CSPRNG, RFC 4122 v4) when missing.
- Pass `pkceMethod: false` to `keycloak.init()` — the PKCE SHA-256 digest needs `crypto.subtle`, which cannot be polyfilled from a CSPRNG. Over an already-plaintext transport this does not meaningfully change the threat model.
- One `console.warn` advising HTTPS. **Secure contexts are completely untouched** — no polyfill, PKCE stays S256.

**2. #550 regression fix** (`deployments/startup.sh`): under the unprivileged nginx image, `cp` cannot replace `index.html` (the html directory isn't writable by the runtime UID → `cp: can't create … File exists`), so the envsubst output was silently discarded and **every `window.*` runtime config stayed an unresolved placeholder**. Overwrite via owner `O_TRUNC` redirection (`cat > file`) instead, which needs only file-level write. Bundled here because this fix cannot ship (or be tested) without it.

## Verification

- Headless-Chrome click-through against a single-server compose stack on a bare IP over HTTP: reproduced `Web Crypto API is not available` on the previous build; with this branch the browser reaches the Keycloak login, signs in, and renders the workspace with **zero page errors** (and the envsubst'd `window.*` values are correct).
- `yarn test`: 55 passing, including 4 new tests for the insecure-context helper (secure no-op, PKCE off + warning, RFC 4122 v4 shape of the polyfill, native `randomUUID` never replaced). `lint:check` + `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)