### PR TITLE
feat(case-portal): add German translation and a runtime language switcher

### DIFF
--- a/apps/react/case-portal/src/App.js
+++ b/apps/react/case-portal/src/App.js
@@ -1,9 +1,10 @@
 import { useEffect, useState, lazy, Suspense } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ThemeRoutes } from './routes'
 import ThemeCustomization from './themes'
 import { SessionStoreProvider } from './SessionStoreContext'
 import { CaseService, RecordService, MenuEventService } from 'services'
-import menuItemsDefs from './menu'
+import { getMenuItems } from './menu'
 import { buildMenu } from './menu/menuBuilder'
 import { RegisterInjectUserSession, RegisteOptions } from './plugins'
 import { accountStore, sessionStore } from './store'
@@ -21,6 +22,9 @@ const App = () => {
   const [recordsTypes, setRecordsTypes] = useState([])
   const [casesDefinitions, setCasesDefinitions] = useState([])
   const [menu, setMenu] = useState({ items: [] })
+  const {
+    i18n: { language },
+  } = useTranslation()
 
   useEffect(() => {
     const { keycloak, initOptions } = sessionStore.bootstrap()
@@ -89,34 +93,39 @@ const App = () => {
     }
   }
 
+  // Fetch the dynamic lists resiliently — a failing call should not blank the
+  // whole navigation. Assembly is deliberately NOT done here: it lives in the
+  // effect below so that switching language re-labels the nav without re-hitting
+  // the backend.
   async function buildMenuItems(keycloak) {
-    // Fetch the dynamic lists resiliently — a failing call should not blank the
-    // whole navigation — then hand the pure assembly off to buildMenu().
-    let recordTypes = []
     try {
-      recordTypes = await RecordService.getAllRecordTypes(keycloak)
-      setRecordsTypes(recordTypes)
+      setRecordsTypes(await RecordService.getAllRecordTypes(keycloak))
     } catch (err) {
       console.error('Failed to load record types for the menu', err)
     }
 
-    let caseDefinitions = []
     try {
-      caseDefinitions = await CaseService.getCaseDefinitions(keycloak)
-      setCasesDefinitions(caseDefinitions)
+      setCasesDefinitions(await CaseService.getCaseDefinitions(keycloak))
     } catch (err) {
       console.error('Failed to load case definitions for the menu', err)
     }
+  }
 
-    return setMenu(
+  // Re-assemble whenever the fetched lists or the active language change. Safe to
+  // run repeatedly: buildMenu() clones before mutating, so it never accumulates
+  // state across builds.
+  useEffect(() => {
+    if (!authenticated) return
+
+    setMenu(
       buildMenu({
-        menuItems: menuItemsDefs.items,
-        recordTypes,
-        caseDefinitions,
+        menuItems: getMenuItems().items,
+        recordTypes: recordsTypes,
+        caseDefinitions: casesDefinitions,
         isManager: accountStore.isManagerUser(keycloak),
       }),
     )
-  }
+  }, [recordsTypes, casesDefinitions, keycloak, authenticated, language])
 
   return (
     keycloak &&
@@ -127,8 +136,20 @@ const App = () => {
             <ScrollTop>
               <SessionStoreProvider value={{ keycloak, menu }}>
                 {/* Per-view boundary: a crash in the routed content shows a
-                    recoverable message while the app shell stays up. */}
-                <ErrorBoundary title='This view failed to render'>
+                    recoverable message while the app shell stays up.
+
+                    Keyed on the active language so a switch remounts the routed
+                    subtree. Several things only read the locale once and would
+                    otherwise stay in the old language: form.io reads
+                    options.language at construction, and views that formatted
+                    dates or mapped status labels while fetching hold already
+                    translated strings in state. Remounting makes them refetch and
+                    re-render. The key sits INSIDE SessionStoreProvider so the
+                    Keycloak instance and session are untouched. */}
+                <ErrorBoundary
+                  key={language}
+                  title='This view failed to render'
+                >
                   <ThemeRoutes
                     keycloak={keycloak}
                     authenticated={authenticated}

--- a/apps/react/case-portal/src/components/@formio/formioOptions.js
+++ b/apps/react/case-portal/src/components/@formio/formioOptions.js
@@ -1,0 +1,90 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+
+import { StorageService } from 'plugins/storage'
+import { getFormioLocale } from '../../i18n/formatters'
+
+/**
+ * form.io ships only an English translation table. A per-language map handed to
+ * `options.i18n` is merged over that built-in `en`, so only the keys we care
+ * about need authoring — anything omitted falls back to English rather than
+ * rendering a raw key.
+ *
+ * These cover the chrome form.io renders itself: button labels and the
+ * client-side validation messages. Field labels come from the form's own JSON
+ * schema and are shown as authored.
+ */
+const FORMIO_BUNDLE = {
+  de: {
+    required: '{{field}} ist ein Pflichtfeld',
+    pattern: '{{field}} entspricht nicht dem erwarteten Format',
+    minLength: '{{field}} muss mindestens {{length}} Zeichen lang sein',
+    maxLength: '{{field}} darf höchstens {{length}} Zeichen lang sein',
+    min: '{{field}} darf nicht kleiner als {{min}} sein',
+    max: '{{field}} darf nicht größer als {{max}} sein',
+    invalid_email: '{{field}} muss eine gültige E-Mail-Adresse sein',
+    invalid_date: '{{field}} ist kein gültiges Datum',
+    invalid_regex: '{{field}} entspricht nicht dem erwarteten Muster',
+    unique: '{{field}} muss eindeutig sein',
+    submit: 'Absenden',
+    cancel: 'Abbrechen',
+    next: 'Weiter',
+    previous: 'Zurück',
+    complete: 'Abschließen',
+    error: 'Bitte korrigieren Sie die markierten Felder',
+    browse: 'Durchsuchen',
+    dropFilesToAttach: 'Dateien hierher ziehen oder',
+    removeFile: 'Datei entfernen',
+  },
+  pt: {
+    required: '{{field}} é obrigatório',
+    pattern: '{{field}} não corresponde ao formato esperado',
+    minLength: '{{field}} deve ter ao menos {{length}} caracteres',
+    maxLength: '{{field}} deve ter no máximo {{length}} caracteres',
+    min: '{{field}} não pode ser menor que {{min}}',
+    max: '{{field}} não pode ser maior que {{max}}',
+    invalid_email: '{{field}} deve ser um e-mail válido',
+    invalid_date: '{{field}} não é uma data válida',
+    invalid_regex: '{{field}} não corresponde ao padrão esperado',
+    unique: '{{field}} deve ser único',
+    submit: 'Enviar',
+    cancel: 'Cancelar',
+    next: 'Próximo',
+    previous: 'Anterior',
+    complete: 'Concluir',
+    error: 'Por favor, corrija os campos destacados',
+    browse: 'Procurar',
+    dropFilesToAttach: 'Arraste arquivos aqui ou',
+    removeFile: 'Remover arquivo',
+  },
+}
+
+/**
+ * Build the options object for a form.io `<Form>` / `<FormBuilder>`.
+ *
+ * Every render site goes through this so the storage plugin and the active
+ * language are wired consistently. `extra` is spread last, so a call site can
+ * still override anything (`readOnly`, `noNewEdit`, validation flags, …).
+ *
+ * Note that form.io reads `language` and `i18n` when the webform is
+ * *constructed*, so changing the language does not retranslate a mounted form —
+ * App.js remounts the routed subtree on a language change, which is what makes
+ * this take effect.
+ */
+export const getFormioOptions = (extra = {}) => ({
+  fileService: new StorageService(),
+  language: getFormioLocale(),
+  i18n: FORMIO_BUNDLE,
+  ...extra,
+})
+
+export default getFormioOptions

--- a/apps/react/case-portal/src/config.js
+++ b/apps/react/case-portal/src/config.js
@@ -2,7 +2,9 @@ const config = {
   basename: '/',
   defaultPath: '/home',
   fontFamily: "'Public Sans', sans-serif",
-  i18n: 'en',
+  // Deployment default language, used when the user has expressed no preference
+  // and the browser asks for something we don't ship. BCP-47.
+  i18n: 'en-US',
   miniDrawer: false,
   container: true,
   mode: 'light',

--- a/apps/react/case-portal/src/i18n/de_de.js
+++ b/apps/react/case-portal/src/i18n/de_de.js
@@ -1,0 +1,201 @@
+const defs = {
+  general: {
+    case: {
+      status: {
+        wip: 'In Bearbeitung',
+        closed: 'Geschlossen',
+        archived: 'Archiviert',
+      },
+    },
+  },
+  menu: {
+    home: 'Übersicht',
+    case: 'Fälle',
+    task: 'Aufgaben',
+    workspace: 'Arbeitsbereich',
+    record: 'Datensätze',
+    system: 'System',
+    settings: 'Einstellungen',
+    casebuilder: 'Fallgestaltung',
+    documentation: 'Dokumentation',
+    management: 'Verwaltung',
+    lookAndFeel: 'Erscheinungsbild',
+
+    profile: 'Profil',
+    logout: 'Abmelden',
+    language: 'Sprache',
+
+    processes: 'Prozesse',
+    caseDefinitions: 'Falldefinitionen',
+    recordTypes: 'Datensatztypen',
+    processEngines: 'Prozess-Engines',
+    forms: 'Formulare',
+    queues: 'Warteschlangen',
+
+    externalLinks: 'Externe Links',
+  },
+  pages: {
+    dashboard: {
+      title: 'Mein Arbeitsbereich',
+      cards: {
+        wipcases: {
+          label: 'In Bearbeitung',
+        },
+        caselist: {
+          label: 'Alle',
+        },
+        tasklist: {
+          label: 'Aufgaben',
+        },
+      },
+    },
+    caselist: {
+      datagrid: {
+        columns: {
+          businesskey: 'Geschäftsschlüssel',
+          statusdescription: 'Status',
+          stage: 'Phase',
+          createdat: 'Erstellt am',
+          queue: 'Warteschlange',
+          caseOwnerName: 'Eigentümer',
+        },
+        action: {
+          details: 'Details',
+        },
+      },
+      action: {
+        newcase: 'Anlegen',
+        refresh: 'Aktualisieren',
+      },
+    },
+    caseform: {
+      actions: {
+        close: 'Schließen',
+        reopen: 'Wieder öffnen',
+        archive: 'Archivieren',
+        newTask: 'Neue Aufgabe',
+        startProcess: 'Prozess starten',
+      },
+      tabs: {
+        details: 'Falldetails',
+        tasks: 'Aufgaben',
+        comments: 'Kommentare',
+        attachments: 'Anhänge',
+        emails: 'E-Mails',
+      },
+      manualProcesses: {
+        title: 'Zu startenden Prozess auswählen',
+        noProcesses: 'Für diese Phase sind keine manuellen Prozesse verfügbar',
+        startFailed: 'Der Prozess konnte nicht gestartet werden.',
+      },
+      validation: {
+        pleaseCorrectErrors:
+          'Bitte korrigieren Sie die folgenden Fehler im Formular:',
+        requiredFieldsMissing:
+          'Pflichtfelder fehlen oder enthalten ungültige Werte.',
+        pleaseFixErrors:
+          'Bitte beheben Sie die folgenden Fehler, bevor Sie fortfahren.',
+      },
+    },
+    tasklist: {
+      datagrid: {
+        columns: {
+          name: 'Aufgabe',
+          caseinstanceid: 'Fall',
+          processdefinitionid: 'Prozess',
+          assignee: 'Bearbeiter',
+          created: 'Erstellt',
+          due: 'Fällig',
+          followup: 'Wiedervorlage',
+        },
+        toolbar: {
+          columns: 'Spalten',
+          filters: 'Filter',
+          density: 'Zeilenhöhe',
+          export: 'Exportieren',
+        },
+      },
+      newTask: {
+        name: 'Aufgabe',
+        description: 'Beschreibung',
+        dueDate: 'Fälligkeitsdatum',
+        assignee: 'Bearbeiter',
+      },
+      upcoming: 'Anstehend & überfällig',
+    },
+    taskform: {
+      claim: 'Übernehmen',
+      complete: 'Abschließen',
+    },
+    recordlist: {
+      datagrid: {
+        action: {
+          details: 'Details',
+        },
+      },
+      action: {
+        newrecord: 'Neu',
+      },
+    },
+    comments: {
+      title: 'Kommentare',
+      actions: {
+        send: 'Senden',
+        reply: 'Antworten',
+        edit: {
+          action: 'Bearbeiten',
+          update: 'Aktualisieren',
+          cancel: 'Abbrechen',
+        },
+        delete: 'Löschen',
+      },
+    },
+    emails: {
+      datagrid: {
+        receivedDateTime: 'Empfangen',
+        hasAttachments: 'Anhänge?',
+        from: 'Von',
+        to: 'An',
+        bodyPreview: 'Vorschau',
+        action: {
+          compose: 'Neu',
+        },
+      },
+      form: {
+        title: 'Neue E-Mail',
+        recipient: 'An',
+        subject: 'Betreff',
+        body: 'Nachricht',
+        send: 'Senden',
+      },
+    },
+    message: {
+      fileUpload: {
+        error: {
+          couldNotUpload: 'Diese Datei konnte nicht hochgeladen werden.',
+        },
+      },
+    },
+    validation: {
+      pleaseCorrectErrors:
+        'Bitte korrigieren Sie die folgenden Fehler im Formular:',
+      requiredFieldsMissing:
+        'Pflichtfelder fehlen oder enthalten ungültige Werte.',
+      requiredField: 'Dieses Feld ist ein Pflichtfeld.',
+      maxLength: 'Die maximale Länge beträgt {{length}} Zeichen.',
+      minLength: 'Die minimale Länge beträgt {{length}} Zeichen.',
+      pattern: 'Ungültiges Format.',
+      invalidEmail: 'Bitte geben Sie eine gültige E-Mail-Adresse ein.',
+      minValue: 'Der Mindestwert ist {{min}}.',
+      maxValue: 'Der Höchstwert ist {{max}}.',
+      notANumber: 'Bitte geben Sie eine gültige Zahl ein.',
+      invalidDate: 'Bitte geben Sie ein gültiges Datum ein.',
+      invalidUrl: 'Bitte geben Sie eine gültige URL ein.',
+      custom: 'Ungültiger Wert.',
+      genericError:
+        'Das Feld {{field}} enthält einen ungültigen Wert. Bitte prüfen und korrigieren.',
+    },
+  },
+}
+
+export default defs

--- a/apps/react/case-portal/src/i18n/en_us.js
+++ b/apps/react/case-portal/src/i18n/en_us.js
@@ -18,6 +18,12 @@ const defs = {
     settings: 'Settings',
     casebuilder: 'Case Builder',
     documentation: 'Documentation',
+    management: 'Management',
+    lookAndFeel: 'Look And Feel',
+
+    profile: 'Profile',
+    logout: 'Logout',
+    language: 'Language',
 
     processes: 'Processes',
     caseDefinitions: 'Case Definitions',
@@ -137,7 +143,7 @@ const defs = {
         edit: {
           action: 'Edit',
           update: 'Update',
-          cancel: 'Candel',
+          cancel: 'Cancel',
         },
         delete: 'Delete',
       },

--- a/apps/react/case-portal/src/i18n/formatters.js
+++ b/apps/react/case-portal/src/i18n/formatters.js
@@ -1,0 +1,49 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+
+import {
+  de as dateFnsDe,
+  enUS as dateFnsEnUS,
+  ptBR as dateFnsPtBR,
+} from 'date-fns/locale'
+import i18n from './index'
+import { localeEntry } from './locales'
+
+// moment resolves locales from its own global registry, and a locale it has not
+// loaded silently falls back to English rather than erroring. Importing the
+// bundles here — once, next to the code that selects them — is what keeps
+// "German relative dates" from quietly degrading to English in production.
+import 'moment/locale/de'
+import 'moment/locale/pt-br'
+
+const DATE_FNS_LOCALES = {
+  enUS: dateFnsEnUS,
+  ptBR: dateFnsPtBR,
+  de: dateFnsDe,
+}
+
+/**
+ * Locale-aware formatting helpers, all keyed off the active i18next language so
+ * callers never keep their own locale tables. Three date mechanisms coexist in
+ * the portal (date-fns, moment, and native Intl); consolidating them is a
+ * separate concern — these just make each of them follow the chosen language.
+ */
+export const getDateFnsLocale = () =>
+  DATE_FNS_LOCALES[localeEntry(i18n.language).dateFns]
+
+export const getMomentLocale = () => localeEntry(i18n.language).moment
+
+/** BCP-47 tag for `Intl` / `toLocaleDateString` and friends. */
+export const getIntlLocale = () => localeEntry(i18n.language).code
+
+/** form.io's own language identifier for `options.language`. */
+export const getFormioLocale = () => localeEntry(i18n.language).formio

--- a/apps/react/case-portal/src/i18n/index.js
+++ b/apps/react/case-portal/src/i18n/index.js
@@ -1,28 +1,109 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+
 import i18n from 'i18next'
+import config from '../config'
 import ptBR from './pt_br'
 import enUS from './en_us'
+import deDE from './de_de'
+import {
+  DEFAULT_LOCALE,
+  STORAGE_KEY,
+  SUPPORTED_LOCALES,
+  matchLocale,
+  resolveLocale,
+} from './locales'
 
-var lang = 'en'
-var fallbackLng = 'en'
+/**
+ * localStorage is not always reachable — Safari private mode and some embedded
+ * / third-party-cookie-blocked contexts throw on access rather than returning
+ * null. This module runs before React (and therefore before any ErrorBoundary)
+ * mounts, so an uncaught throw here is a blank white screen. Every access is
+ * wrapped and a failure is treated as "no stored preference".
+ */
+const readStoredLocale = () => {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY)
+  } catch (err) {
+    console.warn('Could not read the stored language preference', err)
+    return null
+  }
+}
 
-if (navigator.language === 'pt-BR') {
-  lang = 'ptBR'
+const writeStoredLocale = (code) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, code)
+  } catch (err) {
+    console.warn('Could not persist the language preference', err)
+  }
+}
+
+/**
+ * Resolution order, most to least specific:
+ *   1. the user's explicit stored choice
+ *   2. the browser's preferred languages, in order (`navigator.languages` — not
+ *      just `navigator.language`, and matched by prefix, so `de`, `de-AT` and
+ *      `en-GB` all land somewhere sensible instead of silently defaulting)
+ *   3. the deployment default in config.js
+ *   4. the hard default
+ */
+const detectLocale = () => {
+  const stored = matchLocale(readStoredLocale())
+  if (stored) return stored
+
+  const preferred = navigator.languages?.length
+    ? navigator.languages
+    : [navigator.language]
+  const fromBrowser = preferred.map(matchLocale).find(Boolean)
+  if (fromBrowser) return fromBrowser
+
+  return resolveLocale(config.i18n)
 }
 
 i18n.init({
   resources: {
-    en: {
-      translation: enUS,
-    },
-    ptBR: {
-      translation: ptBR,
-    },
+    'en-US': { translation: enUS },
+    'pt-BR': { translation: ptBR },
+    'de-DE': { translation: deDE },
   },
-  lng: lang,
-  fallbackLng: fallbackLng,
+  lng: detectLocale(),
+  fallbackLng: DEFAULT_LOCALE,
+  supportedLngs: SUPPORTED_LOCALES.map((locale) => locale.code),
+  // Keep i18n.language exactly as resolved. Our catalogs are keyed by full
+  // BCP-47 tag, so i18next must not strip the region looking for a bare-language
+  // bundle that does not exist. (This is also why `nonExplicitSupportedLngs` is
+  // deliberately NOT set: it would resolve `en-US` down to `en` and every lookup
+  // would fall through to the raw key. Normalising arbitrary browser tags onto a
+  // supported one is matchLocale's job, before i18next ever sees them.)
+  load: 'currentOnly',
   interpolation: {
     escapeValue: false,
   },
 })
+
+/**
+ * Switch the active language. This is the only sanctioned way to do it —
+ * calling `i18n.changeLanguage` directly skips persistence and the `lang`
+ * attribute, and leaves the two out of sync with the UI.
+ */
+export const setLocale = (candidate) => {
+  const code = resolveLocale(candidate)
+  if (code === i18n.language) return Promise.resolve()
+
+  writeStoredLocale(code)
+  document.documentElement.lang = code
+  return i18n.changeLanguage(code)
+}
+
+document.documentElement.lang = i18n.language
 
 export default i18n

--- a/apps/react/case-portal/src/i18n/locales.js
+++ b/apps/react/case-portal/src/i18n/locales.js
@@ -1,0 +1,98 @@
+/*
+ * WKS Platform - Open-Source Project
+ *
+ * This file is part of the WKS Platform, an open-source project developed by WKS Power.
+ *
+ * WKS Platform is licensed under the MIT License.
+ *
+ * © 2021 WKS Power. All rights reserved.
+ *
+ * For licensing information, see the LICENSE file in the root directory of the project.
+ */
+
+/**
+ * The single place a locale code is spelled out.
+ *
+ * Codes are BCP-47 so they can be handed straight to Intl and to
+ * `document.documentElement.lang`. The third-party libraries in the portal each
+ * use their own identifiers, so every locale carries the mapping with it —
+ * consumers ask this registry rather than keeping their own tables.
+ *
+ * `label` is deliberately an autonym (the language's own name for itself) and is
+ * never translated: someone looking for their language reads it in that
+ * language, not in whichever one the UI happens to be showing.
+ */
+export const SUPPORTED_LOCALES = [
+  {
+    code: 'en-US',
+    label: 'English',
+    dateFns: 'enUS',
+    moment: 'en',
+    formio: 'en',
+  },
+  {
+    code: 'pt-BR',
+    label: 'Português (Brasil)',
+    dateFns: 'ptBR',
+    moment: 'pt-br',
+    formio: 'pt',
+  },
+  {
+    code: 'de-DE',
+    label: 'Deutsch',
+    dateFns: 'de',
+    moment: 'de',
+    formio: 'de',
+  },
+]
+
+export const DEFAULT_LOCALE = 'en-US'
+
+/** localStorage key holding the user's explicit choice. */
+export const STORAGE_KEY = 'wks.locale'
+
+/**
+ * Match an arbitrary language tag onto a supported locale, or `null` if none
+ * fits.
+ *
+ * Handles the three shapes that actually turn up: an exact supported code, a
+ * bare language subtag (`de` → `de-DE`), and a region we don't ship but whose
+ * language we do (`de-AT` → `de-DE`, `en-GB` → `en-US`). Matching is
+ * case-insensitive because browsers and stored values are not consistent about
+ * it.
+ *
+ * Returning `null` rather than the default is what lets callers walk a list of
+ * candidates (`navigator.languages`) and tell "no preference matched" apart from
+ * "the first preference happened to be English".
+ */
+export const matchLocale = (candidate) => {
+  if (!candidate || typeof candidate !== 'string') return null
+
+  const wanted = candidate.trim().toLowerCase()
+  if (!wanted) return null
+
+  const exact = SUPPORTED_LOCALES.find(
+    (locale) => locale.code.toLowerCase() === wanted,
+  )
+  if (exact) return exact.code
+
+  const language = wanted.split('-')[0]
+  const byLanguage = SUPPORTED_LOCALES.find(
+    (locale) => locale.code.toLowerCase().split('-')[0] === language,
+  )
+
+  return byLanguage ? byLanguage.code : null
+}
+
+/**
+ * Like {@link matchLocale} but always yields a usable code. Never throws — this
+ * runs during module init, where a throw is a blank screen.
+ */
+export const resolveLocale = (candidate) =>
+  matchLocale(candidate) || DEFAULT_LOCALE
+
+/** The registry entry for a code, always defined (falls back to the default). */
+export const localeEntry = (code) => {
+  const resolved = resolveLocale(code)
+  return SUPPORTED_LOCALES.find((locale) => locale.code === resolved)
+}

--- a/apps/react/case-portal/src/i18n/locales.test.js
+++ b/apps/react/case-portal/src/i18n/locales.test.js
@@ -1,0 +1,77 @@
+import {
+  DEFAULT_LOCALE,
+  SUPPORTED_LOCALES,
+  localeEntry,
+  matchLocale,
+  resolveLocale,
+} from './locales'
+
+describe('matchLocale', () => {
+  it('matches a supported code exactly', () => {
+    expect(matchLocale('de-DE')).toBe('de-DE')
+    expect(matchLocale('pt-BR')).toBe('pt-BR')
+  })
+
+  it('matches case-insensitively, because stored and browser values vary', () => {
+    expect(matchLocale('DE-de')).toBe('de-DE')
+    expect(matchLocale('pt-br')).toBe('pt-BR')
+  })
+
+  it('matches a bare language subtag', () => {
+    expect(matchLocale('de')).toBe('de-DE')
+    expect(matchLocale('en')).toBe('en-US')
+  })
+
+  it('matches a region we do not ship onto the language we do', () => {
+    expect(matchLocale('de-AT')).toBe('de-DE')
+    expect(matchLocale('en-GB')).toBe('en-US')
+    expect(matchLocale('pt-PT')).toBe('pt-BR')
+  })
+
+  it('returns null for an unknown language so callers can keep looking', () => {
+    expect(matchLocale('fr-FR')).toBeNull()
+    expect(matchLocale('zz')).toBeNull()
+  })
+
+  it('returns null for junk input rather than throwing', () => {
+    expect(matchLocale(undefined)).toBeNull()
+    expect(matchLocale(null)).toBeNull()
+    expect(matchLocale('')).toBeNull()
+    expect(matchLocale('   ')).toBeNull()
+    expect(matchLocale(42)).toBeNull()
+    expect(matchLocale({})).toBeNull()
+  })
+})
+
+describe('resolveLocale', () => {
+  it('falls back to the default instead of returning null', () => {
+    expect(resolveLocale('fr-FR')).toBe(DEFAULT_LOCALE)
+    expect(resolveLocale(undefined)).toBe(DEFAULT_LOCALE)
+  })
+
+  it('still resolves what matchLocale would match', () => {
+    expect(resolveLocale('de')).toBe('de-DE')
+  })
+})
+
+describe('the registry itself', () => {
+  it('exposes the default as a supported locale', () => {
+    expect(SUPPORTED_LOCALES.map((l) => l.code)).toContain(DEFAULT_LOCALE)
+  })
+
+  it('gives every locale a library mapping, so no formatter lookup can miss', () => {
+    SUPPORTED_LOCALES.forEach((locale) => {
+      expect(locale.code).toMatch(/^[a-z]{2}-[A-Z]{2}$/)
+      expect(locale.label).toBeTruthy()
+      expect(locale.dateFns).toBeTruthy()
+      expect(locale.moment).toBeTruthy()
+      expect(locale.formio).toBeTruthy()
+    })
+  })
+
+  it('localeEntry is always defined, even for junk', () => {
+    expect(localeEntry('de-DE').label).toBe('Deutsch')
+    expect(localeEntry('nonsense').code).toBe(DEFAULT_LOCALE)
+    expect(localeEntry(undefined).code).toBe(DEFAULT_LOCALE)
+  })
+})

--- a/apps/react/case-portal/src/i18n/pt_br.js
+++ b/apps/react/case-portal/src/i18n/pt_br.js
@@ -18,6 +18,12 @@ const defs = {
     settings: 'Configurações',
     casebuilder: 'Case Builder',
     documentation: 'Documentação',
+    management: 'Gestão',
+    lookAndFeel: 'Aparência',
+
+    profile: 'Perfil',
+    logout: 'Sair',
+    language: 'Idioma',
 
     processes: 'Processos',
     caseDefinitions: 'Definições de Casos',

--- a/apps/react/case-portal/src/layout/MainLayout/Header/HeaderContent/Profile/LanguageTab.js
+++ b/apps/react/case-portal/src/layout/MainLayout/Header/HeaderContent/Profile/LanguageTab.js
@@ -1,0 +1,57 @@
+import { Fragment } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  ListSubheader,
+} from '@mui/material'
+import CheckOutlined from '@ant-design/icons/CheckOutlined'
+import GlobalOutlined from '@ant-design/icons/GlobalOutlined'
+
+import { setLocale } from '../../../../../i18n'
+import { SUPPORTED_LOCALES } from '../../../../../i18n/locales'
+
+/**
+ * Language picker for the profile popper.
+ *
+ * Renders list items directly rather than wrapping them in its own <List>: it is
+ * mounted inside ProfileTab's list, so a nested list would emit a <ul> inside a
+ * <ul>. Sharing the parent list also means it inherits the popper's icon styling.
+ *
+ * The language names are autonyms and stay untranslated on purpose — someone
+ * looking for their own language should find it written the way they write it,
+ * whatever the UI is currently showing.
+ */
+const LanguageTab = () => {
+  const { t, i18n } = useTranslation()
+
+  return (
+    <Fragment>
+      <ListSubheader
+        disableSticky
+        sx={{ bgcolor: 'transparent', lineHeight: '32px' }}
+      >
+        {t('menu.language')}
+      </ListSubheader>
+      {SUPPORTED_LOCALES.map((locale) => {
+        const selected = i18n.language === locale.code
+
+        return (
+          <ListItemButton
+            key={locale.code}
+            selected={selected}
+            onClick={() => setLocale(locale.code)}
+          >
+            <ListItemIcon>
+              {selected ? <CheckOutlined /> : <GlobalOutlined />}
+            </ListItemIcon>
+            <ListItemText primary={locale.label} />
+          </ListItemButton>
+        )
+      })}
+    </Fragment>
+  )
+}
+
+export default LanguageTab

--- a/apps/react/case-portal/src/layout/MainLayout/Header/HeaderContent/Profile/ProfileTab.js
+++ b/apps/react/case-portal/src/layout/MainLayout/Header/HeaderContent/Profile/ProfileTab.js
@@ -1,10 +1,20 @@
 import PropTypes from 'prop-types'
+import { useTranslation } from 'react-i18next'
 import { useTheme } from '@mui/material/styles'
-import { List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material'
+import {
+  Divider,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from '@mui/material'
 import LogoutOutlined from '@ant-design/icons/LogoutOutlined'
+
+import LanguageTab from './LanguageTab'
 
 const ProfileTab = ({ handleLogout }) => {
   const theme = useTheme()
+  const { t } = useTranslation()
 
   return (
     <List
@@ -17,11 +27,13 @@ const ProfileTab = ({ handleLogout }) => {
         },
       }}
     >
+      <LanguageTab />
+      <Divider />
       <ListItemButton onClick={handleLogout}>
         <ListItemIcon>
           <LogoutOutlined />
         </ListItemIcon>
-        <ListItemText primary='Logout' />
+        <ListItemText primary={t('menu.logout')} />
       </ListItemButton>
     </List>
   )

--- a/apps/react/case-portal/src/layout/MainLayout/Header/HeaderContent/Profile/index.js
+++ b/apps/react/case-portal/src/layout/MainLayout/Header/HeaderContent/Profile/index.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import Avatar from '@mui/material/Avatar'
 import Box from '@mui/material/Box'
 import ButtonBase from '@mui/material/ButtonBase'
@@ -49,6 +50,7 @@ function a11yProps(index) {
 
 const Profile = ({ keycloak }) => {
   const theme = useTheme()
+  const { t } = useTranslation()
   const iconBackColorOpen = 'grey.300'
   const anchorRef = useRef(null)
   const [open, setOpen] = useState(false)
@@ -195,7 +197,7 @@ const Profile = ({ keycloak }) => {
                                   }}
                                 />
                               }
-                              label='Profile'
+                              label={t('menu.profile')}
                               {...a11yProps(0)}
                             />
                           </Tabs>

--- a/apps/react/case-portal/src/menu/externalLinks.js
+++ b/apps/react/case-portal/src/menu/externalLinks.js
@@ -7,6 +7,8 @@ const icons = {
   IconExternalLink,
 }
 
+// Link titles come from customer-authored configuration, so they are shown as
+// authored and deliberately not routed through the message catalog.
 const links =
   menuItens
     .filter((item) => !!item.url)
@@ -23,13 +25,14 @@ const links =
       }
     }) ?? []
 
