### PR TITLE
fix(case-portal): fail startup when runtime config substitution doesn't land

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ On first run the `demo-data-loader` bootstraps a Keycloak realm and a `demo` use
 sample cases. Wait for it to finish, then open [http://localhost:3001](http://localhost:3001)
 and log in with `demo` / `demo`.
 
+> **Returning to a stack you brought up before?** Run `docker compose pull` first. The default
+> `WKS_VERSION` is the floating `develop` tag, and `docker compose up` reuses whatever image you
+> already have locally rather than checking for a newer one — so a stack that worked weeks ago
+> can come back up on stale images that predate a fix.
+
 ## Minimal stack (no auth, no authorization)
 
 Runs just the case engine + portal — **no Mongo, Keycloak, OPA, Camunda or MinIO**. It uses an

--- a/apps/react/case-portal/deployments/startup.sh
+++ b/apps/react/case-portal/deployments/startup.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Fail fast. If the runtime-config substitution below doesn't land, index.html
+# still carries the literal $__SERVER_*__ placeholders: the browser then builds
+# a nonsense issuer URL and the portal redirect-loops until nginx answers 414.
+# That reads as "the portal doesn't open" while the container looks healthy, so
+# refuse to serve rather than serve an unconfigured page.
+set -e
+
 envsubst < /usr/share/nginx/html/index.html > /tmp/index.html
 
 # Overwrite via redirection (owner O_TRUNC), not cp: under the unprivileged
@@ -7,5 +14,12 @@ envsubst < /usr/share/nginx/html/index.html > /tmp/index.html
 # unlink-and-recreate replace fails with "File exists" while an in-place
 # truncate of the (owned, writable) file succeeds.
 cat /tmp/index.html > /usr/share/nginx/html/index.html
+
+# Belt and braces: a partial write or a future refactor could leave placeholders
+# behind without any command returning non-zero.
+if grep -q '\$__SERVER_' /usr/share/nginx/html/index.html; then
+    echo "startup.sh: runtime config substitution failed - index.html still contains \$__SERVER_* placeholders" >&2
+    exit 1
+fi
 
 nginx


### PR DESCRIPTION
## Problem

The portal came up "healthy" but was unusable in the browser: `docker compose ps` showed the container `running` and `GET /` returned `200`, yet the page never loaded.

`deployments/startup.sh` rewrites `index.html` with `envsubst` at boot, then starts nginx **unconditionally**. When that rewrite fails, `index.html` keeps its literal placeholders:

```js
window.AUTH_ISSUER_URL = "$__SERVER_AUTH_ISSUER_URL__";
```

The browser builds a nonsense issuer URL from that and redirect-loops, each hop concatenating the path onto itself, until nginx answers **414 Request-URI Too Large**. The only signal is one line on stderr, buried under nginx access logs.

Encountered in practice on an image predating #550: the pre-#550 `cp` failed with `cp: can't create '/usr/share/nginx/html/index.html': File exists` under the unprivileged image, and the container served the unconfigured page anyway.

## Fix

- `set -e`, so a failing substitution stops the script instead of falling through to `nginx`.
- An explicit guard that refuses to start nginx if any `$__SERVER_*` placeholder survives — covering a partial write or a future refactor where no command returns non-zero.

The container now exits non-zero with `runtime config substitution failed` rather than serving a dead page.

## Also

README quick start now tells returning users to `docker compose pull` first. `WKS_VERSION` defaults to the floating `develop` tag and `docker compose up` reuses the local image rather than checking for a newer one — so a stack that worked weeks ago can come back up on images that predate a fix, which is exactly how this surfaced.

## Verification

Ran all three cases against the real `ghcr.io/wkspower/case-portal:develop` image with the script bind-mounted:

| Scenario | Container | HTTP | Result |
|---|---|---|---|
| Pre-#550 script, substitution fails | `running` | 200 | serves placeholders — silent breakage |
| This script, substitution fails (`index.html` read-only) | `exited (1)` | — | `can't create ...: Permission denied`, nginx never starts |
| This script, happy path | `running` | 200 | `window.AUTH_ISSUER_URL = "http://kc:8082"` ✓ |

Also `sh -n` clean.

## Note for reviewers

This is a shell-level guard, not a repo test — the portal's Jest suite doesn't exercise the container boot path, so there's no natural home for this as CI-run code. It protects anyone who rebuilds the image, but CI won't catch a regression here.

No enforcement was added against the stale-image trap itself. `pull_policy: always` on the ghcr services would prevent it, but it forces network access on every `up` and cuts against the `--build` local-dev flow — documented rather than decided unilaterally. Happy to add it if maintainers prefer.