### PR TITLE
fix(case-portal): serve cache-bustable assets so upgrades reach the browser

### DIFF
--- a/apps/react/case-portal/deployments/nginx.conf
+++ b/apps/react/case-portal/deployments/nginx.conf
@@ -35,61 +35,32 @@ http {
     server {
         listen 8080 default_server;
 
+        # index.html is rewritten at boot with the runtime config (startup.sh)
+        # and its <script> tags name the current build's hashed bundles, so it
+        # must never be cached: a stale copy points the browser at the previous
+        # build's assets, which is how an upgraded image can keep serving the
+        # old UI. Matches both `/` and the try_files/error_page redirects to
+        # /index.html.
+        location = /index.html {
+            add_header 'Cache-Control' 'no-store' always;
+        }
+
         location / {
             if ($request_method = 'OPTIONS') {
-                add_header 'Cache-Control' 'no-cache';
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-                add_header 'Content-Type' 'text/plain; charset=utf-8';
-                add_header 'Content-Length' 0;
                 return 204;
-            }
-
-            if ($request_method = 'POST') {
-                add_header 'Cache-Control' 'no-cache';
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-                add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
-            if ($request_method = 'GET') {
-                add_header 'Cache-Control' 'no-cache';
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-                add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
             }
 
             try_files $uri $uri/ /index.html;
         }
 
-        location ~* \.(js|jpg|png|css|gif|svg)$ {
+        # Build output is content-hashed: a changed file gets a changed URL, so
+        # these can be cached indefinitely. index.html is what invalidates them.
+        location /build/ {
             if ($request_method = 'OPTIONS') {
-                add_header 'Cache-Control' 'no-cache';
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-                add_header 'Content-Length' 0;
                 return 204;
             }
 
-            if ($request_method = 'POST') {
-                add_header 'Cache-Control' 'no-cache';
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-                add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
-
-            if ($request_method = 'GET') {
-                add_header 'Cache-Control' 'no-cache';
-                add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-                add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-            }
+            add_header 'Cache-Control' 'public, max-age=31536000, immutable' always;
         }
 
         location = /status {

--- a/apps/react/case-portal/test/webpackConfig.test.js
+++ b/apps/react/case-portal/test/webpackConfig.test.js
@@ -1,0 +1,49 @@
+const configFactory = require('../webpack.config')
+
+/**
+ * Guards the cache-busting contract.
+ *
+ * Production bundles must carry a content hash. Without one every build emits
+ * the same `build/<id>.js` names, and because those assets are served with a
+ * long-lived cache, a browser holding the previous build keeps running it after
+ * an image upgrade — a shipped fix then looks like it never landed.
+ */
+describe('webpack production output', () => {
+  const production = configFactory({}, { mode: 'production' })
+
+  it('content-hashes the entry bundle', () => {
+    expect(production.output.filename).toContain('[contenthash]')
+  })
+
+  it('content-hashes split chunks too', () => {
+    // splitChunks is on, so most of the app ships as chunks rather than the
+    // entry bundle — hashing only `filename` would leave them cacheable-stale.
+    expect(production.output.chunkFilename).toContain('[contenthash]')
+  })
+
+  it('clears stale hashed files between builds', () => {
+    expect(production.output.clean).toBe(true)
+  })
+})
+
+describe('webpack development output', () => {
+  const development = configFactory({}, { mode: 'development' })
+
+  it('keeps stable names so the dev server can hot update', () => {
+    // Content hashes are incompatible with hot updates; dev is served from
+    // memory and never cached, so it doesn't need them.
+    expect(development.output.filename).not.toContain('[contenthash]')
+  })
+})
+
+describe('webpack config shape', () => {
+  it('is a factory, so mode can drive the output naming', () => {
+    expect(typeof configFactory).toBe('function')
+  })
+
+  it('tolerates being called without argv', () => {
+    // `webpack --mode=production` passes argv, but plain `require` of the
+    // config (tooling, editors) may not.
+    expect(() => configFactory({})).not.toThrow()
+  })
+})

--- a/apps/react/case-portal/webpack.config.js
+++ b/apps/react/case-portal/webpack.config.js
@@ -4,74 +4,91 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const Dotenv = require('dotenv-webpack')
 
 /*eslint-disable no-undef*/
-module.exports = {
-  entry: './src/index.js',
-  resolve: {
-    modules: [path.resolve(__dirname, 'src'), 'node_modules'],
-    preferRelative: true,
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'build/[name].js',
-    publicPath: '/',
-  },
-  optimization: {
-    splitChunks: {
-      chunks: 'all',
-      minSize: 10000,
-      maxSize: 250000,
+module.exports = (env, argv = {}) => {
+  const isProduction = argv.mode === 'production'
+
+  // Production bundles carry a content hash so a new build lands on new URLs.
+  // Without it every build emits the same `build/<id>.js` names, and a browser
+  // holding the previous build in cache keeps serving it after an upgrade —
+  // the fix looks like it never shipped. Hashes can't be combined with the dev
+  // server's hot updates, so development keeps stable names.
+  const bundleName = isProduction
+    ? 'build/[name].[contenthash].js'
+    : 'build/[name].js'
+
+  return {
+    entry: './src/index.js',
+    resolve: {
+      modules: [path.resolve(__dirname, 'src'), 'node_modules'],
+      preferRelative: true,
     },
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        include: path.resolve(__dirname, 'src'),
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: [
-              '@babel/preset-env',
-              ['@babel/preset-react', { runtime: 'automatic' }],
-            ],
-          },
-        },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: bundleName,
+      chunkFilename: bundleName,
+      publicPath: '/',
+      // Hashed names accumulate across builds; drop stale ones so `dist` only
+      // ever holds the current build.
+      clean: true,
+    },
+    optimization: {
+      splitChunks: {
+        chunks: 'all',
+        minSize: 10000,
+        maxSize: 250000,
       },
-      {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.(png|svg|jpg|gif|svg)$/,
-        use: ['file-loader'],
-      },
-      {
-        test: /\.(woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
-        use: ['file-loader'],
-      },
-      {
-        test: /favicon\.ico$/,
-        use: [
-          {
-            loader: 'file-loader',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          include: path.resolve(__dirname, 'src'),
+          use: {
+            loader: 'babel-loader',
             options: {
-              name: '[name].[ext]',
+              presets: [
+                '@babel/preset-env',
+                ['@babel/preset-react', { runtime: 'automatic' }],
+              ],
             },
           },
-        ],
-      },
+        },
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
+        },
+        {
+          test: /\.(png|svg|jpg|gif|svg)$/,
+          use: ['file-loader'],
+        },
+        {
+          test: /\.(woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
+          use: ['file-loader'],
+        },
+        {
+          test: /favicon\.ico$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                name: '[name].[ext]',
+              },
+            },
+          ],
+        },
+      ],
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: './public/index.html',
+      }),
+      new Dotenv({ systemvars: true }),
     ],
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: './public/index.html',
-    }),
-    new Dotenv({ systemvars: true }),
-  ],
-  devServer: {
-    static: path.join(__dirname, 'public'),
-    port: 3001,
-    historyApiFallback: true,
-  },
-  devtool: 'source-map',
+    devServer: {
+      static: path.join(__dirname, 'public'),
+      port: 3001,
+      historyApiFallback: true,
+    },
+    devtool: 'source-map',
+  }
 }


