### PR TITLE
fix(case-engine): stop config inserts failing after a successful write

### DIFF
--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/definition/repository/CaseDefinitionRepositoryImpl.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/cases/definition/repository/CaseDefinitionRepositoryImpl.java
@@ -15,9 +15,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.bson.BsonObjectId;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonObject;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
@@ -30,6 +30,7 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import com.wks.caseengine.cases.definition.CaseDefinition;
 import com.wks.caseengine.db.EngineMongoDataConnection;
+import com.wks.caseengine.db.MongoDocuments;
 import com.wks.caseengine.repository.DatabaseRecordNotFoundException;
 
 @Primary
@@ -78,8 +79,9 @@ public class CaseDefinitionRepositoryImpl implements CaseDefinitionRepository {
 
 	@Override
 	public String save(final CaseDefinition caseDefinition) {
-		return ((BsonObjectId) getCollection().insertOne((new JsonObject(gsonBuilder.create().toJson(caseDefinition))))
-				.getInsertedId()).getValue().toHexString();
+		ObjectId id = new ObjectId();
+		getCollection().insertOne(MongoDocuments.withId(gsonBuilder.create(), caseDefinition, id));
+		return id.toHexString();
 	}
 
 	@Override
@@ -109,7 +111,7 @@ public class CaseDefinitionRepositoryImpl implements CaseDefinitionRepository {
 		}
 	}
 