-const external = {
+/** See createWorkspace: built per call so the caption follows a language switch. */
+const createExternalLinks = () => ({
   id: 'externallinks',
   title: '',
   caption: i18n.t('menu.externalLinks'),
   type: 'group',
   external: true,
   children: links,
-}
+})
 
-export default external
+export default createExternalLinks

--- a/apps/react/case-portal/src/menu/index.js
+++ b/apps/react/case-portal/src/menu/index.js
@@ -1,11 +1,17 @@
-import workspace from './workspace'
-import management from './management'
-import externalLinks from './externalLinks'
+import createWorkspace from './workspace'
+import createManagement from './management'
+import createExternalLinks from './externalLinks'
 
-const items = [externalLinks, workspace, management]
+/**
+ * Assemble the static menu definitions in the active language.
+ *
+ * Call this on every rebuild rather than holding the result: the group builders
+ * translate their titles, so a cached tree would keep the language it was first
+ * built in. Each call returns fresh objects, which also keeps buildMenu() free to
+ * treat them as its own.
+ */
+export const getMenuItems = () => ({
+  items: [createExternalLinks(), createWorkspace(), createManagement()],
+})
 
-const menuItems = {
-  items: items,
-}
-
-export default menuItems
+export default getMenuItems

--- a/apps/react/case-portal/src/menu/index.test.js
+++ b/apps/react/case-portal/src/menu/index.test.js
@@ -1,0 +1,58 @@
+import i18n from '../i18n'
+import { getMenuItems } from './index'
+
+const findById = (groups, id) => {
+  for (const group of groups) {
+    if (group.id === id) return group
+    const found = group.children ? findById(group.children, id) : undefined
+    if (found) return found
+  }
+  return undefined
+}
+
+describe('getMenuItems', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en-US')
+  })
+
+  it('returns the three menu groups', () => {
+    expect(getMenuItems().items.map((group) => group.id)).toEqual([
+      'externallinks',
+      'utilities',
+      'management',
+    ])
+  })
+
+  it('re-translates titles after a language change', async () => {
+    await i18n.changeLanguage('en-US')
+    const english = getMenuItems().items
+    expect(findById(english, 'task-list').title).toBe('Tasks')
+    expect(findById(english, 'case-definition').title).toBe('Case Definitions')
+
+    await i18n.changeLanguage('de-DE')
+    const german = getMenuItems().items
+    expect(findById(german, 'task-list').title).toBe('Aufgaben')
+    expect(findById(german, 'case-definition').title).toBe('Falldefinitionen')
+  })
+
+  it('re-translates group captions after a language change', async () => {
+    await i18n.changeLanguage('de-DE')
+    const items = getMenuItems().items
+    expect(findById(items, 'externallinks').caption).toBe('Externe Links')
+    expect(findById(items, 'management').caption).toBe('Verwaltung')
+  })
+
+  // The regression this whole refactor exists for: the groups used to be
+  // module-level singletons whose titles were translated at import time, so a
+  // language switch could never reach the navigation.
+  it('returns fresh objects on every call', () => {
+    const first = getMenuItems()
+    const second = getMenuItems()
+
+    expect(first).not.toBe(second)
+    expect(first.items[0]).not.toBe(second.items[0])
+
+    first.items[1].title = 'mutated'
+    expect(getMenuItems().items[1].title).not.toBe('mutated')
+  })
+})