### PR DESCRIPTION
## The bug

An upgraded portal image can keep serving the **previous build's JavaScript**. Two causes compound:

1. Every build emits the same filenames — `build/[name].js`, no content hash.
2. nginx sends **no `Cache-Control`** on those assets, only `ETag`/`Last-Modified`, so browsers apply *heuristic* freshness and reuse the cached copy without even revalidating.

Same URL + no cache directive = the browser confidently runs stale code. This is why #560 appeared not to have shipped until a hard reload.

## The headers weren't wrong — they were absent

Worth a look during review: every `add_header` in `nginx.conf` sits inside an `if` block and **never reaches a response**. The CORS headers were dead too. Confirmed against the running container:

| Mechanism | Result |
|---|---|
| `add_header` at location level (`/status`) | ✅ emitted |
| `if` + `return` (OPTIONS → 204) | ✅ works |
| `add_header` inside `if` | ❌ nothing emitted |

Before this change, `GET /` and `GET /build/*.js` returned only `Server`, `Date`, `Content-Type`, `Content-Length`, `Last-Modified`, `ETag`, `Accept-Ranges`. No `Cache-Control`, no CORS.

## The fix

**Content-hash production bundles.** The config becomes a factory so `mode` drives naming:

- production → `build/[name].[contenthash].js` for **both** entry and chunks. `splitChunks` is on, so hashing only `filename` would leave most of the app cacheable-stale.
- development → stable names, since content hashes can't be combined with the dev server's hot updates.
- `clean: true` so hashed files don't accumulate across builds.

**Set cache headers where they take effect** (location level):

- `index.html` → `no-store`. It's rewritten at boot with the runtime config, and its `<script>` tags name the current build's bundles — it is what invalidates everything else, so it can never be cached.
- `/build/` → `public, max-age=31536000, immutable`. The filename changes whenever the content does.

OPTIONS → 204 preserved on both locations.

## Deliberate choice worth reviewing

**The dead CORS headers are removed, not repaired.** They have demonstrably never been emitted, so removing them preserves observed behaviour *exactly*. Switching on `Access-Control-Allow-Origin: *` where it has never been on is the riskier move and should be a deliberate decision, not a side effect of a caching fix. If cross-origin asset access is ever wanted, it now has to be added properly at location level.

## Verification

Against a local stack with a rebuilt portal image:

| Request | Result |
|---|---|
| `/` | `Cache-Control: no-store` |
| `/index.html` | `no-store` |
| SPA deep link (`try_files` fallback) | `no-store` |
| `/build/8482.0300cadb….js` | `public, max-age=31536000, immutable` |
| `OPTIONS /`, `OPTIONS /build/…` | 204 (unchanged) |
| `/status`, `/favicon.ico` | 200 (unchanged) |
| `/build/8482.js` (old unhashed URL) | 404 — URLs genuinely change per build |

All 343 chunks hashed. Jest **76 passing** (6 new pinning the hashing contract, so it can't silently revert). `yarn build` green, so eslint and prettier pass.

## Note for the release

Browsers holding the previously cached `index.html` will request the old unhashed URLs once and get a 404 — a blank page until one reload. That's a one-time cost of introducing hashing, and the last time it can happen. Worth a line in the release notes.

Related: #560 (the fix this was hiding), #562 (parked follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)