### PR TITLE
fix(case-portal): wire Form.io builder edits back into saved forms

### DIFF
--- a/apps/react/case-portal/jest.config.js
+++ b/apps/react/case-portal/jest.config.js
@@ -32,6 +32,8 @@ module.exports = {
   },
   // Some deps (e.g. keycloak-js) ship ESM-only builds. Jest ignores node_modules
   // for transforms by default, so allow-list the ESM ones through babel.
-  transformIgnorePatterns: ['/node_modules/(?!(keycloak-js)/)'],
+  transformIgnorePatterns: [
+    '/node_modules/(?!(keycloak-js|react-syntax-highlighter)/)',
+  ],
   testMatch: ['<rootDir>/src/**/*.test.js', '<rootDir>/test/**/*.test.js'],
 }

--- a/apps/react/case-portal/src/views/management/form/formDetail.js
+++ b/apps/react/case-portal/src/views/management/form/formDetail.js
@@ -19,6 +19,7 @@ import MainCard from 'components/MainCard'
 import { FormService } from 'services'
 import { useSession } from 'SessionStoreContext'
 import { StorageService } from 'plugins/storage'
+import { useFormBuilderSchema } from '../useFormBuilderSchema'
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction='up' ref={ref} {...props} />
@@ -32,9 +33,14 @@ export const FormDetail = ({
   handleSelectDisplay,
 }) => {
   const keycloak = useSession()
+  const { onBuilderChange, mergeBuilderSchema } = useFormBuilderSchema(open)
 
   const saveForm = () => {
-    FormService.update(keycloak, form.key, form)
+    // The components live in the builder, not in state — pull them in on save.
+    FormService.update(keycloak, form.key, {
+      ...form,
+      structure: mergeBuilderSchema(form.structure),
+    })
       .then(() => handleClose())
       .catch((err) => {
         console.log(err.message)
@@ -134,6 +140,7 @@ export const FormDetail = ({
           <MainCard>
             <FormBuilder
               form={form.structure}
+              onChange={onBuilderChange}
               options={{
                 noNewEdit: true,
                 noDefaultSubmitButton: true,

--- a/apps/react/case-portal/src/views/management/form/formDetail.test.js
+++ b/apps/react/case-portal/src/views/management/form/formDetail.test.js
@@ -1,0 +1,94 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormDetail } from './formDetail'
+
+const mockBuilder = { props: null }
+jest.mock('@formio/react', () => ({
+  FormBuilder: (props) => {
+    mockBuilder.props = props
+    return null
+  },
+}))
+
+jest.mock('plugins/storage', () => ({ StorageService: class {} }))
+jest.mock('services', () => ({
+  FormService: {
+    update: jest.fn(() => Promise.resolve()),
+    remove: jest.fn(() => Promise.resolve()),
+  },
+}))
+
+const { FormService } = jest.requireMock('services')
+
+const existingForm = () => ({
+  key: 'customer',
+  title: 'Customer',
+  toolTip: '',
+  structure: { components: [{ key: 'firstName' }], display: 'form' },
+})
+
+const renderDetail = (form = existingForm(), props = {}) =>
+  render(
+    <FormDetail
+      open
+      form={form}
+      handleClose={jest.fn()}
+      handleInputChange={jest.fn()}
+      handleSelectDisplay={jest.fn()}
+      {...props}
+    />,
+  )
+
+beforeEach(() => {
+  mockBuilder.props = null
+  FormService.update.mockClear()
+})
+
+describe('FormDetail', () => {
+  it('saves the components edited in the builder', async () => {
+    const user = userEvent.setup()
+    renderDetail()
+
+    act(() =>
+      mockBuilder.props.onChange(
+        {},
+        { components: [{ key: 'firstName' }, { key: 'lastName' }] },
+      ),
+    )
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    const [, key, payload] = FormService.update.mock.calls[0]
+    expect(key).toBe('customer')
+    expect(payload.structure.components).toEqual([
+      { key: 'firstName' },
+      { key: 'lastName' },
+    ])
+  })
+
+  it('saves a component removed in the builder', async () => {
+    const user = userEvent.setup()
+    renderDetail()
+
+    act(() => mockBuilder.props.onChange({}, { components: [] }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    const [, , payload] = FormService.update.mock.calls[0]
+    expect(payload.structure.components).toEqual([])
+  })
+
+  it('leaves the structure untouched when nothing was edited', async () => {
+    const user = userEvent.setup()
+    const form = existingForm()
+    renderDetail(form)
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    const [, , payload] = FormService.update.mock.calls[0]
+    expect(payload.structure).toEqual(form.structure)
+  })
+
+  it('passes an onChange to the builder, its only outbound path', () => {
+    renderDetail()
+    expect(typeof mockBuilder.props.onChange).toBe('function')
+  })
+})

--- a/apps/react/case-portal/src/views/management/form/formNew.js
+++ b/apps/react/case-portal/src/views/management/form/formNew.js
@@ -19,6 +19,7 @@ import { FormBuilder } from '@formio/react'
 import { FormService } from 'services'
 import { useSession } from 'SessionStoreContext'
 import { StorageService } from 'plugins/storage'
+import { useFormBuilderSchema } from '../useFormBuilderSchema'
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction='up' ref={ref} {...props} />
@@ -27,6 +28,7 @@ const Transition = React.forwardRef(function Transition(props, ref) {
 export const FormNew = ({ open, handleClose }) => {
   const [form, setForm] = useState(null)
   const keycloak = useSession()
+  const { onBuilderChange, mergeBuilderSchema } = useFormBuilderSchema(open)
 
   useEffect(() => {
     setForm({
@@ -37,7 +39,11 @@ export const FormNew = ({ open, handleClose }) => {
   }, [open])
 
   const saveNewForm = () => {
-    FormService.create(keycloak, form)
+    // The components live in the builder, not in state — pull them in on save.
+    FormService.create(keycloak, {
+      ...form,
+      structure: mergeBuilderSchema(form.structure),
+    })
       .then(() => handleClose())
       .catch((err) => {
         console.log(err.message)
@@ -135,6 +141,7 @@ export const FormNew = ({ open, handleClose }) => {
           <MainCard>
             <FormBuilder
               form={form.structure}
+              onChange={onBuilderChange}
               options={{
                 noNewEdit: true,
                 noDefaultSubmitButton: true,

--- a/apps/react/case-portal/src/views/management/form/formNew.test.js
+++ b/apps/react/case-portal/src/views/management/form/formNew.test.js
@@ -1,0 +1,67 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormNew } from './formNew'
+
+// Stand in for @formio/react's builder, which only reports edits through
+// onChange — see useFormBuilderSchema.test.js for the contract this mirrors.
+const mockBuilder = { props: null }
+jest.mock('@formio/react', () => ({
+  FormBuilder: (props) => {
+    mockBuilder.props = props
+    return null
+  },
+}))
+
+jest.mock('plugins/storage', () => ({ StorageService: class {} }))
+jest.mock('services', () => ({
+  FormService: { create: jest.fn(() => Promise.resolve()) },
+}))
+
+const { FormService } = jest.requireMock('services')
+
+const designComponent = (component) =>
+  act(() =>
+    mockBuilder.props.onChange(
+      {},
+      { components: [component], display: 'form' },
+    ),
+  )
+
+beforeEach(() => {
+  mockBuilder.props = null
+  FormService.create.mockClear()
+})
+
+describe('FormNew', () => {
+  it('saves the components designed in the builder', async () => {
+    const user = userEvent.setup()
+    render(<FormNew open handleClose={jest.fn()} />)
+
+    designComponent({ key: 'firstName', type: 'textfield' })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    const [, payload] = FormService.create.mock.calls[0]
+    expect(payload.structure.components).toEqual([
+      { key: 'firstName', type: 'textfield' },
+    ])
+  })
+
+  it('keeps the display chosen in the toolbar rather than the builder copy', async () => {
+    const user = userEvent.setup()
+    render(<FormNew open handleClose={jest.fn()} />)
+
+    await user.click(screen.getByRole('combobox', { name: 'Display' }))
+    await user.click(screen.getByRole('option', { name: 'Wizard' }))
+    designComponent({ key: 'firstName' })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    const [, payload] = FormService.create.mock.calls[0]
+    expect(payload.structure.display).toBe('wizard')
+    expect(payload.structure.components).toEqual([{ key: 'firstName' }])
+  })
+
+  it('passes an onChange to the builder, its only outbound path', () => {
+    render(<FormNew open handleClose={jest.fn()} />)
+    expect(typeof mockBuilder.props.onChange).toBe('function')
+  })
+})

--- a/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
+++ b/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
@@ -15,6 +15,7 @@ import MainCard from 'components/MainCard'
 import { RecordTypeService, MenuEventService } from 'services'
 import { useSession } from 'SessionStoreContext'
 import { StorageService } from 'plugins/storage'
+import { useFormBuilderSchema } from '../useFormBuilderSchema'
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction='up' ref={ref} {...props} />
@@ -27,10 +28,17 @@ export const RecordTypeForm = ({
   handleInputChange,
 }) => {
   const keycloak = useSession()
+  const { onBuilderChange, mergeBuilderSchema } = useFormBuilderSchema(open)
 
   const save = () => {
+    // The fields live in the builder, not in state — pull them in on save.
+    const payload = {
+      ...recordType,
+      fields: mergeBuilderSchema(recordType.fields),
+    }
+
     if (recordType.mode && recordType.mode === 'new') {
-      RecordTypeService.create(keycloak, recordType)
+      RecordTypeService.create(keycloak, payload)
         .then(() => {
           MenuEventService.triggerMenuUpdate()
           handleClose()
@@ -39,7 +47,7 @@ export const RecordTypeForm = ({
           console.log(err.message)
         })
     } else {
-      RecordTypeService.update(keycloak, recordType.id, recordType)
+      RecordTypeService.update(keycloak, recordType.id, payload)
         .then(() => {
           MenuEventService.triggerMenuUpdate()
           handleClose()
@@ -113,6 +121,7 @@ export const RecordTypeForm = ({
           <MainCard>
             <FormBuilder
               form={recordType.fields}
+              onChange={onBuilderChange}
               options={{
                 noNewEdit: true,
                 noDefaultSubmitButton: true,

--- a/apps/react/case-portal/src/views/management/recordType/recordTypeForm.test.js
+++ b/apps/react/case-portal/src/views/management/recordType/recordTypeForm.test.js
@@ -1,0 +1,81 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RecordTypeForm } from './recordTypeForm'
+
+const mockBuilder = { props: null }
+jest.mock('@formio/react', () => ({
+  FormBuilder: (props) => {
+    mockBuilder.props = props
+    return null
+  },
+}))
+
+jest.mock('plugins/storage', () => ({ StorageService: class {} }))
+jest.mock('services', () => ({
+  RecordTypeService: {
+    create: jest.fn(() => Promise.resolve()),
+    update: jest.fn(() => Promise.resolve()),
+    remove: jest.fn(() => Promise.resolve()),
+  },
+  MenuEventService: { triggerMenuUpdate: jest.fn() },
+}))
+
+const { RecordTypeService } = jest.requireMock('services')
+
+const renderForm = (recordType) =>
+  render(
+    <RecordTypeForm
+      open
+      recordType={recordType}
+      handleClose={jest.fn()}
+      handleInputChange={jest.fn()}
+    />,
+  )
+
+const designField = (field) =>
+  act(() =>
+    mockBuilder.props.onChange({}, { components: [field], display: 'form' }),
+  )
+
+beforeEach(() => {
+  mockBuilder.props = null
+  RecordTypeService.create.mockClear()
+  RecordTypeService.update.mockClear()
+})
+
+describe('RecordTypeForm', () => {
+  it('saves the fields designed in the builder on a new record type', async () => {
+    const user = userEvent.setup()
+    renderForm({
+      id: 'customer',
+      fields: { components: [], display: 'form' },
+      mode: 'new',
+    })
+
+    designField({ key: 'email', type: 'email' })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    const [, payload] = RecordTypeService.create.mock.calls[0]
+    expect(payload.fields.components).toEqual([{ key: 'email', type: 'email' }])
+  })
+
+  it('saves the fields edited in the builder on an existing record type', async () => {
+    const user = userEvent.setup()
+    renderForm({
+      id: 'customer',
+      fields: { components: [{ key: 'email' }], display: 'form' },
+    })
+
+    designField({ key: 'phone' })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    const [, id, payload] = RecordTypeService.update.mock.calls[0]
+    expect(id).toBe('customer')
+    expect(payload.fields.components).toEqual([{ key: 'phone' }])
+  })
+
+  it('passes an onChange to the builder, its only outbound path', () => {
+    renderForm({ id: 'customer', fields: { components: [], display: 'form' } })
+    expect(typeof mockBuilder.props.onChange).toBe('function')
+  })
+})

--- a/apps/react/case-portal/src/views/management/useFormBuilderSchema.js
+++ b/apps/react/case-portal/src/views/management/useFormBuilderSchema.js
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+/**
+ * Bridges @formio/react's <FormBuilder> back into the view that renders it.
+ *
+ * FormBuilder never touches the object handed to its `form` prop — it builds on
+ * a copy (`form = Object.assign({}, form)`) — so the edited schema only escapes
+ * through `onChange`. A call site that omits `onChange` saves the untouched
+ * initial structure and silently discards everything the user designed.
+ *
+ * The edited schema is kept in a ref rather than in state on purpose:
+ * FormBuilder runs a layout effect on the `form` prop that calls `setForm()` on
+ * the builder instance, so feeding a fresh object back on every drag would
+ * rebuild the builder mid-edit.
+ *
+ * @param {boolean} open whether the editing dialog is open. Opening starts a new
+ *   editing session, so anything captured from the previous one is dropped — the
+ *   builder can outlive a close/reopen, or be reused for a different record.
+ */
+export const useFormBuilderSchema = (open) => {
+  const schemaRef = useRef(null)
+
+  useEffect(() => {
+    if (open) {
+      schemaRef.current = null
+    }
+  }, [open])
+
+  // FormBuilder calls onChange(instanceForm, schema); `schema` is the cleaned
+  // export and exposes `components` through a live getter.
+  const onBuilderChange = useCallback((instanceForm, schema) => {
+    schemaRef.current = schema || instanceForm
+  }, [])
+
+  /**
+   * Layers the builder's components over the structure the view holds in state.
+   * State stays authoritative for the fields the view controls itself (display,
+   * title, ...); only `components` comes from the builder. With no edits
+   * captured the structure is returned untouched.
+   */
+  const mergeBuilderSchema = useCallback((structure) => {
+    const schema = schemaRef.current
+    if (!schema) {
+      return structure
+    }
+    return { ...structure, components: schema.components ?? [] }
+  }, [])
+
+  return { onBuilderChange, mergeBuilderSchema }
+}

--- a/apps/react/case-portal/src/views/management/useFormBuilderSchema.test.js
+++ b/apps/react/case-portal/src/views/management/useFormBuilderSchema.test.js
@@ -1,0 +1,136 @@
+import { act, render } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
+import FormBuilder from '@formio/react/lib/components/FormBuilder'
+import { useFormBuilderSchema } from './useFormBuilderSchema'
+
+// formiojs only supplies the *default* Builder implementation; every test here
+// injects its own through FormBuilder's `Builder` prop, so the core never runs.
+// Stubbing it keeps the heavyweight (and jsdom-hostile) import out of the way
+// while the real @formio/react wrapper — the code whose contract we care about —
+// stays untouched.
+jest.mock('formiojs', () => ({ FormBuilder: class {} }))
+
+let lastBuilder = null
+
+/**
+ * Minimal stand-in for a formiojs builder: same surface @formio/react drives
+ * (ready / instance / on / off / setForm / setDisplay / destroy).
+ */
+class FakeBuilder {
+  constructor(element, form) {
+    lastBuilder = this
+    this.handlers = {}
+    const self = this
+    this.instance = {
+      form: { ...form },
+      get schema() {
+        return self.instance.form
+      },
+      on: (name, fn) => {
+        self.handlers[name] = [...(self.handlers[name] || []), fn]
+      },
+      off: (name, fn) => {
+        self.handlers[name] = (self.handlers[name] || []).filter(
+          (h) => h !== fn,
+        )
+      },
+      destroy: () => {},
+    }
+    this.ready = Promise.resolve()
+  }
+
+  setDisplay() {}
+
+  setForm(form) {
+    this.instance.form = { ...form }
+  }
+
+  /** What a drag-and-drop into the designer amounts to. */
+  dropComponent(component) {
+    this.instance.form = {
+      ...this.instance.form,
+      components: [...(this.instance.form.components || []), component],
+    }
+    ;(this.handlers['addComponent'] || []).forEach((fn) => fn())
+  }
+}
+
+const flushReady = async () => {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+beforeEach(() => {
+  lastBuilder = null
+})
+
+describe('@formio/react FormBuilder contract', () => {
+  it('does not write edits back into the form object it was given', async () => {
+    const structure = { components: [], display: 'form' }
+    render(<FormBuilder form={structure} Builder={FakeBuilder} />)
+    await flushReady()
+
+    act(() => lastBuilder.dropComponent({ key: 'firstName' }))
+
+    // This is the whole bug: the caller's object stays empty, so a view that
+    // saves its own state saves nothing the user designed.
+    expect(structure.components).toEqual([])
+  })
+
+  it('reports edits through onChange, the only outbound path', async () => {
+    const structure = { components: [], display: 'form' }
+    const onChange = jest.fn()
+    render(
+      <FormBuilder
+        form={structure}
+        Builder={FakeBuilder}
+        onChange={onChange}
+      />,
+    )
+    await flushReady()
+
+    act(() => lastBuilder.dropComponent({ key: 'firstName' }))
+
+    const [, schema] = onChange.mock.calls[onChange.mock.calls.length - 1]
+    expect(schema.components).toEqual([{ key: 'firstName' }])
+  })
+})
+
+describe('useFormBuilderSchema', () => {
+  const structure = { components: [], display: 'form' }
+
+  it('returns the structure untouched when the builder reported nothing', () => {
+    const { result } = renderHook(() => useFormBuilderSchema(true))
+    expect(result.current.mergeBuilderSchema(structure)).toEqual(structure)
+  })
+
+  it('layers the builder components over the structure held in state', () => {
+    const { result } = renderHook(() => useFormBuilderSchema(true))
+
+    act(() =>
+      result.current.onBuilderChange({}, { components: [{ key: 'age' }] }),
+    )
+
+    expect(
+      result.current.mergeBuilderSchema({ ...structure, display: 'wizard' }),
+    ).toEqual({ components: [{ key: 'age' }], display: 'wizard' })
+  })
+
+  it('drops the previous session when the dialog is reopened', () => {
+    const { result, rerender } = renderHook(
+      ({ open }) => useFormBuilderSchema(open),
+      { initialProps: { open: true } },
+    )
+
+    act(() =>
+      result.current.onBuilderChange({}, { components: [{ key: 'age' }] }),
+    )
+    rerender({ open: false })
+    rerender({ open: true })
+
+    // A builder that outlived the close must not leak its components into the
+    // next record edited.
+    expect(result.current.mergeBuilderSchema(structure)).toEqual(structure)
+  })
+})


### PR DESCRIPTION
## The bug

Everything dragged into the Form.io designer was discarded on save. Reported as "no customizations get saved" against the delivered `sha-9f40ab9` build.

`@formio/react`'s `<FormBuilder>` builds on a *copy* of the object handed to its `form` prop (`initializeBuilder` does `form = Object.assign({}, form)`), so its edited schema only escapes through the `onChange` prop. All three builder call sites in the portal omitted it:

| Call site | Effect |
|---|---|
| `form/formNew.js` | new forms POSTed with `components: []` |
| `form/formDetail.js` | component edits to existing forms dropped |
| `recordType/recordTypeForm.js` | record-type field definitions never saved |

The write returned 200 and the dialog closed, so nothing looked wrong until the form was reopened and came back blank. Only Title / Tool Tip / Display persisted — those have real MUI `onChange` handlers.

## The fix

A shared `useFormBuilderSchema` hook captures the builder's schema and merges its components into the payload at save time, used by all three views.

Three deliberate design calls, each covered by a test:

- **Ref, not state.** `FormBuilder` runs a layout effect on the `form` prop that calls `setForm()` on the builder instance, so pushing a new object back on every drag would rebuild the builder mid-edit.
- **Only `components` comes from the builder.** State stays authoritative for `display`, which the toolbar `Select` owns — otherwise a display change made after the last drag would be clobbered.
- **Capture resets when the dialog opens.** `FormDetail` stays mounted across a close/reopen, so without this, editing form A then opening form B would write A's components onto B.

## Tests

15 new tests; **9 fail without the fix** (verified by reverting only the three view files).

Two layers, because mocking the builder alone would prove nothing about the library's actual behavior:

- **Contract tests** drive the *real* `@formio/react` component with an injected `Builder`, pinning both that it never writes back into the caller's object and that `onChange` is the sole outbound path.
- **View tests** cover each of the three call sites, including component removal and the display-vs-components precedence.

Also allow-lists `react-syntax-highlighter` in the jest transform — it ships ESM-only and any test importing `MainCard` died on it.

## Verification

Full suite: **70 passing** (15 new), eslint and prettier clean — locally and in the container build.

Exercised end to end against a local Docker stack (rebuilt portal image + Keycloak + case-engine + MongoDB): dragged a text field into a new form, saved, and confirmed in MongoDB that the document persisted `structure.components = [textfield]`, where the previous build wrote an empty array.

## Note for reviewers

Testing this surfaced two **unrelated, pre-existing** issues on `develop`, both out of scope here and worth their own PRs:

1. `FormRepositoryImpl.save()` (and the RecordType / CaseDefinition / Queue equivalents) casts `InsertOneResult.getInsertedId()`, which is `null` for `MongoCollection<JsonObject>` inserts — `JsonObjectCodec` isn't a `CollectibleCodec`, so the driver never tracks an `_id`. The write succeeds, then the response NPEs with a 500; retries create duplicates.
2. The portal's webpack output uses `build/[name].js` with no content hash and no `Cache-Control` on static assets, so browsers happily keep serving a previous build's JS after an image upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)