-	private MongoCollection<JsonObject> getCollection() {
+	protected MongoCollection<JsonObject> getCollection() {
 		return connection.getCaseDefCollection();
 	}
 

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/db/EngineMongoDataConnectionImpl.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/db/EngineMongoDataConnectionImpl.java
@@ -38,6 +38,12 @@ public class EngineMongoDataConnectionImpl implements EngineMongoDataConnection 
 	@Qualifier("mongoTemplateShared")
 	private MongoTemplate byShared;
 
+	/**
+	 * Natural keys of the config collections are unique; the index is ensured on
+	 * first use because the tenant set isn't known at startup.
+	 */
+	private final MongoUniqueIndexes uniqueIndexes = new MongoUniqueIndexes();
+
 	@Override
 	public MongoTemplate getOperations() {
 		return byTenant;
@@ -53,6 +59,7 @@ public class EngineMongoDataConnectionImpl implements EngineMongoDataConnection 
 	public MongoCollection<JsonObject> getCaseDefCollection() {
 		MongoDatabase db = byTenant.getDb();
 		log.debug("using database MongoDataConnection: {}", db.getName());
+		uniqueIndexes.ensure(db, "caseDefinition", "id");
 		return db.getCollection("caseDefinition", JsonObject.class);
 	}
 
@@ -65,12 +72,14 @@ public class EngineMongoDataConnectionImpl implements EngineMongoDataConnection 
 	@Override
 	public MongoCollection<JsonObject> getFormCollection() {
 		MongoDatabase db = byTenant.getDb();
+		uniqueIndexes.ensure(db, "form", "key");
 		return db.getCollection("form", JsonObject.class);
 	}
 
 	@Override
 	public MongoCollection<JsonObject> getRecordTypeCollection() {
 		MongoDatabase db = byTenant.getDb();
+		uniqueIndexes.ensure(db, "recordType", "id");
 		return db.getCollection("recordType", JsonObject.class);
 	}
 
@@ -89,6 +98,7 @@ public class EngineMongoDataConnectionImpl implements EngineMongoDataConnection 
 	@Override
 	public MongoCollection<JsonObject> getQueueCollection() {
 		MongoDatabase db = byTenant.getDb();
+		uniqueIndexes.ensure(db, "queue", "id");
 		return db.getCollection("queue", JsonObject.class);
 	}
 

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/db/MongoDocuments.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/db/MongoDocuments.java
@@ -1,0 +1,62 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.db;
+
+import org.bson.types.ObjectId;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+/**
+ * Helpers for building the JSON documents the Mongo repositories insert.
+ *
+ * @author victor.franca
+ */
+public final class MongoDocuments {
+
+	private MongoDocuments() {
+	}
+
+	/**
+	 * Serialises {@code entity} to a document carrying an explicit {@code _id}.
+	 *
+	 * <p>
+	 * The config repositories insert into
+	 * {@code MongoCollection<org.bson.json.JsonObject>}, and {@code JsonObjectCodec}
+	 * is not a {@code CollectibleCodec}: the driver neither generates nor tracks an
+	 * {@code _id} for these documents, so
+	 * {@link com.mongodb.client.result.InsertOneResult#getInsertedId()} returns null
+	 * and the server assigns the id instead. Callers that dereferenced that result
+	 * threw a {@link NullPointerException} <em>after</em> the write had already
+	 * committed — the request failed with a 500 while the document existed, so
+	 * retries silently piled up duplicates.
+	 *
+	 * <p>
+	 * Supplying the id up front means the caller knows it without reading anything
+	 * back, and is independent of driver-version codec behaviour.
+	 *
+	 * @param gson   the same Gson the repository uses, so serialisation is identical
+	 * @param entity the domain object to persist
+	 * @param id     the id to assign
+	 * @return the document, as extended JSON with {@code _id} as an ObjectId
+	 */
+	public static org.bson.json.JsonObject withId(final Gson gson, final Object entity, final ObjectId id) {
+		JsonObject document = gson.toJsonTree(entity).getAsJsonObject();
+
+		JsonObject objectId = new JsonObject();
+		objectId.addProperty("$oid", id.toHexString());
+		document.add("_id", objectId);
+
+		return new org.bson.json.JsonObject(gson.toJson(document));
+	}
+
+}

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/db/MongoUniqueIndexes.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/db/MongoUniqueIndexes.java
@@ -1,0 +1,68 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.db;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Lazily ensures the unique indexes that keep a config collection's natural key
+ * unique.
+ *
+ * <p>
+ * Databases here are resolved per tenant at request time, so there is no startup
+ * point that knows the full set of tenants — the indexes have to be ensured on
+ * first use instead. Each (database, collection, field) is attempted once per
+ * process and then memoised, so this costs one round trip per tenant per
+ * collection rather than one per request.
+ *
+ * @author victor.franca
+ */
+@Slf4j
+class MongoUniqueIndexes {
+
+	private final Set<String> attempted = ConcurrentHashMap.newKeySet();
+
+	/**
+	 * Creates a unique index on {@code field} if this process has not already tried
+	 * to for this database and collection.
+	 *
+	 * <p>
+	 * Enforcement is best-effort by design. A database that predates the index may
+	 * already hold duplicates, and the create then fails; that tenant must still be
+	 * able to use the engine, so the failure is logged rather than propagated. It is
+	 * not retried until the next restart, which would otherwise add a failing round
+	 * trip to every request.
+	 */
+	void ensure(final MongoDatabase database, final String collection, final String field) {
+		if (!attempted.add(database.getName() + "." + collection + "." + field)) {
+			return;
+		}
+
+		try {
+			database.getCollection(collection).createIndex(Indexes.ascending(field),
+					new IndexOptions().unique(true));
+			log.debug("Ensured unique index {}.{} on '{}'", database.getName(), collection, field);
+		} catch (RuntimeException e) {
+			log.warn("Could not create unique index {}.{} on '{}' — existing duplicates must be removed before "
+					+ "uniqueness can be enforced for this tenant. Cause: {}", database.getName(), collection, field,
+					e.getMessage());
+		}
+	}
+
+}

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/form/FormRepositoryImpl.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/form/FormRepositoryImpl.java
@@ -14,9 +14,9 @@ package com.wks.caseengine.form;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.bson.BsonObjectId;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonObject;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
@@ -28,6 +28,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import com.wks.caseengine.db.EngineMongoDataConnection;
+import com.wks.caseengine.db.MongoDocuments;
 import com.wks.caseengine.repository.DatabaseRecordNotFoundException;
 
 @Primary
@@ -56,8 +57,9 @@ public class FormRepositoryImpl implements FormRepository {
 
 	@Override
 	public String save(final Form form) {
-		return ((BsonObjectId) getCollection().insertOne((new JsonObject(gsonBuilder.create().toJson(form))))
-				.getInsertedId()).getValue().toHexString();
+		ObjectId id = new ObjectId();
+		getCollection().insertOne(MongoDocuments.withId(gsonBuilder.create(), form, id));
+		return id.toHexString();
 	}
 
 	@Override
@@ -90,7 +92,7 @@ public class FormRepositoryImpl implements FormRepository {
 
 	}
 
-	private MongoCollection<JsonObject> getCollection() {
+	protected MongoCollection<JsonObject> getCollection() {
 		return connection.getFormCollection();
 	}
 

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/queue/QueueRepositoryImpl.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/queue/QueueRepositoryImpl.java
@@ -14,9 +14,9 @@ package com.wks.caseengine.queue;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.bson.BsonObjectId;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonObject;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
@@ -28,6 +28,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import com.wks.caseengine.db.EngineMongoDataConnection;
+import com.wks.caseengine.db.MongoDocuments;
 import com.wks.caseengine.repository.DatabaseRecordNotFoundException;
 
 @Primary
@@ -60,8 +61,9 @@ public class QueueRepositoryImpl implements QueueRepository {
 
 	@Override
 	public String save(Queue queue) {
-		return ((BsonObjectId) getCollection().insertOne((new JsonObject(gsonBuilder.create().toJson(queue))))
-				.getInsertedId()).getValue().toHexString();
+		ObjectId id = new ObjectId();
+		getCollection().insertOne(MongoDocuments.withId(gsonBuilder.create(), queue, id));
+		return id.toHexString();
 	}
 
 	@Override
@@ -89,7 +91,7 @@ public class QueueRepositoryImpl implements QueueRepository {
 
 	}
 
-	private MongoCollection<JsonObject> getCollection() {
+	protected MongoCollection<JsonObject> getCollection() {
 		return connection.getQueueCollection();
 	}
 

--- a/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/record/type/RecordTypeRepositoryImpl.java
+++ b/apps/java/libraries/case-engine/src/main/java/com/wks/caseengine/record/type/RecordTypeRepositoryImpl.java
@@ -14,9 +14,9 @@ package com.wks.caseengine.record.type;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.bson.BsonObjectId;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonObject;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
@@ -28,6 +28,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import com.wks.caseengine.db.EngineMongoDataConnection;
+import com.wks.caseengine.db.MongoDocuments;
 import com.wks.caseengine.repository.DatabaseRecordNotFoundException;
 
 @Primary
@@ -56,8 +57,9 @@ public class RecordTypeRepositoryImpl implements RecordTypeRepository {
 
 	@Override
 	public String save(final RecordType recordType) {
-		return ((BsonObjectId) getCollection().insertOne((new JsonObject(gsonBuilder.create().toJson(recordType))))
-				.getInsertedId()).getValue().toHexString();
+		ObjectId id = new ObjectId();
+		getCollection().insertOne(MongoDocuments.withId(gsonBuilder.create(), recordType, id));
+		return id.toHexString();
 	}
 
 	@Override
@@ -90,7 +92,7 @@ public class RecordTypeRepositoryImpl implements RecordTypeRepository {
 
 	}
 
-	private MongoCollection<JsonObject> getCollection() {
+	protected MongoCollection<JsonObject> getCollection() {
 		return connection.getRecordTypeCollection();
 	}
 

--- a/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/db/MongoDocumentsTest.java
+++ b/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/db/MongoDocumentsTest.java
@@ -1,0 +1,71 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.bson.BsonDocument;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.wks.caseengine.form.Form;
+
+/**
+ * @author victor.franca
+ */
+public class MongoDocumentsTest {
+
+	private final Gson gson = new Gson();
+
+	@Test
+	public void shouldCarryTheSuppliedIdAsAnObjectId() {
+		ObjectId id = new ObjectId();
+
+		BsonDocument document = BsonDocument.parse(MongoDocuments.withId(gson, form(), id).getJson());
+
+		assertTrue(document.get("_id").isObjectId(), "_id must be an ObjectId, not a string");
+		assertEquals(id, document.get("_id").asObjectId().getValue());
+	}
+
+	@Test
+	public void shouldPreserveTheEntityFields() {
+		BsonDocument document = BsonDocument.parse(MongoDocuments.withId(gson, form(), new ObjectId()).getJson());
+
+		assertEquals("customer-support", document.getString("key").getValue());
+		assertEquals("Customer Support", document.getString("title").getValue());
+	}
+
+	@Test
+	public void shouldPreserveNestedJsonStructure() {
+		Form form = form();
+		JsonObject structure = new JsonObject();
+		structure.addProperty("display", "form");
+		form.setStructure(structure);
+
+		BsonDocument document = BsonDocument.parse(MongoDocuments.withId(gson, form, new ObjectId()).getJson());
+
+		// The builder schema must land as a nested document, not a stringified blob.
+		assertTrue(document.get("structure").isDocument());
+		assertEquals("form", document.getDocument("structure").getString("display").getValue());
+	}
+
+	private Form form() {
+		Form form = new Form();
+		form.setKey("customer-support");
+		form.setTitle("Customer Support");
+		return form;
+	}
+
+}

--- a/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/db/MongoUniqueIndexesTest.java
+++ b/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/db/MongoUniqueIndexesTest.java
@@ -1,0 +1,114 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.db;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+
+/**
+ * @author victor.franca
+ */
+public class MongoUniqueIndexesTest {
+
+	private MongoDatabase database;
+	private MongoCollection<Document> collection;
+	private MongoUniqueIndexes uniqueIndexes;
+
+	@SuppressWarnings("unchecked")
+	@BeforeEach
+	public void setup() {
+		database = mock(MongoDatabase.class);
+		collection = mock(MongoCollection.class);
+		when(database.getName()).thenReturn("tenant-a");
+		when(database.getCollection("form")).thenReturn(collection);
+		uniqueIndexes = new MongoUniqueIndexes();
+	}
+
+	@Test
+	public void shouldCreateTheUniqueIndexOnFirstUse() {
+		uniqueIndexes.ensure(database, "form", "key");
+
+		verify(collection).createIndex(any(Bson.class), any(IndexOptions.class));
+	}
+
+	@Test
+	public void shouldNotHitTheServerAgainForTheSameCollection() {
+		uniqueIndexes.ensure(database, "form", "key");
+		uniqueIndexes.ensure(database, "form", "key");
+		uniqueIndexes.ensure(database, "form", "key");
+
+		// Ensured once per process, not once per request.
+		verify(collection, times(1)).createIndex(any(Bson.class), any(IndexOptions.class));
+	}
+
+	@Test
+	public void shouldEnsurePerDatabaseSoEachTenantGetsTheIndex() {
+		MongoDatabase other = mock(MongoDatabase.class);
+		@SuppressWarnings("unchecked")
+		MongoCollection<Document> otherCollection = mock(MongoCollection.class);
+		when(other.getName()).thenReturn("tenant-b");
+		when(other.getCollection("form")).thenReturn(otherCollection);
+
+		uniqueIndexes.ensure(database, "form", "key");
+		uniqueIndexes.ensure(other, "form", "key");
+
+		verify(collection).createIndex(any(Bson.class), any(IndexOptions.class));
+		verify(otherCollection).createIndex(any(Bson.class), any(IndexOptions.class));
+	}
+
+	@Test
+	public void shouldNotPropagateAFailedIndexBuild() {
+		doThrow(duplicateKeyOnBuild()).when(collection).createIndex(any(Bson.class), any(IndexOptions.class));
+
+		// A tenant whose data predates the index still has to be able to use the
+		// engine, so a failed build must not surface to the caller.
+		uniqueIndexes.ensure(database, "form", "key");
+	}
+
+	@Test
+	public void shouldNotRetryAFailedIndexBuildOnEveryCall() {
+		doThrow(duplicateKeyOnBuild()).when(collection).createIndex(any(Bson.class), any(IndexOptions.class));
+
+		uniqueIndexes.ensure(database, "form", "key");
+		uniqueIndexes.ensure(database, "form", "key");
+
+		// Otherwise every single request would pay for a round trip that cannot succeed.
+		verify(collection, times(1)).createIndex(any(Bson.class), any(IndexOptions.class));
+	}
+
+	private MongoCommandException duplicateKeyOnBuild() {
+		Document response = new Document("ok", 0).append("code", 11000).append("errmsg",
+				"E11000 duplicate key error collection: tenant-a.form index: key_1");
+		return new MongoCommandException(BsonDocumentOf(response), new ServerAddress());
+	}
+
+	private static org.bson.BsonDocument BsonDocumentOf(final Document document) {
+		return document.toBsonDocument(org.bson.BsonDocument.class,
+				com.mongodb.MongoClientSettings.getDefaultCodecRegistry());
+	}
+
+}

--- a/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/form/FormRepositoryImplIT.java
+++ b/apps/java/libraries/case-engine/src/test/java/com/wks/caseengine/form/FormRepositoryImplIT.java
@@ -1,0 +1,135 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.form;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.bson.BsonDocument;
+import org.bson.json.JsonObject;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.mongodb.test.autoconfigure.DataMongoTest;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.google.gson.GsonBuilder;
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+
+/**
+ * Exercises the real write path against an embedded MongoDB.
+ *
+ * <p>
+ * The bug these cover shipped because nothing drove {@code save()} against a
+ * real server: {@code InsertOneResult#getInsertedId()} is null for a
+ * {@code MongoCollection<JsonObject>}, so the old implementation threw a
+ * {@link NullPointerException} <em>after</em> committing the write. Only a real
+ * insert reproduces that.
+ *
+ * @author victor.franca
+ */
+@DataMongoTest
+@ExtendWith(SpringExtension.class)
+public class FormRepositoryImplIT {
+
+	@Autowired
+	private MongoOperations operations;
+
+	private FormRepositoryImpl repository;
+
+	@BeforeEach
+	public void setup() {
+		collection().drop();
+
+		repository = new FormRepositoryImpl() {
+			@Override
+			protected MongoCollection<JsonObject> getCollection() {
+				return collection();
+			}
+		};
+		ReflectionTestUtils.setField(repository, "gsonBuilder", new GsonBuilder());
+	}
+
+	private MongoCollection<JsonObject> collection() {
+		return ((MongoTemplate) operations).getDb().getCollection("form", JsonObject.class);
+	}
+
+	@Test
+	public void shouldReturnTheIdOfTheInsertedForm() {
+		String id = repository.save(form("customer-support", "Customer Support"));
+
+		assertNotNull(id, "save must return the new document id, not throw");
+		assertTrue(ObjectId.isValid(id), "returned id must be a valid ObjectId: " + id);
+	}
+
+	@Test
+	public void shouldPersistTheFormUnderTheReturnedId() {
+		String id = repository.save(form("customer-support", "Customer Support"));
+
+		JsonObject stored = collection().find(Filters.eq("_id", new ObjectId(id))).first();
+
+		assertNotNull(stored, "the returned id must address the document actually written");
+
+		BsonDocument document = BsonDocument.parse(stored.getJson());
+		assertEquals("customer-support", document.getString("key").getValue());
+		assertEquals("Customer Support", document.getString("title").getValue());
+	}
+
+	@Test
+	public void shouldRoundTripTheSavedFormThroughGet() throws Exception {
+		repository.save(form("customer-support", "Customer Support"));
+
+		Form reloaded = repository.get("customer-support");
+
+		assertEquals("customer-support", reloaded.getKey());
+		assertEquals("Customer Support", reloaded.getTitle());
+	}
+
+	@Test
+	public void shouldWriteExactlyOneDocumentPerSave() {
+		repository.save(form("a", "A"));
+		repository.save(form("b", "B"));
+
+		assertEquals(2, collection().countDocuments());
+	}
+
+	@Test
+	public void shouldRejectDuplicateKeyOnceTheUniqueIndexExists() {
+		collection().createIndex(Indexes.ascending("key"), new IndexOptions().unique(true));
+
+		repository.save(form("customer-support", "Customer Support"));
+
+		// The duplicate must be refused by the database rather than quietly stored —
+		// this is what stopped retries piling up rows.
+		assertThrows(MongoWriteException.class, () -> repository.save(form("customer-support", "Again")));
+		assertEquals(1, collection().countDocuments());
+	}
+
+	private Form form(final String key, final String title) {
+		Form form = new Form();
+		form.setKey(key);
+		form.setTitle(title);
+		return form;
+	}
+
+}

--- a/apps/java/services/case-engine-rest-api/src/main/java/com/wks/caseengine/rest/exception/GlobalExceptionHandler.java
+++ b/apps/java/services/case-engine-rest-api/src/main/java/com/wks/caseengine/rest/exception/GlobalExceptionHandler.java
@@ -17,6 +17,8 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
 import com.wks.caseengine.config.validation.ConfigValidationException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -54,6 +56,24 @@ public class GlobalExceptionHandler {
 		ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.getReasonPhrase(),
 				"Message not readable: " + ex.getMostSpecificCause().getMessage());
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+	}
+
+	@ExceptionHandler(MongoWriteException.class)
+	public ResponseEntity<ErrorResponse> handleMongoWriteException(MongoWriteException ex) {
+		if (ErrorCategory.DUPLICATE_KEY.equals(ex.getError().getCategory())) {
+			// Expected client error: the natural key is already taken. Without this the
+			// unique indexes on the config collections would surface as a 500, which the
+			// portal reads as "save failed" — and the user retries.
+			log.warn("Rejected duplicate record: {}", ex.getError().getMessage());
+			ErrorResponse errorResponse = new ErrorResponse(HttpStatus.CONFLICT.getReasonPhrase(),
+					"A record with the same identifier already exists");
+			return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+		}
+
+		log.error("Mongo write error", ex);
+		ErrorResponse errorResponse = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+				"Internal Server Error");
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/apps/java/services/case-engine-rest-api/src/test/java/com/wks/caseengine/rest/exception/GlobalExceptionHandlerTest.java
+++ b/apps/java/services/case-engine-rest-api/src/test/java/com/wks/caseengine/rest/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,67 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+package com.wks.caseengine.rest.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
+import com.mongodb.WriteError;
+
+/**
+ * @author victor.franca
+ */
+public class GlobalExceptionHandlerTest {
+
+	private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+	@Test
+	public void shouldAnswerConflictWhenTheNaturalKeyIsAlreadyTaken() {
+		ResponseEntity<ErrorResponse> response = handler.handleMongoWriteException(duplicateKey());
+
+		// A 500 here would read as "save failed" in the portal, and the user would
+		// retry — which is how duplicates piled up in the first place.
+		assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+	}
+
+	@Test
+	public void shouldNotLeakTheDriverMessageToTheClient() {
+		ResponseEntity<ErrorResponse> response = handler.handleMongoWriteException(duplicateKey());
+
+		assertEquals("A record with the same identifier already exists", response.getBody().getErrorMessage());
+	}
+
+	@Test
+	public void shouldStillAnswerServerErrorForOtherWriteFailures() {
+		MongoWriteException ex = new MongoWriteException(new WriteError(121, "Document failed validation", new BsonDocument()),
+				new ServerAddress(), Collections.emptySet());
+
+		ResponseEntity<ErrorResponse> response = handler.handleMongoWriteException(ex);
+
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+	}
+
+	private MongoWriteException duplicateKey() {
+		return new MongoWriteException(
+				new WriteError(11000, "E11000 duplicate key error collection: tenant.form index: key_1",
+						new BsonDocument()),
+				new ServerAddress(), Collections.emptySet());
+	}
+
+}


### PR DESCRIPTION
## The bug

Creating a form, record type, case definition or queue returned **500 — while the document was successfully written**. The portal reads that as "save failed", so the user retries, and every retry commits another row.

Not theoretical: this was found while verifying #560, and the local demo database held **12 identical case definitions written inside 4 seconds** plus 4 duplicate forms.

```
java.lang.NullPointerException: Cannot invoke "org.bson.BsonObjectId.getValue()" because the
return value of "com.mongodb.client.result.InsertOneResult.getInsertedId()" is null
	at com.wks.caseengine.form.FormRepositoryImpl.save(FormRepositoryImpl.java:60)
```

`getInsertedId()` is null for a `MongoCollection<JsonObject>`: `JsonObjectCodec` is not a `CollectibleCodec`, so the driver neither generates nor tracks an `_id` — the server assigns it. The cast then throws, *after* the insert has committed.

| Repository | Document type | Status |
|---|---|---|
| Form, RecordType, CaseDefinition, Queue | `MongoCollection<JsonObject>` | **broken — fixed here** |
| CaseInstance, CaseEmail | POJO codec | unaffected, unchanged |

## The fix

**1. Generate the id up front.** A shared `MongoDocuments#withId` embeds a client-generated `ObjectId` in the document, so the caller knows the id without reading anything back — and independently of driver-version codec behaviour, unlike the code it replaces.

**2. Add the unique indexes** that should have prevented the duplicates. Two things worth reviewer attention:

- The natural key **is not uniform**: `key` for form, `id` for recordType, caseDefinition and queue.
- Databases resolve per tenant at request time, so no startup point knows the tenant set. Indexes are ensured on first use and memoised — one round trip per tenant per collection, not per request.

**3. Map duplicate-key writes to 409.** Without this the new indexes would convert a silent duplicate into a 500, which the portal reads as "save failed" — and the user retries. That is the exact loop this set out to close.

## Judgment call worth reviewing

**A failed index build is logged, not propagated.** A database that predates the index may already hold duplicates, and the build fails. Breaking every request for that tenant seemed worse than not enforcing uniqueness there, so it warns and carries on, and does not retry until restart (otherwise every request pays for a round trip that cannot succeed).

The consequence: **existing deployments holding duplicates get no enforcement until someone dedupes and restarts.** Happy to make it fail hard instead if that is the preferred trade.

## Tests

16 new. The integration tests drive **real inserts against an embedded MongoDB** — that is precisely what was missing, since nothing exercised `save()` against a real server and a `NullPointerException` on every create shipped.

Reverting `save()` to the previous implementation reproduces the **exact production stack trace** in all five integration tests.

Full `case-engine` + `case-engine-rest-api` verify green.

## Verification

Against a local Docker stack with a **rebuilt engine image**, Keycloak and MongoDB:

| Check | Before | After |
|---|---|---|
| `POST /form` | 500 + NPE | **204**, no NPE |
| Duplicate key | silently written | **409** with a clean message |
| Retry after failure | extra row each time | **1 document** |

All four collections took their unique index on first use — including `recordType`, whose collection did not previously exist:

```
form:           _id_, key_1 UNIQUE
caseDefinition: _id_, id_1 UNIQUE
queue:          _id_, id_1 UNIQUE
recordType:     _id_, id_1 UNIQUE
```

## Follow-up, not in this PR

`case-engine/pom.xml` declares `mongodb-driver-sync` **twice** — once pinned to `${mongo.version}` (4.11.5), once BOM-managed. Maven warns `must be unique`; the BOM version wins, so the pin is inert (the running engine reports driver 5.6.5). Left alone deliberately: resolving it changes the driver version and deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)