--- a/apps/react/case-portal/src/menu/management.js
+++ b/apps/react/case-portal/src/menu/management.js
@@ -16,10 +16,11 @@ const icons = {
   IconSchema,
 }
 
-const management = {
+/** See createWorkspace: built per call so the titles follow a language switch. */
+const createManagement = () => ({
   id: 'management',
-  title: 'Management',
-  caption: 'Management',
+  title: i18n.t('menu.management'),
+  caption: i18n.t('menu.management'),
   type: 'group',
   children: [
     {
@@ -30,7 +31,7 @@ const management = {
       children: [
         {
           id: 'look-and-feel',
-          title: 'Look And Feel',
+          title: i18n.t('menu.lookAndFeel'),
           type: 'item',
           url: '/system/look-and-feel',
           icon: icons.IconPalette,
@@ -87,6 +88,6 @@ const management = {
       ],
     },
   ],
-}
+})
 
-export default management
+export default createManagement

--- a/apps/react/case-portal/src/menu/workspace.js
+++ b/apps/react/case-portal/src/menu/workspace.js
@@ -23,7 +23,12 @@ const icons = {
   IconLayoutDashboard,
 }
 
-const workspace = {
+/**
+ * Built per call rather than exported as a module-level constant: the titles are
+ * translated here, so a singleton would capture whichever language happened to
+ * be active at import time and never re-translate when the user switches.
+ */
+const createWorkspace = () => ({
   id: 'utilities',
   title: '',
   type: 'group',
@@ -59,6 +64,6 @@ const workspace = {
       children: [],
     },
   ],
-}
+})
 
-export default workspace
+export default createWorkspace

--- a/apps/react/case-portal/src/services/NotificationService.js
+++ b/apps/react/case-portal/src/services/NotificationService.js
@@ -1,6 +1,7 @@
 import moment from 'moment'
 import { CaseService } from './CaseService'
 import { Typography } from '@mui/material'
+import { getMomentLocale } from '../i18n/formatters'
 
 export const NotificationService = {
   getNotifications,
@@ -38,8 +39,16 @@ async function getNotifications(keycloak) {
 
         return {
           ...data,
-          createdAt: moment(it.createdAt, 'DD/MM/YYYY').calendar(),
-          daysAgo: moment(it.createdAt, 'DD/MM/YYYY').startOf('day').fromNow(),
+          // The 'DD/MM/YYYY' argument is the INPUT parse format and must stay as
+          // it is — it describes what the backend sends, not how we display it.
+          // .locale() only affects the rendered output of calendar()/fromNow().
+          createdAt: moment(it.createdAt, 'DD/MM/YYYY')
+            .locale(getMomentLocale())
+            .calendar(),
+          daysAgo: moment(it.createdAt, 'DD/MM/YYYY')
+            .locale(getMomentLocale())
+            .startOf('day')
+            .fromNow(),
           eventType: getEventType(it.stage),
           total: page.total,
           message: (

--- a/apps/react/case-portal/src/views/caseComment/Comment.js
+++ b/apps/react/case-portal/src/views/caseComment/Comment.js
@@ -4,6 +4,7 @@ import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 import User1 from 'assets/images/users/avatar-3.png'
 import { useTranslation } from 'react-i18next'
+import { getIntlLocale } from '../../i18n/formatters'
 import CommentForm from './CommentForm'
 
 const Comment = ({
@@ -31,9 +32,10 @@ const Comment = ({
   const canReply = true //Boolean(currentUserId);
   const canEdit = true //currentUserId === comment.userId && !timePassed;
   const replyId = parentId ? parentId : comment.id
-  const createdAt = new Date(comment.createdAt).toLocaleDateString()
-
   const { t } = useTranslation()
+  const createdAt = new Date(comment.createdAt).toLocaleDateString(
+    getIntlLocale(),
+  )
 
   return (
     <div key={comment.id} className='comment'>

--- a/apps/react/case-portal/src/views/caseEmail/caseEmailList.js
+++ b/apps/react/case-portal/src/views/caseEmail/caseEmailList.js
@@ -15,6 +15,7 @@ import { useSession } from 'SessionStoreContext'
 import DOMPurify from 'dompurify'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { getIntlLocale } from '../../i18n/formatters'
 import { EmailService } from '../../services'
 import { EmailForm } from './emailForm'
 
@@ -106,7 +107,9 @@ export const CaseEmailsList = ({ caseInstanceBusinessKey }) => {
                     </Typography>
                     <Typography variant='body2' color='text.secondary'>
                       {t('pages.emails.datagrid.receivedDateTime')}:{' '}
-                      {new Date(email.receivedDateTime).toLocaleString()}
+                      {new Date(email.receivedDateTime).toLocaleString(
+                        getIntlLocale(),
+                      )}
                     </Typography>
                     <Typography variant='body2' color='text.secondary'>
                       {t('pages.emails.datagrid.hasAttachments')}:{' '}

--- a/apps/react/case-portal/src/views/caseForm/caseForm.js
+++ b/apps/react/case-portal/src/views/caseForm/caseForm.js
@@ -27,7 +27,7 @@ import Toolbar from '@mui/material/Toolbar'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { CaseStatus } from 'common/caseStatus'
-import { StorageService } from 'plugins/storage'
+import { getFormioOptions } from 'components/@formio/formioOptions'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -366,10 +366,7 @@ export const CaseForm = ({ open, handleClose, aCase, keycloak }) => {
                     <Form
                       form={form.structure}
                       submission={formData}
-                      options={{
-                        readOnly: true,
-                        fileService: new StorageService(),
-                      }}
+                      options={getFormioOptions({ readOnly: true })}
                     />
                   </Grid>
                 </TabPanel>

--- a/apps/react/case-portal/src/views/caseForm/newCaseForm.js
+++ b/apps/react/case-portal/src/views/caseForm/newCaseForm.js
@@ -14,7 +14,7 @@ import React from 'react'
 import { Form } from '@formio/react'
 import { useSession } from 'SessionStoreContext'
 import { CaseService, FormService } from '../../services'
-import { StorageService } from 'plugins/storage'
+import { getFormioOptions } from 'components/@formio/formioOptions'
 import ValidationErrorAlert from '../../components/FormValidation/ValidationErrorAlert'
 import { validateForm } from '../../utils/formValidation'
 
@@ -178,8 +178,7 @@ export const NewCaseForm = ({
               submission={formData}
               onChange={onChange}
               onInit={onFormInit}
-              options={{
-                fileService: new StorageService(),
+              options={getFormioOptions({
                 validateOnInit: false,
                 validate: true,
                 showErrors: true,
@@ -193,7 +192,7 @@ export const NewCaseForm = ({
                 buttonSettings: {
                   showSubmit: false,
                 },
-              }}
+              })}
             />
           </Grid>
         </Grid>

--- a/apps/react/case-portal/src/views/management/form/formDetail.js
+++ b/apps/react/case-portal/src/views/management/form/formDetail.js
@@ -18,7 +18,7 @@ import { TextField } from '@mui/material'
 import MainCard from 'components/MainCard'
 import { FormService } from 'services'
 import { useSession } from 'SessionStoreContext'
-import { StorageService } from 'plugins/storage'
+import { getFormioOptions } from 'components/@formio/formioOptions'
 import { useFormBuilderSchema } from '../useFormBuilderSchema'
 
 const Transition = React.forwardRef(function Transition(props, ref) {
@@ -141,11 +141,10 @@ export const FormDetail = ({
             <FormBuilder
               form={form.structure}
               onChange={onBuilderChange}
-              options={{
+              options={getFormioOptions({
                 noNewEdit: true,
                 noDefaultSubmitButton: true,
-                fileService: new StorageService(),
-              }}
+              })}
             />
           </MainCard>
         </Box>

--- a/apps/react/case-portal/src/views/management/form/formNew.js
+++ b/apps/react/case-portal/src/views/management/form/formNew.js
@@ -18,7 +18,7 @@ import MainCard from 'components/MainCard'
 import { FormBuilder } from '@formio/react'
 import { FormService } from 'services'
 import { useSession } from 'SessionStoreContext'
-import { StorageService } from 'plugins/storage'
+import { getFormioOptions } from 'components/@formio/formioOptions'
 import { useFormBuilderSchema } from '../useFormBuilderSchema'
 
 const Transition = React.forwardRef(function Transition(props, ref) {
@@ -142,11 +142,10 @@ export const FormNew = ({ open, handleClose }) => {
             <FormBuilder
               form={form.structure}
               onChange={onBuilderChange}
-              options={{
+              options={getFormioOptions({
                 noNewEdit: true,
                 noDefaultSubmitButton: true,
-                fileService: new StorageService(),
-              }}
+              })}
             />
           </MainCard>
         </Box>

--- a/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
+++ b/apps/react/case-portal/src/views/management/recordType/recordTypeForm.js
@@ -14,7 +14,7 @@ import { TextField } from '@mui/material'
 import MainCard from 'components/MainCard'
 import { RecordTypeService, MenuEventService } from 'services'
 import { useSession } from 'SessionStoreContext'
-import { StorageService } from 'plugins/storage'
+import { getFormioOptions } from 'components/@formio/formioOptions'
 import { useFormBuilderSchema } from '../useFormBuilderSchema'
 
 const Transition = React.forwardRef(function Transition(props, ref) {
@@ -122,11 +122,10 @@ export const RecordTypeForm = ({
             <FormBuilder
               form={recordType.fields}
               onChange={onBuilderChange}
-              options={{
+              options={getFormioOptions({
                 noNewEdit: true,
                 noDefaultSubmitButton: true,
-                fileService: new StorageService(),
-              }}
+              })}
             />
           </MainCard>
         </Box>

--- a/apps/react/case-portal/src/views/record/recordForm.js
+++ b/apps/react/case-portal/src/views/record/recordForm.js
@@ -13,7 +13,7 @@ import MainCard from 'components/MainCard'
 import { useEffect } from 'react'
 import { RecordService } from '../../services'
 import { useSession } from 'SessionStoreContext'
-import { StorageService } from 'plugins/storage'
+import { getFormioOptions } from 'components/@formio/formioOptions'
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction='up' ref={ref} {...props} />
@@ -112,9 +112,7 @@ export const RecordForm = ({ open, recordType, record, handleClose, mode }) => {
               <Form
                 form={form}
                 submission={formData}
-                options={{
-                  fileService: new StorageService(),
-                }}
+                options={getFormioOptions()}
               />
             </MainCard>
           </Grid>

--- a/apps/react/case-portal/src/views/taskForm/taskForm.js
+++ b/apps/react/case-portal/src/views/taskForm/taskForm.js
@@ -9,7 +9,7 @@ import Slide from '@mui/material/Slide'
 import Toolbar from '@mui/material/Toolbar'
 import Typography from '@mui/material/Typography'
 import MainCard from 'components/MainCard'
-import { StorageService } from 'plugins/storage'
+import { getFormioOptions } from 'components/@formio/formioOptions'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FormService, TaskService, VariableService } from 'services'
@@ -175,9 +175,7 @@ export const TaskForm = ({ open, handleClose, task }) => {
             <Form
               form={formComponents}
               submission={variableValues}
-              options={{
-                fileService: new StorageService(),
-              }}
+              options={getFormioOptions()}
             />
           </div>
         </div>

--- a/apps/react/case-portal/src/views/taskList/taskList.js
+++ b/apps/react/case-portal/src/views/taskList/taskList.js
@@ -13,6 +13,7 @@ import Config from 'consts/index'
 import { format } from 'date-fns'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { getDateFnsLocale } from '../../i18n/formatters'
 import { TaskService } from 'services'
 import { useSession } from '../../SessionStoreContext'
 import { AdHocTaskForm } from '../taskForm/adHocTaskForm'
@@ -236,14 +237,25 @@ function fetchTasks(setFetching, keycloak, businessKey, setTasks) {
 
   TaskService.filterTasks(keycloak, businessKey)
     .then((data) => {
+      // Resolved per fetch rather than at module load, so a language switch is
+      // picked up (the routed subtree remounts and refetches — see App.js).
+      const dateLocale = getDateFnsLocale()
+
       setTasks(
         data?.map(
           (o) =>
             (o = {
               ...o,
-              created: o.created && format(new Date(o.created), 'P'),
-              due: o.due && format(new Date(o.due), 'P'),
-              followUp: o.followUp && format(new Date(o.followUp), 'P'),
+              // 'P' is date-fns' localized-date token, but it only honours the
+              // locale when one is passed — otherwise it silently renders en-US.
+              created:
+                o.created &&
+                format(new Date(o.created), 'P', { locale: dateLocale }),
+              due:
+                o.due && format(new Date(o.due), 'P', { locale: dateLocale }),
+              followUp:
+                o.followUp &&
+                format(new Date(o.followUp), 'P', { locale: dateLocale }),
             }),
         ),
       )


### PR DESCRIPTION
## Why

A German customer is bringing one of their processes onto the platform. The portal shipped `en_us` and `pt_br` catalogs but no way to choose between them — and the plumbing made a switcher impossible.

This is the first of a sequence: **1a — German + switcher** (this PR) → 1b — management screens → config import/export → CMMN import.

## What was actually broken

Three independent mechanisms each captured the language once and never released it. Any one of them would have silently defeated a switcher on its own:

| | Before | Now |
|---|---|---|
| **Detection** | `src/i18n/index.js` resolved at module load, matching `navigator.language === 'pt-BR'` **exactly** — so `de`, `de-AT`, `pt`, `en-GB` all fell through to English | `localStorage` → `navigator.languages` best-match → `config.js` default → hard default, and the choice persists |
| **Navigation** | The three menu modules called `i18n.t()` at **module scope** on exported singletons, so `changeLanguage()` could never re-label the nav | Factory functions behind `getMenuItems()`, rebuilt per language without re-fetching the dynamic case/record lists |
| **form.io** | Reads `options.language` at **construction**, so a mounted form keeps its original language | The routed subtree is keyed on the active language |

The remount key does triple duty: it also makes views refetch, so already-formatted dates and the status labels mapped in `services/CaseService.js` re-render instead of showing stale strings.

## Also in here

- **`de-DE` catalog** at full parity — 106 leaf keys in each of the three catalogs, verified zero missing on any pairing.
- **`src/i18n/locales.js`** — the single place a locale code is spelled. Each entry carries its date-fns, moment, and form.io identifier, so no consumer keeps a private mapping table. Locale codes are now BCP-47.
- **Language picker** in the profile menu, each language listed by its own name (autonyms are deliberately never translated — you should find your language written the way you write it).
- **Dates**: all four formatting sites rendered en-US regardless of language; each now follows the locale. `moment` locale bundles are imported explicitly, since a missing one silently falls back to English rather than erroring.
- **`getFormioOptions()`** replaces seven copies of an inline options object, each keeping its own extras.
- Drive-by: `pages.comments.actions.edit.cancel` was `'Candel'`.

## Deliberately out of scope

- **`src/views/management/**` is still hardcoded English** (~70 strings across 12 files) — that's PR 1b. These screens are gated behind `mgmt_*` roles. *Caveat: the CMMN-import slice puts the Case Builder on the demo path, so `views/management/index.js` may want pulling forward.*
- **Backend-driven text is unaffected by the language setting** and shown as authored: case-definition names (`menu/menuBuilder.js:73`), record-type ids used as titles, stage names (`views/caseForm/caseForm.js:94`), task names (`views/taskList/taskList.js:114`), and form.io field labels. **A tenant wanting a German UI must author its case definitions and forms in German** — the catalog cannot reach them. Adding per-locale label maps to the config schema was considered and rejected for now.
- Date-library consolidation — `date-fns`, `moment`, and native `Date` all coexist. Made locale-aware, not merged.
- `src/views/utilities/**` and `src/views/management/utilities/**` (~30 Mantis template demo strings).

## Gotcha worth knowing

`nonExplicitSupportedLngs: true` on `i18n.init` makes i18next resolve `en-US` down to `en`, which has no resource bundle — so **every** `t()` returns the raw key. It fails completely and silently. It's also redundant here, because normalising arbitrary browser tags onto a supported locale is `matchLocale`'s job before i18next ever sees them. There's a comment at the option and `src/menu/index.test.js` guards the behaviour.

Also: `NotificationService`'s `'DD/MM/YYYY'` argument is an **input parse** format, not a display format — only `.locale()` was added. Verified `01/03/2026` still parses to 1 March, not 3 January.

## Follow-up (pre-existing, not touched)

`src/menu/management.js` references `icons.IconBuilding`, `icons.IconPalette`, and `icons.IconSettingsAutomation`, none of which are in the `icons` map — they resolve to `undefined`, so the System and Case Builder groups render without icons. Predates this change and is unrelated to i18n; kept out to avoid muddying the diff.

`src/layout/.../Profile/SettingTab.js` is dead code (`Profile/index.js` imports only `ProfileTab`). Left in place.

## Verification

- `yarn test` — **95/95 passing** across 16 suites, including the pre-existing `menuBuilder.test.js` (which needed no edits) and two new suites.
- `yarn lint:check`, `yarn format:check`, `yarn build` — all clean.
- Catalog parity checked programmatically: 106 keys each, no gaps.
- Formatting confirmed per locale: date-fns `03/09/2026`→`09.03.2026`, Intl `3/9/2026`→`9.3.2026`, moment `5 months ago`→`vor 5 Monaten`, form.io `en`→`de`.
- Minimal H2 + dev-token stack built and run; the **served container bundle** confirmed to contain the German catalog and the `wks.locale` storage key.

**Reviewer note — the one assertion worth clicking:** switch to Deutsch from the profile menu and confirm the **left nav re-labels immediately, without a reload**. That's the frozen-nav fix, and it's the part a unit test can only partly cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
